### PR TITLE
Oc build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,6 @@ RUN apt-get remove -y rsync && \
 #RUN --mount=type=cache,target=/root/.yarn3-cache,id=yarn3-cache \
 #    YARN_CACHE_FOLDER=/root/.yarn3-cache \
 #    yarn install --immutable --inline-builds
-RUN yarn install --immutable --inline-builds
 
 
 ###################################################################
@@ -74,6 +73,8 @@ RUN yarn install --immutable --inline-builds
 ###################################################################
 
 FROM helsinkitest/node:16-slim  AS builder
+ARG YARN_CACHE_FOLDER=/root/.yarn3-cache
+
 # Build ARGS
 ARG PROJECT
 ARG NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT
@@ -110,7 +111,9 @@ COPY --chown=appuser:appuser  . .
 COPY --from=deps --chown=appuser:appuser /workspace-install ./
 
 # Optional: if the app depends on global /static shared assets like images, locales...
-# RUN yarn workspace ${PROJECT} share-static-hardlink
+
+RUN yarn install --immutable --inline-builds
+RUN yarn workspace ${PROJECT} share-static-hardlink
 RUN yarn workspace ${PROJECT} build
 
 # Does not play well with buildkit on CI

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --chown=appuser:appuser .yarn/ ./.yarn/
 #
 #   - All package.json present in the host (root, apps/*, packages/*)
 #
-RUN --mount=type=bind,target=/docker-context \
+RUN --mount=type=bind,source=./,target=/docker-context \
     rsync -amv --delete \
     --owner=appuser --group=appuser \
     --exclude='node_modules' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ WORKDIR /workspace-install
 
 COPY --chown=appuser:appuser yarn.lock .yarnrc.yml ./
 COPY --chown=appuser:appuser .yarn/ ./.yarn/
-# Use non-root user
-USER appuser
 
 # Specific to monerepo's as docker COPY command is pretty limited
 # we use buidkit to prepare all files that are necessary for install

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get remove -y rsync && \
 #RUN --mount=type=cache,target=/root/.yarn3-cache,id=yarn3-cache \
 #    YARN_CACHE_FOLDER=/root/.yarn3-cache \
 #    yarn install --immutable --inline-builds
+RUN yarn install --immutable --inline-builds
 
 
 ###################################################################
@@ -119,6 +120,7 @@ RUN yarn workspace ${PROJECT} build
 #    SKIP_POSTINSTALL=1 \
 #    YARN_CACHE_FOLDER=/root/.yarn3-cache \
 #    yarn workspaces focus ${PROJECT} --production
