### PR TITLE
TH-1129 | Add location extra info to event detail page

### DIFF
--- a/apps/events-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/events-helsinki/config/jest/mockDataUtils.ts
@@ -87,6 +87,7 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       audienceMaxAge: '15',
       typeId: EventTypeId.General,
       __typename: 'EventDetails',
+      locationExtraInfo: null,
     },
     overrides
   );

--- a/apps/events-helsinki/src/domain/event/EventUtils.ts
+++ b/apps/events-helsinki/src/domain/event/EventUtils.ts
@@ -341,6 +341,7 @@ export const getEventFields = (event: EventFields, locale: Language) => {
     audienceMaxAge: event.audienceMaxAge,
     photographerName: event.images[0]?.photographerName,
     ...getEventLocationFields(event, locale),
+    locationExtraInfo: getLocalizedString(event.locationExtraInfo, locale),
   };
 };
 

--- a/apps/events-helsinki/src/domain/event/eventContent/EventContent.tsx
+++ b/apps/events-helsinki/src/domain/event/eventContent/EventContent.tsx
@@ -19,7 +19,10 @@ interface Props {
 const EventContent: React.FC<Props> = ({ event, superEvent }) => {
   const { t } = useTranslation(['common', 'event']);
   const locale = useLocale();
-  const { description, photographerName } = getEventFields(event, locale);
+  const { description, photographerName, locationExtraInfo } = getEventFields(
+    event,
+    locale
+  );
 
   const isInternetEvent = event?.location?.id === EVENT_LOCATIONS.INTERNET;
 
@@ -40,6 +43,16 @@ const EventContent: React.FC<Props> = ({ event, superEvent }) => {
                     __html: sanitizeHtml(description),
                   }}
                 />
+                {locationExtraInfo && (
+                  <>
+                    <h2 className={styles.descriptionTitle}>
+                      {t('event:locationExtraInfo.title')}
+                    </h2>
+                    <div className={styles.description}>
+                      <p>{locationExtraInfo}</p>
+                    </div>
+                  </>
+                )}
                 {photographerName && (
                   <p>
                     {t('common:photographerText', {

--- a/apps/events-helsinki/src/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/apps/events-helsinki/src/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -106,3 +106,23 @@ it('should hide map if internet event', () => {
   );
   expect(screen.queryByText(/sijainti/i)).not.toBeInTheDocument();
 });
+
+it('should show location extra info when available', () => {
+  render(
+    <EventContent
+      event={
+        {
+          ...event,
+          locationExtraInfo: { fi: 'Sisään takaovesta' },
+        } as EventFieldsFragment
+      }
+    />
+  );
+  expect(screen.getByText(/Paikan lisätiedot/i)).toBeInTheDocument();
+  expect(screen.getByText(/Sisään takaovesta/i)).toBeInTheDocument();
+});
+
+it('should not show location extra info title when location extra info not available', () => {
+  render(<EventContent event={event} />);
+  expect(screen.queryByText(/Paikan lisätiedot/i)).not.toBeInTheDocument();
+});

--- a/apps/events-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/apps/events-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -47,6 +47,7 @@ const getFakeEvent = (overrides?: Partial<EventDetails>) => {
       streetAddress: { fi: streetAddress },
     },
     externalLinks: [],
+    locationExtraInfo: null,
     ...overrides,
   }) as EventFieldsFragment;
 };

--- a/apps/events-helsinki/src/domain/event/query.ts
+++ b/apps/events-helsinki/src/domain/event/query.ts
@@ -80,6 +80,9 @@ export const QUERY_EVENT_DETAILS = gql`
         ...localizedFields
       }
     }
+    locationExtraInfo {
+      ...localizedFields
+    }
   }
 
   query EventDetails($id: ID!, $include: [String]) {

--- a/apps/events-helsinki/src/domain/nextApi/graphql/generated/graphql.tsx
+++ b/apps/events-helsinki/src/domain/nextApi/graphql/generated/graphql.tsx
@@ -757,6 +757,12 @@ export type EventFieldsFragment = {
       sv?: string | null;
     } | null;
   }>;
+  locationExtraInfo?: {
+    __typename?: 'LocalizedObject';
+    en?: string | null;
+    fi?: string | null;
+    sv?: string | null;
+  } | null;
 };
 
 export type EventDetailsQueryVariables = Exact<{
@@ -934,6 +940,12 @@ export type EventDetailsQuery = {
         sv?: string | null;
       } | null;
     }>;
+    locationExtraInfo?: {
+      __typename?: 'LocalizedObject';
+      en?: string | null;
+      fi?: string | null;
+      sv?: string | null;
+    } | null;
   };
 };
 
@@ -1484,6 +1496,12 @@ export type EventListQuery = {
           sv?: string | null;
         } | null;
       }>;
+      locationExtraInfo?: {
+        __typename?: 'LocalizedObject';
+        en?: string | null;
+        fi?: string | null;
+        sv?: string | null;
+      } | null;
     }>;
   };
 };
@@ -1673,6 +1691,12 @@ export type EventsByIdsQuery = {
           sv?: string | null;
         } | null;
       }>;
+      locationExtraInfo?: {
+        __typename?: 'LocalizedObject';
+        en?: string | null;
+        fi?: string | null;
+        sv?: string | null;
+      } | null;
     }>;
     meta: {
       __typename?: 'Meta';
@@ -1823,6 +1847,9 @@ export const EventFieldsFragmentDoc = gql`
       name {
         ...localizedFields
       }
+    }
+    locationExtraInfo {
+      ...localizedFields
     }
   }
   ${LocalizedFieldsFragmentDoc}

--- a/packages/common-i18n/src/locales/en/event.json
+++ b/packages/common-i18n/src/locales/en/event.json
@@ -72,6 +72,9 @@
     "openMap": "Open the map",
     "title": "Location"
   },
+  "locationExtraInfo": {
+    "title": "Location extra info"
+  },
   "notFound": {
     "linkSearchEvents": "Find hobbies",
     "text": "For some reason we can't find the event you are looking for. Try searching for something else here:",

--- a/packages/common-i18n/src/locales/fi/event.json
+++ b/packages/common-i18n/src/locales/fi/event.json
@@ -71,6 +71,9 @@
     "openMap": "Avaa kartta",
     "title": "Sijainti"
   },
+  "locationExtraInfo": {
+    "title": "Paikan lisätiedot"
+  },
   "notFound": {
     "linkSearchEvents": "Hae itsellesi tekemistä",
     "text": "Syystä tai toisesta hakemaasi tapahtumaa ei löydy. Löydä itsellesi tekemistä vaikkapa täältä:",

--- a/packages/common-i18n/src/locales/sv/event.json
+++ b/packages/common-i18n/src/locales/sv/event.json
@@ -71,6 +71,9 @@
     "openMap": "Öppna kartan",
     "title": "Plats"
   },
+  "locationExtraInfo": {
+    "title": "Plats ytterligare info"
+  },
   "notFound": {
     "linkSearchEvents": "Hitta hobbyer",
     "text": "Av en eller annan orsak så hittas inte evenemänget du letade efter. Försök istället att hitta något att göra härifrån:",


### PR DESCRIPTION
## Description

Added location extra info to event detail page.

## Issues

### Closes

**[TH-1129](https://helsinkisolutionoffice.atlassian.net/browse/TH-1129): Show "Paikan lisätiedot" in single event page**

## Screenshots
<img width="1295" alt="Screenshot 2022-11-08 at 9 59 08" src="https://user-images.githubusercontent.com/1314604/200545207-67e9d2d4-7262-4042-9b62-04f96bc8d18a.png">

