### PR TITLE
TH-1269 | Add "Show only remote events" checkbox to events-helsinki's advanced search

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -208,6 +208,16 @@ const AdvancedSearch: React.FC<Props> = ({
     scrollToResultList();
   };
 
+  const handleOnlyRemoteEventChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const search = getSearchQuery({
+      ...searchFilters,
+      onlyRemoteEvents: e.target.checked,
+    });
+    goToSearch(search);
+  };
+
   const handleIsFreeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const search = getSearchQuery({
       ...searchFilters,
@@ -383,6 +393,15 @@ const AdvancedSearch: React.FC<Props> = ({
                     id={EVENT_SEARCH_FILTERS.IS_FREE}
                     label={t('search.checkboxIsFree')}
                     onChange={handleIsFreeChange}
+                  />
+                </div>
+                <div>
+                  <Checkbox
+                    className={styles.checkbox}
+                    checked={onlyRemoteEvents}
+                    id={EVENT_SEARCH_FILTERS.ONLY_REMOTE_EVENTS}
+                    label={t('search.checkboxOnlyRemoteEvents')}
+                    onChange={handleOnlyRemoteEventChange}
                   />
                 </div>
                 <div className={styles.buttonWrapper}>

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -65,7 +65,7 @@ const searchJazzMocks = [
     response: eventsResponse,
   }),
   createEventListRequestAndResultMocks({
-    variables: { allOngoingAnd: ['jazz'] },
+    variables: { internetBased: true, allOngoingAnd: ['jazz'] },
     response: {
       ...fakeEvents(1, [{ name: fakeLocalizedObject(testEventName) }]),
       meta: meta2,
@@ -250,3 +250,31 @@ it.todo('should scroll to result list on mobile screen');
 
 //   expect(scroller.scrollTo).toBeCalled();
 // });
+
+it('should search remote events with remote event checkbox', async () => {
+  advanceTo(new Date(2020, 7, 12));
+  renderComponent();
+
+  await waitFor(() => {
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      screen.getByText(eventsResponse.data[0].name.fi!)
+    ).toBeInTheDocument();
+  });
+
+  const remoteEventCheckbox = screen.getByRole('checkbox', {
+    name: /näytä vain etätapahtumat/i,
+  });
+
+  await userEvent.click(remoteEventCheckbox);
+  // remote events search result should be visibe
+  await screen.findByText(testEventName);
+
+  // uncheck and previous search data comes from cache
+  await userEvent.click(remoteEventCheckbox);
+
+  eventsResponse.data.forEach((event) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(screen.getByText(event.name.fi!)).toBeInTheDocument();
+  });
+});

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -228,6 +228,21 @@ it('should change search query after clicking category menu item', async () => {
   });
 }, 50_000);
 
+it('should change search query with remote events checkbox', async () => {
+  const { router } = renderComponent();
+
+  const remoteEventsCheckbox = screen.getByRole('checkbox', {
+    name: /näytä vain etätapahtumat/i,
+  });
+
+  await userEvent.click(remoteEventsCheckbox);
+
+  expect(router).toMatchObject({
+    pathname,
+    query: { onlyRemoteEvents: 'true', text: 'jazz' },
+  });
+});
+
 // TODO: SKipped since there is no divisions input at the moment, but I've heard it should be there
 it.skip('disivions dropdown has additional divisions', async () => {
   renderComponent();

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -194,7 +194,7 @@ export const getEventSearchVariables = ({
     keywordNot,
     onlyChildrenEvents,
     onlyEveningEvents,
-    // onlyRemoteEvents,
+    onlyRemoteEvents,
     places,
     publisher,
     text,
@@ -269,7 +269,7 @@ export const getEventSearchVariables = ({
     end,
     include,
     isFree: isFree || undefined,
-    // internetBased: onlyRemoteEvents || undefined,
+    internetBased: onlyRemoteEvents || undefined,
     keywordOrSet2: [...(keyword ?? []), ...mappedCategories],
     keywordOrSet3: [...(keyword ?? []), ...mappedHobbyTypes],
     keywordAnd,
@@ -356,8 +356,8 @@ export const getSearchFilters = (searchParams: URLSearchParams): Filters => {
     //   searchParams.get(EVENT_SEARCH_FILTERS.ONLY_CHILDREN_EVENTS) === 'true',
     // onlyEveningEvents:
     //   searchParams.get(EVENT_SEARCH_FILTERS.ONLY_EVENING_EVENTS) === 'true',
-    // onlyRemoteEvents:
-    //   searchParams.get(EVENT_SEARCH_FILTERS.ONLY_REMOTE_EVENTS) === 'true',
+    onlyRemoteEvents:
+      searchParams.get(EVENT_SEARCH_FILTERS.ONLY_REMOTE_EVENTS) === 'true',
     places: getUrlParamAsArray(searchParams, EVENT_SEARCH_FILTERS.PLACES),
     publisher: searchParams.get(EVENT_SEARCH_FILTERS.PUBLISHER),
     start,


### PR DESCRIPTION
## Description

Add "Show only remote events" checkbox to events-helsinki's advanced search, enable its functionality and add tests for it.

## Issues

### Closes

**[TH-1269](https://helsinkisolutionoffice.atlassian.net/browse/TH-1269)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Old state from tapahtumat.hel.fi

#### Before clicking "Näytä vain etätapahtumat" checkbox
![old1](https://user-images.githubusercontent.com/77663720/199979807-5e528891-490e-4bcf-a2d0-7a94df52cfaa.png)

#### After clicking "Näytä vain etätapahtumat" checkbox
![old2](https://user-images.githubusercontent.com/77663720/199979819-114e815b-f8eb-461e-a947-22c2f53d8286.png)

### New state

#### Before clicking "Näytä vain etätapahtumat" checkbox
![new1](https://user-images.githubusercontent.com/77663720/199979828-434e5a01-b396-47c4-ab84-cd2ecd2bcbac.png)

#### After clicking "Näytä vain etätapahtumat" checkbox
![new2](https://user-images.githubusercontent.com/77663720/199979833-b866f124-9fbc-46cb-80a3-420f126a9aa9.png)

## Additional notes
