### PR TITLE
TH-1268 | Add "Show only evening events" checkbox to events-helsinki's advanced search

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -198,6 +198,16 @@ const AdvancedSearch: React.FC<Props> = ({
     scrollToResultList();
   };
 
+  const handleOnlyEveningEventChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const search = getSearchQuery({
+      ...searchFilters,
+      onlyEveningEvents: e.target.checked,
+    });
+    goToSearch(search);
+  };
+
   const handleOnlyRemoteEventChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -360,6 +370,15 @@ const AdvancedSearch: React.FC<Props> = ({
                     id={EVENT_SEARCH_FILTERS.IS_FREE}
                     label={t('search.checkboxIsFree')}
                     onChange={handleIsFreeChange}
+                  />
+                </div>
+                <div>
+                  <Checkbox
+                    className={styles.checkbox}
+                    checked={onlyEveningEvents}
+                    id={EVENT_SEARCH_FILTERS.ONLY_EVENING_EVENTS}
+                    label={t('search.checkboxOnlyEveningEvents')}
+                    onChange={handleOnlyEveningEventChange}
                   />
                 </div>
                 <div>

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -138,6 +138,21 @@ it.todo('should change search query after clicking autosuggest menu item');
 //   });
 // });
 
+it('should change search query after checking only evening events checkbox', async () => {
+  const { router } = renderComponent();
+
+  const onlyEveningEventsCheckbox = screen.getByRole('checkbox', {
+    name: /näytä vain iltatapahtumat/i,
+  });
+
+  await userEvent.click(onlyEveningEventsCheckbox);
+
+  expect(router).toMatchObject({
+    pathname,
+    query: { onlyEveningEvents: 'true', text: 'jazz' },
+  });
+});
+
 it('should change search query after checking is free checkbox', async () => {
   const { router } = renderComponent();
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -354,8 +354,8 @@ export const getSearchFilters = (searchParams: URLSearchParams): Filters => {
     ),
     // onlyChildrenEvents:
     //   searchParams.get(EVENT_SEARCH_FILTERS.ONLY_CHILDREN_EVENTS) === 'true',
-    // onlyEveningEvents:
-    //   searchParams.get(EVENT_SEARCH_FILTERS.ONLY_EVENING_EVENTS) === 'true',
+    onlyEveningEvents:
+      searchParams.get(EVENT_SEARCH_FILTERS.ONLY_EVENING_EVENTS) === 'true',
     onlyRemoteEvents:
       searchParams.get(EVENT_SEARCH_FILTERS.ONLY_REMOTE_EVENTS) === 'true',
     places: getUrlParamAsArray(searchParams, EVENT_SEARCH_FILTERS.PLACES),


### PR DESCRIPTION
## Description

Add "Show only evening events" checkbox to events-helsinki's advanced search, enable its functionality and add test for it.

## Issues

### Closes

**[TH-1268](https://helsinkisolutionoffice.atlassian.net/browse/TH-1268)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Old state from tapahtumat.hel.fi

#### Before clicking "Näytä vain iltatapahtumat" checkbox
![old1](https://user-images.githubusercontent.com/77663720/199973589-afa94507-4336-4444-a3aa-3428977d2ea0.png)

#### After clicking "Näytä vain iltatapahtumat" checkbox
![old2](https://user-images.githubusercontent.com/77663720/199973597-42b1063d-dc89-450e-bb3d-2a8ce2d2ba93.png)

### New state

#### Before clicking "Näytä vain iltatapahtumat" checkbox
![new1](https://user-images.githubusercontent.com/77663720/200289624-ab74c988-37a1-4603-bdc1-01e696709840.png)

#### After clicking "Näytä vain iltatapahtumat" checkbox
![new2](https://user-images.githubusercontent.com/77663720/200289806-dd12c8b0-11c3-42cb-b68a-baca5b084f14.png)

## Additional notes
