### PR TITLE
TH-1258 | Remove age filter from events-helsinki's advanced search

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -254,6 +254,10 @@ const AdvancedSearch: React.FC<Props> = ({
                     searchValue={autosuggestInput}
                   />
                 </div>
+              </div>
+            </div>
+            <div className={styles.rowWrapper}>
+              <div className={styles.row}>
                 <div>
                   <MultiSelectDropdown
                     checkboxName="categoryOptions"
@@ -268,10 +272,6 @@ const AdvancedSearch: React.FC<Props> = ({
                     value={selectedCategories}
                   />
                 </div>
-              </div>
-            </div>
-            <div className={styles.rowWrapper}>
-              <div className={styles.row}>
                 <div>
                   <MultiSelectDropdown
                     checkboxName="hobbyTypeOptions"

--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -5,18 +5,10 @@ import {
   Checkbox,
   DateSelector,
   MultiSelectDropdown,
-  RangeDropdown,
   useLocale,
 } from 'events-helsinki-components';
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
-import {
-  Button,
-  IconCake,
-  IconArrowRight,
-  IconSearch,
-  IconLocation,
-  IconGroup,
-} from 'hds-react';
+import { Button, IconSearch, IconLocation, IconGroup } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import qs, { parse } from 'query-string';
@@ -41,8 +33,6 @@ import {
   getEventCategoryOptions,
   getSearchFilters,
   getSearchQuery,
-  MAX_AGE,
-  MIN_AGE,
 } from './utils';
 
 interface Props {
@@ -242,11 +232,6 @@ const AdvancedSearch: React.FC<Props> = ({
     scrollToResultList();
   };
 
-  const handleSetAgeValues = (minAge: string, maxAge: string) => {
-    setMinAgeInput(minAge);
-    setMaxAgeInput(maxAge);
-  };
-
   return (
     <PageSection
       korosBottom
@@ -343,24 +328,6 @@ const AdvancedSearch: React.FC<Props> = ({
                     showSelectAll={true}
                     title={t('search.titleDropdownPlace')}
                     value={selectedPlaces}
-                  />
-                </div>
-                <div>
-                  <RangeDropdown
-                    icon={<IconCake aria-hidden />}
-                    rangeIcon={<IconArrowRight aria-hidden />}
-                    minInputValue={minAgeInput}
-                    minInputLabel={t('search.ageLimitMin')}
-                    minInputStartValue={MIN_AGE.toString()}
-                    minInputFixedValue={'18'}
-                    maxInputValue={maxAgeInput}
-                    maxInputLabel={t('search.ageLimitMax')}
-                    maxInputEndValue={MAX_AGE.toString()}
-                    name="ageLimitValues"
-                    onChange={handleSetAgeValues}
-                    fixedValuesText={t('search.showOnlyAdultCourses')}
-                    title={t('search.ageLimitValues')}
-                    value={[minAgeInput, maxAgeInput]}
                   />
                 </div>
               </div>

--- a/apps/events-helsinki/src/domain/search/eventSearch/search.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/search.module.scss
@@ -69,7 +69,7 @@ $buttonWidth: 180px;
 
     & > :first-child {
       @include respond-above(m) {
-        grid-column: 1 / 4;
+        grid-column: 1 / 5;
       }
     }
   }


### PR DESCRIPTION
## Description

Remove age filter from events-helsinki's advanced search and rearrange its UI elements.

## Issues

### Closes

**[TH-1258](https://helsinkisolutionoffice.atlassian.net/browse/TH-1258)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Large width:
![1](https://user-images.githubusercontent.com/77663720/199948799-ce68a824-af03-4591-b20f-3fb4fcb11da0.png)

### Middle width:
![2](https://user-images.githubusercontent.com/77663720/199948807-4b47ddcb-8542-4a2b-bc2e-012a784d32d2.png)

### Small width:
![3](https://user-images.githubusercontent.com/77663720/199948821-00b9ad90-82a5-414a-8480-cbd9c3979bb6.png)

## Additional notes