+RUN yarn workspaces focus ${PROJECT} --production
 
 CMD ["sh", "-c", "echo ${PROJECT}"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ WORKDIR /workspace-install
 
 COPY --chown=appuser:appuser yarn.lock .yarnrc.yml ./
 COPY --chown=appuser:appuser .yarn/ ./.yarn/
+# Use non-root user
+USER appuser
 
 # Specific to monerepo's as docker COPY command is pretty limited
 # we use buidkit to prepare all files that are necessary for install

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,8 @@ COPY --chown=appuser:appuser  . .
 COPY --from=deps --chown=appuser:appuser /workspace-install ./
 
 # Optional: if the app depends on global /static shared assets like images, locales...
-RUN yarn workspace ${PROJECT} share-static-hardlink && yarn workspace ${PROJECT} build
+RUN yarn workspace ${PROJECT} share-static-hardlink 
+RUN yarn workspace ${PROJECT} build
 
 # Does not play well with buildkit on CI
 # https://github.com/moby/buildkit/issues/1673

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,6 @@ RUN apt-get remove -y rsync && \
 ###################################################################
 
 FROM helsinkitest/node:16-slim  AS builder
-ARG YARN_CACHE_FOLDER=/root/.yarn3-cache
-
 # Build ARGS
 ARG PROJECT
 ARG NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,12 @@ USER appuser
 #
 #   - All package.json present in the host (root, apps/*, packages/*)
 #
-RUN --mount=type=bind,source=./,target=/docker-context \
-    rsync -amv --delete \
+# Copy all files
+WORKDIR /docker-context
+COPY --chown=appuser:appuser . /docker-context
+
+# RUN --mount=type=bind,source=./,target=/docker-context \
+RUN rsync -amv --delete \
     --owner=appuser --group=appuser \
     --exclude='node_modules' \
     --exclude='*/node_modules' \
@@ -38,7 +42,10 @@ RUN --mount=type=bind,source=./,target=/docker-context \
     /docker-context/ /workspace-install/;
 
 # Copy all files
-# COPY --chown=appuser:appuser . .
+WORKDIR /docker-context
+COPY --chown=appuser:appuser . /docker-context
+
+
 RUN chown -R appuser:appuser .
 
 # remove rsync and apt cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ USER appuser
 WORKDIR /docker-context
 COPY --chown=appuser:appuser . /docker-context
 
+# mount type bind is not supported on current version (4.10.35) of OpenShift build
 # RUN --mount=type=bind,source=./,target=/docker-context \
 RUN rsync -amv --delete \
     --owner=appuser --group=appuser \
@@ -40,11 +41,6 @@ RUN rsync -amv --delete \
     --include='package.json' \
     --include='*/' --exclude='*' \
     /docker-context/ /workspace-install/;
-
-# Copy all files
-WORKDIR /docker-context
-COPY --chown=appuser:appuser . /docker-context
-
 
 RUN chown -R appuser:appuser .
 
@@ -68,9 +64,10 @@ RUN apt-get remove -y rsync && \
 # Does not play well with buildkit on CI
 # https://github.com/moby/buildkit/issues/1673
 
-RUN --mount=type=cache,target=/root/.yarn3-cache,id=yarn3-cache \
-    YARN_CACHE_FOLDER=/root/.yarn3-cache \
-    yarn install --immutable --inline-builds
+# mount type cache is not supported on current version (4.10.35) of OpenShift build
+#RUN --mount=type=cache,target=/root/.yarn3-cache,id=yarn3-cache \
+#    YARN_CACHE_FOLDER=/root/.yarn3-cache \
+#    yarn install --immutable --inline-builds
 
 
 ###################################################################
@@ -118,10 +115,11 @@ RUN yarn workspace ${PROJECT} share-static-hardlink && yarn workspace ${PROJECT}
 
 # Does not play well with buildkit on CI
 # https://github.com/moby/buildkit/issues/1673
-RUN --mount=type=cache,target=/root/.yarn3-cache,id=yarn3-cache \
-    SKIP_POSTINSTALL=1 \
-    YARN_CACHE_FOLDER=/root/.yarn3-cache \
-    yarn workspaces focus ${PROJECT} --production
+# mount type cache is not supported on current version (4.10.35) of OpenShift build
+#RUN --mount=type=cache,target=/root/.yarn3-cache,id=yarn3-cache \
+#    SKIP_POSTINSTALL=1 \
+#    YARN_CACHE_FOLDER=/root/.yarn3-cache \
+#    yarn workspaces focus ${PROJECT} --production
 
 CMD ["sh", "-c", "echo ${PROJECT}"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ COPY --chown=appuser:appuser  . .
 COPY --from=deps --chown=appuser:appuser /workspace-install ./
 
 # Optional: if the app depends on global /static shared assets like images, locales...
-RUN yarn workspace ${PROJECT} share-static-hardlink 
+# RUN yarn workspace ${PROJECT} share-static-hardlink
 RUN yarn workspace ${PROJECT} build
 
 # Does not play well with buildkit on CI

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -15,7 +15,7 @@
     "?share-static-symlink": "echo 'Use this command to link assets... from shared static folder'",
     "share-static-symlink": "rimraf ./public/shared-assets && symlink-dir ../../static/assets ./public/shared-assets",
     "?share-static-hardlink": "echo 'Use this command to link assets... from shared static folder'",
-    "share-static-hardlink": "rimraf ./public/shared-assets && syncdir ../../static/assets ./public/shared-assets --copy",
+    "share-static-hardlink": "rm -fr ./public/shared-assets && syncdir ../../static/assets ./public/shared-assets --copy",
     "check-dist": "es-check -v",
     "check-size": "size-limit --highlight-less",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -15,7 +15,7 @@
     "?share-static-symlink": "echo 'Use this command to link assets... from shared static folder'",
     "share-static-symlink": "rimraf ./public/shared-assets && symlink-dir ../../static/assets ./public/shared-assets",
     "?share-static-hardlink": "echo 'Use this command to link assets... from shared static folder'",
-    "share-static-hardlink": "rm -fr ./public/shared-assets && syncdir ../../static/assets ./public/shared-assets --copy",
+    "share-static-hardlink": "rimraf ./public/shared-assets && syncdir ../../static/assets ./public/shared-assets --copy",
     "check-dist": "es-check -v",
     "check-size": "size-limit --highlight-less",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",


### PR DESCRIPTION
## Description
 Mount type bind or cache are not supported on current version (4.10.35) of OpenShift build

## Issues

### Closes
[PLAENH-202](https://helsinkisolutionoffice.atlassian.net/browse/PLAENH-202)
### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
