### PR TITLE
feat(cookie-consent): language change

### DIFF
--- a/apps/events-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
+++ b/apps/events-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
@@ -19,6 +19,7 @@ export default async function serverSideTranslationsWithCommon(
     [...new Set([...COMMON_TRANSLATIONS, ...namespaces])],
     {
       ...nextI18nextConfig,
-    }
+    },
+    ['fi', 'en', 'sv'] // FIXME: We should not need all the translations, all at once
   );
 }

--- a/packages/components/src/components/eventsCookieConsent/EventsCookieConsent.tsx
+++ b/packages/components/src/components/eventsCookieConsent/EventsCookieConsent.tsx
@@ -1,6 +1,5 @@
 import type { ContentSource } from 'hds-react';
 import { CookieModal } from 'hds-react';
-import { useRouter } from 'next/router';
 import React from 'react';
 import { MAIN_CONTENT_ID } from '../../constants';
 import { useCommonTranslation } from '../../hooks';
@@ -11,262 +10,263 @@ const EventsCookieConsent: React.FC = () => {
   const locale = useLocale();
   const { t } = useCommonTranslation();
   const [language, setLanguage] = React.useState<Language>(locale);
-  const router = useRouter();
-  const { pathname, asPath, query } = router;
 
-  const onLanguageChange = (newLang: Language) => {
-    setLanguage(newLang);
- //   void router.push({ pathname, query }, asPath, { locale: newLang });
+  const onLanguageChange = (newLang: string) => {
+    setLanguage(newLang as Language);
   };
 
-  const contentSource: ContentSource = React.useMemo(() => ({
-      siteName: t('eventsCommon:appName'),
-    currentLanguage: language,
-    requiredCookies: {
-      groups: [
-        {
+  const contentSource: ContentSource = React.useMemo(
+    () => ({
+      siteName: t('eventsCommon:appName', { lng: language }),
+      currentLanguage: language as string as ContentSource['currentLanguage'],
+      requiredCookies: {
+        groups: [
+          {
             commonGroup: 'login',
-          cookies: [
-            {
-              commonCookie: 'tunnistamo',
-            },
-            {
-              commonCookie: 'keycloak',
-            },
-          ],
-        },
-        {
-          commonGroup: 'essential',
-          cookies: [
-            {
-              commonCookie: 'cms-session',
-            },
-          ],
-        },
-        {
-          commonGroup: 'loadBalancing',
-          cookies: [
-            {
-              id: 'loadbalancer',
-              name: 'Loadbalancer Cookie',
-              hostName: 'CDN site',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'accessibility',
-          cookies: [
-            {
-              id: 'accessibility',
-              name: 'Accessibility cookie',
-              hostName: 'CDN site',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'userInputs',
-          cookies: [
-            {
-              id: 'userInputs',
-              name: 'User inputs cookie',
-              hostName: 'CDN site',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-      ],
-    },
-    optionalCookies: {
-      groups: [
-        {
-          commonGroup: 'marketing',
-          cookies: [
-            {
-              id: 'marketing',
-              name: 'Custom Marketing cookie',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'preferences',
-          cookies: [
-            {
-              id: 'preferences1',
-              name: 'Preference 1',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-            {
-              id: 'preferences2',
-              name: 'Preference 2',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1 years',
-            },
-            {
-              id: 'preferences3',
-              name: 'Preference 3',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '2h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'statistics',
-          cookies: [
-            {
-              commonCookie: 'matomo',
-            },
-            {
-              commonCookie: 'cookiehub',
-            },
-            {
-              id: 'someOtherConsent',
-              name: 'Other consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'location',
-          cookies: [
-            {
-              id: 'location',
-              name: 'Location consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'content',
-          cookies: [
-            {
-              id: 'content',
-              name: 'Content consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'thirdParty',
-          cookies: [
-            {
-              id: 'thirdParty',
-              name: 'ThirdParty consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'chat',
-          cookies: [
-            {
-              id: 'chat',
-              name: 'Chat consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'deviceInfo',
-          cookies: [
-            {
-              id: 'deviceInfo',
-              name: 'Device info consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'socialMedia',
-          cookies: [
-            {
-              id: 'socialMedia',
-              name: 'Social media consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-        {
-          commonGroup: 'informationSecurity',
-          cookies: [
-            {
-              id: 'informationSecurity',
-              name: 'Information security consent',
-              hostName: 'Host name',
-              description:
-                'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
-              expiration: '1h',
-            },
-          ],
-        },
-      ],
-    },
+            cookies: [
+              {
+                commonCookie: 'tunnistamo',
+              },
+              {
+                commonCookie: 'keycloak',
+              },
+            ],
+          },
+          {
+            commonGroup: 'essential',
+            cookies: [
+              {
+                commonCookie: 'cms-session',
+              },
+            ],
+          },
+          {
+            commonGroup: 'loadBalancing',
+            cookies: [
+              {
+                id: 'loadbalancer',
+                name: 'Loadbalancer Cookie',
+                hostName: 'CDN site',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'accessibility',
+            cookies: [
+              {
+                id: 'accessibility',
+                name: 'Accessibility cookie',
+                hostName: 'CDN site',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'userInputs',
+            cookies: [
+              {
+                id: 'userInputs',
+                name: 'User inputs cookie',
+                hostName: 'CDN site',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+        ],
+      },
+      optionalCookies: {
+        groups: [
+          {
+            commonGroup: 'marketing',
+            cookies: [
+              {
+                id: 'marketing',
+                name: 'Custom Marketing cookie',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'preferences',
+            cookies: [
+              {
+                id: 'preferences1',
+                name: 'Preference 1',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+              {
+                id: 'preferences2',
+                name: 'Preference 2',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1 years',
+              },
+              {
+                id: 'preferences3',
+                name: 'Preference 3',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '2h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'statistics',
+            cookies: [
+              {
+                commonCookie: 'matomo',
+              },
+              {
+                commonCookie: 'cookiehub',
+              },
+              {
+                id: 'someOtherConsent',
+                name: 'Other consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'location',
+            cookies: [
+              {
+                id: 'location',
+                name: 'Location consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'content',
+            cookies: [
+              {
+                id: 'content',
+                name: 'Content consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'thirdParty',
+            cookies: [
+              {
+                id: 'thirdParty',
+                name: 'ThirdParty consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'chat',
+            cookies: [
+              {
+                id: 'chat',
+                name: 'Chat consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'deviceInfo',
+            cookies: [
+              {
+                id: 'deviceInfo',
+                name: 'Device info consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'socialMedia',
+            cookies: [
+              {
+                id: 'socialMedia',
+                name: 'Social media consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+          {
+            commonGroup: 'informationSecurity',
+            cookies: [
+              {
+                id: 'informationSecurity',
+                name: 'Information security consent',
+                hostName: 'Host name',
+                description:
+                  'Description lectus lacinia sed. Phasellus purus nisi, imperdiet id volutpat vel, pellentesque in ex. In pretium maximus finibus',
+                expiration: '1h',
+              },
+            ],
+          },
+        ],
+      },
 
-    language: {
-      onLanguageChange,
-    },
-    onAllConsentsGiven: (consents) => {
-      if (consents.matomo) {
-        //  start tracking
-        // window._paq.push(['setConsentGiven']);
-        // window._paq.push(['setCookieConsentGiven']);
-      }
-    },
-    onConsentsParsed: (consents, hasUserHandledAllConsents) => {
-      if (consents.matomo === undefined) {
-        // tell matomo to wait for consent:
-        // window._paq.push(['requireConsent']);
-        // window._paq.push(['requireCookieConsent']);
-        // eslint-disable-next-line sonarjs/no-duplicated-branches
-      } else if (consents.matomo === false) {
-        // tell matomo to forget conset
-        // window._paq.push(['forgetConsentGiven']);
-      }
-      if (hasUserHandledAllConsents) {
+      language: {
+        current: language as string as ContentSource['currentLanguage'],
+        onLanguageChange,
+      },
+      onAllConsentsGiven: (consents) => {
+        if (consents.matomo) {
+          //  start tracking
+          // window._paq.push(['setConsentGiven']);
+          // window._paq.push(['setCookieConsentGiven']);
+        }
+      },
+      onConsentsParsed: (consents, hasUserHandledAllConsents) => {
+        if (consents.matomo === undefined) {
+          // tell matomo to wait for consent:
+          // window._paq.push(['requireConsent']);
+          // window._paq.push(['requireCookieConsent']);
+          // eslint-disable-next-line sonarjs/no-duplicated-branches
+        } else if (consents.matomo === false) {
+          // tell matomo to forget conset
+          // window._paq.push(['forgetConsentGiven']);
+        }
+        if (hasUserHandledAllConsents) {
           // cookie consent modal will not be shown
-      }
-    },
-    focusTargetSelector: MAIN_CONTENT_ID,
-  }), [t,language]);
+        }
+      },
+      focusTargetSelector: MAIN_CONTENT_ID,
+    }),
+    [t, language]
+  );
 
   return <CookieModal contentSource={contentSource} />;
 };


### PR DESCRIPTION
Add the language change feature to #44 

HH-145.

Cookie consent language can be changed
without changing the whole UI language.

All the locales are loaded server side all at once.