### PR TITLE
TH-1256 & TH-1276 | Update search categories to production values

### DIFF
--- a/apps/events-helsinki/config/jest/mocks/eventListMocks.ts
+++ b/apps/events-helsinki/config/jest/mocks/eventListMocks.ts
@@ -44,14 +44,13 @@ export const getOtherEventsVariables = (
 });
 
 const createRequest = (
-  type: EventType = 'course',
   variablesOverride: EventListQueryVariables = {}
 ): GraphQLRequest => ({
   query: EventListDocument,
   variables: {
     ...eventListBaseVariables,
     ...variablesOverride,
-    eventType: type === 'event' ? [EventTypeId.General] : [EventTypeId.Course],
+    eventType: [EventTypeId.General],
   },
 });
 
@@ -71,19 +70,17 @@ export type EventListMockArguments = {
 };
 
 export const createEventListRequestAndResultMocks = ({
-  type = 'event',
   variables = {},
   response,
 }: EventListMockArguments): MockedResponse => ({
-  request: createRequest(type, variables),
+  request: createRequest(variables),
   result: createResult(response),
 });
 
 export const createEventListRequestThrowsErrorMocks = ({
-  type = 'event',
   variables = {},
 }: EventListMockArguments = {}): MockedResponse => ({
-  request: createRequest(type, variables),
+  request: createRequest(variables),
   error: new Error('not found'),
 });
 

--- a/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
+++ b/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
@@ -6,10 +6,7 @@ import CategoryFilter from '../../common-events/components/category/CategoryFilt
 
 import { ROUTES } from '../../constants';
 import { getLocalizedCmsItemUrl } from '../../utils/routerUtils';
-import {
-  CATEGORY_CATALOG,
-  COURSE_DEFAULT_SEARCH_FILTERS,
-} from '../search/eventSearch/constants';
+import { COURSE_DEFAULT_SEARCH_FILTERS } from '../search/eventSearch/constants';
 import type { CategoryOption, Filters } from '../search/eventSearch/types';
 import {
   getEventCategoryOptions,
@@ -36,10 +33,7 @@ const FooterCategories: FunctionComponent = () => {
     [ROUTES.SEARCH]: COURSE_DEFAULT_SEARCH_FILTERS,
   };
 
-  const categories = getEventCategoryOptions(
-    t,
-    CATEGORY_CATALOG.Course.default
-  );
+  const categories = getEventCategoryOptions(t);
   const footerTitle = t(`footer:titleEventsCategories`);
 
   return (

--- a/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
+++ b/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
@@ -40,7 +40,7 @@ const FooterCategories: FunctionComponent = () => {
     t,
     CATEGORY_CATALOG.Course.default
   );
-  const footerTitle = t(`footer:titleCoursesCategories`);
+  const footerTitle = t(`footer:titleEventsCategories`);
 
   return (
     <div className={styles.topFooterWrapper}>

--- a/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
+++ b/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
@@ -6,7 +6,7 @@ import CategoryFilter from '../../common-events/components/category/CategoryFilt
 
 import { ROUTES } from '../../constants';
 import { getLocalizedCmsItemUrl } from '../../utils/routerUtils';
-import { COURSE_DEFAULT_SEARCH_FILTERS } from '../search/eventSearch/constants';
+import { EVENT_DEFAULT_SEARCH_FILTERS } from '../search/eventSearch/constants';
 import type { CategoryOption, Filters } from '../search/eventSearch/types';
 import {
   getEventCategoryOptions,
@@ -30,7 +30,7 @@ const FooterCategories: FunctionComponent = () => {
   };
 
   const defaultSearchFiltersMap: Record<string, Filters> = {
-    [ROUTES.SEARCH]: COURSE_DEFAULT_SEARCH_FILTERS,
+    [ROUTES.SEARCH]: EVENT_DEFAULT_SEARCH_FILTERS,
   };
 
   const categories = getEventCategoryOptions(t);

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -221,25 +221,25 @@ it('should change search query after clicking category menu item', async () => {
   });
 
   await userEvent.click(chooseCategoryButton);
-  await userEvent.click(
-    screen.getByRole('checkbox', { name: /elokuva ja media/i })
-  );
+  await userEvent.click(screen.getByRole('checkbox', { name: /elokuva/i }));
   await userEvent.click(screen.getByRole('button', { name: /hae/i }));
   expect(router).toMatchObject({
     pathname,
-    asPath: `${pathname}?categories=movie_and_media&text=jazz`,
-    query: { categories: 'movie_and_media', text: 'jazz' },
+    asPath: `${pathname}?categories=movie&text=jazz`,
+    query: { categories: 'movie', text: 'jazz' },
   });
 
   // multiple selection
   await userEvent.click(chooseCategoryButton);
-  await userEvent.click(screen.getByRole('checkbox', { name: /pelit/i }));
+  await userEvent.click(
+    screen.getByRole('checkbox', { name: /luonto ja ulkoilu/i })
+  );
   await userEvent.click(screen.getByRole('checkbox', { name: /musiikki/i }));
   await userEvent.click(screen.getByRole('button', { name: /hae/i }));
   expect(router).toMatchObject({
     pathname,
-    asPath: `${pathname}?categories=movie_and_media%2Cgames%2Cmusic&text=jazz`,
-    query: { categories: 'movie_and_media,games,music', text: 'jazz' },
+    asPath: `${pathname}?categories=movie%2Cnature%2Cmusic&text=jazz`,
+    query: { categories: 'movie,nature,music', text: 'jazz' },
   });
 }, 50_000);
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -3,9 +3,9 @@ import { DATE_TYPES } from 'events-helsinki-components';
 import { advanceTo, clear } from 'jest-date-mock';
 
 import {
-  EVENT_CATEGORIES,
   EVENT_DEFAULT_SEARCH_FILTERS,
   EVENT_SORT_OPTIONS,
+  MAPPED_EVENT_CATEGORIES,
 } from '../constants';
 import { getEventSearchVariables, getNextPage, getSearchQuery } from '../utils';
 
@@ -46,77 +46,23 @@ describe('getEventSearchVariables function', () => {
     sortOrder: EVENT_SORT_OPTIONS.END_TIME,
     superEventType: [],
   };
-  it('should return correct keywords per category', () => {
-    const { keywordOrSet2: keyword1 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.CULTURE}`),
-    });
-    expect((keyword1 || []).join(',')).toContain(
-      // eslint-disable-next-line max-len
-      'kulke:33,kulke:51,kulke:205,kulke:351,matko:teatteri,yso:p360,yso:p1235,yso:p1278,yso:p1808,yso:p2625,yso:p2739,yso:p2850,yso:p2851,yso:p4934,yso:p5121,yso:p6889,yso:p7969,yso:p8113,yso:p8144,yso:p9592,yso:p9593,yso:p10105,yso:p16327'
-    );
+  it.each(Object.entries(MAPPED_EVENT_CATEGORIES))(
+    'should return correct keywords per category',
+    (category, expected_keywords) => {
+      const { keywordOrSet2: keywords } = getEventSearchVariables({
+        ...defaultParams,
+        params: new URLSearchParams(`?categories=${category}`),
+      });
+      expect((keywords || []).join(',')).toContain(expected_keywords.join(','));
+    }
+  );
 
-    const { keywordOrSet2: keyword2 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.DANCE}`),
-    });
-    expect(keyword2).toContain('yso:p1278');
-
-    const { keywordOrSet2: keyword3 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.FOOD}`),
-    });
-    expect(keyword3).toContain('yso:p3670');
-
-    const { keywordOrSet2: keyword4 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.INFLUENCE}`),
-    });
-    expect((keyword4 || []).join(',')).toContain(
-      'yso:p1657,yso:p742,yso:p5164,yso:p8268,yso:p15882,yso:p15292'
-    );
-
-    const { keywordOrSet2: keyword6 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MOVIE}`),
-    });
-    expect(keyword6).toContain('yso:p1235');
-
-    const { keywordOrSet2: keyword7 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MUSEUM}`),
-    });
-    expect((keyword7 || []).join(',')).toContain('matko:museo,yso:p4934');
-
-    const { keywordOrSet2: keyword8 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MUSIC}`),
-    });
-    expect(keyword8).toContain('yso:p1808');
-
-    const { keywordOrSet2: keyword9 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.NATURE}`),
-    });
-    expect(keyword9).toContain('yso:p2771');
-
-    const { keywordOrSet2: keyword10 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.SPORT}`),
-    });
-    expect((keyword10 || []).join(',')).toContain('yso:p916,yso:p965');
-
-    const { keywordOrSet2: keyword11 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.THEATRE}`),
-    });
-    expect(keyword11).toContain('yso:p2625');
-
-    const { keywordOrSet2: keyword12 } = getEventSearchVariables({
+  it('should not return any keywords for an undefined category', () => {
+    const { keywordOrSet2: keywords } = getEventSearchVariables({
       ...defaultParams,
       params: new URLSearchParams(`?categories=not_found`),
     });
-    expect(keyword12).toStrictEqual([]);
+    expect(keywords).toStrictEqual([]);
   });
 
   it('should return start=now if start time is in past/today', () => {

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -76,12 +76,6 @@ describe('getEventSearchVariables function', () => {
       'yso:p1657,yso:p742,yso:p5164,yso:p8268,yso:p15882,yso:p15292'
     );
 
-    const { keywordOrSet2: keyword5 } = getEventSearchVariables({
-      ...defaultParams,
-      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MISC}`),
-    });
-    expect(keyword5).toContain('yso:p2108');
-
     const { keywordOrSet2: keyword6 } = getEventSearchVariables({
       ...defaultParams,
       params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MOVIE}`),

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -2,7 +2,11 @@ import type { Language } from 'events-helsinki-components';
 import { DATE_TYPES } from 'events-helsinki-components';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { EVENT_DEFAULT_SEARCH_FILTERS, EVENT_SORT_OPTIONS } from '../constants';
+import {
+  EVENT_CATEGORIES,
+  EVENT_DEFAULT_SEARCH_FILTERS,
+  EVENT_SORT_OPTIONS,
+} from '../constants';
 import { getEventSearchVariables, getNextPage, getSearchQuery } from '../utils';
 
 afterAll(() => {
@@ -42,6 +46,84 @@ describe('getEventSearchVariables function', () => {
     sortOrder: EVENT_SORT_OPTIONS.END_TIME,
     superEventType: [],
   };
+  it('should return correct keywords per category', () => {
+    const { keywordOrSet2: keyword1 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.CULTURE}`),
+    });
+    expect((keyword1 || []).join(',')).toContain(
+      // eslint-disable-next-line max-len
+      'kulke:33,kulke:51,kulke:205,kulke:351,matko:teatteri,yso:p360,yso:p1235,yso:p1278,yso:p1808,yso:p2625,yso:p2739,yso:p2850,yso:p2851,yso:p4934,yso:p5121,yso:p6889,yso:p7969,yso:p8113,yso:p8144,yso:p9592,yso:p9593,yso:p10105,yso:p16327'
+    );
+
+    const { keywordOrSet2: keyword2 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.DANCE}`),
+    });
+    expect(keyword2).toContain('yso:p1278');
+
+    const { keywordOrSet2: keyword3 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.FOOD}`),
+    });
+    expect(keyword3).toContain('yso:p3670');
+
+    const { keywordOrSet2: keyword4 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.INFLUENCE}`),
+    });
+    expect((keyword4 || []).join(',')).toContain(
+      'yso:p1657,yso:p742,yso:p5164,yso:p8268,yso:p15882,yso:p15292'
+    );
+
+    const { keywordOrSet2: keyword5 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MISC}`),
+    });
+    expect(keyword5).toContain('yso:p2108');
+
+    const { keywordOrSet2: keyword6 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MOVIE}`),
+    });
+    expect(keyword6).toContain('yso:p1235');
+
+    const { keywordOrSet2: keyword7 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MUSEUM}`),
+    });
+    expect((keyword7 || []).join(',')).toContain('matko:museo,yso:p4934');
+
+    const { keywordOrSet2: keyword8 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.MUSIC}`),
+    });
+    expect(keyword8).toContain('yso:p1808');
+
+    const { keywordOrSet2: keyword9 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.NATURE}`),
+    });
+    expect(keyword9).toContain('yso:p2771');
+
+    const { keywordOrSet2: keyword10 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.SPORT}`),
+    });
+    expect((keyword10 || []).join(',')).toContain('yso:p916,yso:p965');
+
+    const { keywordOrSet2: keyword11 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.THEATRE}`),
+    });
+    expect(keyword11).toContain('yso:p2625');
+
+    const { keywordOrSet2: keyword12 } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?categories=not_found`),
+    });
+    expect(keyword12).toStrictEqual([]);
+  });
 
   it('should return start=now if start time is in past/today', () => {
     advanceTo('2020-10-06');

--- a/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -17,7 +17,7 @@ import type { Filters, SearchCategoryOption } from './types';
 // Page size of the event list
 export const PAGE_SIZE = 10;
 
-export enum COURSE_CATEGORIES {
+export enum EVENT_CATEGORIES {
   MOVIE = 'movie_and_media',
   LANGUAGES = 'languages',
   LITERATURE = 'literature',
@@ -96,28 +96,28 @@ export enum EVENT_SEARCH_FILTERS {
 export const CATEGORY_CATALOG = {
   [EventTypeId.Course]: {
     default: [
-      COURSE_CATEGORIES.MOVIE,
-      COURSE_CATEGORIES.LANGUAGES,
-      COURSE_CATEGORIES.LITERATURE,
-      COURSE_CATEGORIES.ARTS_AND_CULTURE,
-      COURSE_CATEGORIES.VISUAL_ARTS,
-      COURSE_CATEGORIES.HANDICRAFTS,
-      COURSE_CATEGORIES.SPORT,
-      COURSE_CATEGORIES.MUSIC,
-      COURSE_CATEGORIES.GAMES,
-      COURSE_CATEGORIES.FOOD,
-      COURSE_CATEGORIES.DANCE,
-      COURSE_CATEGORIES.THEATRE,
+      EVENT_CATEGORIES.MOVIE,
+      EVENT_CATEGORIES.LANGUAGES,
+      EVENT_CATEGORIES.LITERATURE,
+      EVENT_CATEGORIES.ARTS_AND_CULTURE,
+      EVENT_CATEGORIES.VISUAL_ARTS,
+      EVENT_CATEGORIES.HANDICRAFTS,
+      EVENT_CATEGORIES.SPORT,
+      EVENT_CATEGORIES.MUSIC,
+      EVENT_CATEGORIES.GAMES,
+      EVENT_CATEGORIES.FOOD,
+      EVENT_CATEGORIES.DANCE,
+      EVENT_CATEGORIES.THEATRE,
     ],
     landingPage: [
-      COURSE_CATEGORIES.LITERATURE,
-      COURSE_CATEGORIES.VISUAL_ARTS,
-      COURSE_CATEGORIES.HANDICRAFTS,
-      COURSE_CATEGORIES.SPORT,
-      COURSE_CATEGORIES.MUSIC,
-      COURSE_CATEGORIES.GAMES,
-      COURSE_CATEGORIES.DANCE,
-      COURSE_CATEGORIES.THEATRE,
+      EVENT_CATEGORIES.LITERATURE,
+      EVENT_CATEGORIES.VISUAL_ARTS,
+      EVENT_CATEGORIES.HANDICRAFTS,
+      EVENT_CATEGORIES.SPORT,
+      EVENT_CATEGORIES.MUSIC,
+      EVENT_CATEGORIES.GAMES,
+      EVENT_CATEGORIES.DANCE,
+      EVENT_CATEGORIES.THEATRE,
     ],
   },
 };
@@ -262,19 +262,19 @@ export const THEATRE_COURSES_KEYWORDS = [
 ];
 
 // todo: replace with valid keyword ids
-export const MAPPED_COURSE_CATEGORIES: Record<string, string[]> = {
-  [COURSE_CATEGORIES.MOVIE]: MOVIES_AND_MEDIA_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.LANGUAGES]: LANGUAGES_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.LITERATURE]: LITERATURE_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.ARTS_AND_CULTURE]: ARTS_AND_CULTURE_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.VISUAL_ARTS]: VISUAL_ARTS_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.HANDICRAFTS]: HANDICRAFTS_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.SPORT]: SPORT_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.MUSIC]: MUSIC_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.GAMES]: GAMES_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.FOOD]: FOOD_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.DANCE]: DANCE_COURSES_KEYWORDS,
-  [COURSE_CATEGORIES.THEATRE]: THEATRE_COURSES_KEYWORDS,
+export const MAPPED_EVENT_CATEGORIES: Record<string, string[]> = {
+  [EVENT_CATEGORIES.MOVIE]: MOVIES_AND_MEDIA_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.LANGUAGES]: LANGUAGES_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.LITERATURE]: LITERATURE_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.ARTS_AND_CULTURE]: ARTS_AND_CULTURE_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.VISUAL_ARTS]: VISUAL_ARTS_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.HANDICRAFTS]: HANDICRAFTS_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.SPORT]: SPORT_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.MUSIC]: MUSIC_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.GAMES]: GAMES_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.FOOD]: FOOD_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.DANCE]: DANCE_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.THEATRE]: THEATRE_COURSES_KEYWORDS,
 };
 
 // course hobby types
@@ -308,56 +308,55 @@ export const WORKSHOPS_KEYWORDS = [
   'kulke:732',
 ];
 
-export const courseCategories: Record<COURSE_CATEGORIES, SearchCategoryOption> =
-  {
-    [COURSE_CATEGORIES.MOVIE]: {
-      icon: <IconMovies />,
-      labelKey: 'home:category.courses.movieAndMedia',
-    },
-    [COURSE_CATEGORIES.LANGUAGES]: {
-      icon: <IconLanguages />,
-      labelKey: 'home:category.courses.languages',
-    },
-    [COURSE_CATEGORIES.LITERATURE]: {
-      icon: <IconLiterature />,
-      labelKey: 'home:category.courses.literature',
-    },
-    [COURSE_CATEGORIES.ARTS_AND_CULTURE]: {
-      icon: <IconArt />,
-      labelKey: 'home:category.courses.artsAndCulture',
-    },
-    [COURSE_CATEGORIES.VISUAL_ARTS]: {
-      icon: <IconArt />,
-      labelKey: 'home:category.courses.visualArts',
-    },
-    [COURSE_CATEGORIES.HANDICRAFTS]: {
-      icon: <IconCraft />,
-      labelKey: 'home:category.courses.handicrafts',
-    },
-    [COURSE_CATEGORIES.SPORT]: {
-      icon: <IconSports />,
-      labelKey: 'home:category.courses.sport',
-    },
-    [COURSE_CATEGORIES.MUSIC]: {
-      icon: <IconMusic />,
-      labelKey: 'home:category.courses.music',
-    },
-    [COURSE_CATEGORIES.GAMES]: {
-      icon: <IconGames />,
-      labelKey: 'home:category.courses.games',
-    },
-    [COURSE_CATEGORIES.FOOD]: {
-      icon: <IconFood />,
-      labelKey: 'home:category.courses.food',
-    },
-    [COURSE_CATEGORIES.DANCE]: {
-      icon: <IconDance />,
-      labelKey: 'home:category.courses.dance',
-    },
-    [COURSE_CATEGORIES.THEATRE]: {
-      icon: <IconTheatre />,
-      labelKey: 'home:category.courses.theatre',
-    },
-  };
+export const eventCategories: Record<EVENT_CATEGORIES, SearchCategoryOption> = {
+  [EVENT_CATEGORIES.MOVIE]: {
+    icon: <IconMovies />,
+    labelKey: 'home:category.courses.movieAndMedia',
+  },
+  [EVENT_CATEGORIES.LANGUAGES]: {
+    icon: <IconLanguages />,
+    labelKey: 'home:category.courses.languages',
+  },
+  [EVENT_CATEGORIES.LITERATURE]: {
+    icon: <IconLiterature />,
+    labelKey: 'home:category.courses.literature',
+  },
+  [EVENT_CATEGORIES.ARTS_AND_CULTURE]: {
+    icon: <IconArt />,
+    labelKey: 'home:category.courses.artsAndCulture',
+  },
+  [EVENT_CATEGORIES.VISUAL_ARTS]: {
+    icon: <IconArt />,
+    labelKey: 'home:category.courses.visualArts',
+  },
+  [EVENT_CATEGORIES.HANDICRAFTS]: {
+    icon: <IconCraft />,
+    labelKey: 'home:category.courses.handicrafts',
+  },
+  [EVENT_CATEGORIES.SPORT]: {
+    icon: <IconSports />,
+    labelKey: 'home:category.courses.sport',
+  },
+  [EVENT_CATEGORIES.MUSIC]: {
+    icon: <IconMusic />,
+    labelKey: 'home:category.courses.music',
+  },
+  [EVENT_CATEGORIES.GAMES]: {
+    icon: <IconGames />,
+    labelKey: 'home:category.courses.games',
+  },
+  [EVENT_CATEGORIES.FOOD]: {
+    icon: <IconFood />,
+    labelKey: 'home:category.courses.food',
+  },
+  [EVENT_CATEGORIES.DANCE]: {
+    icon: <IconDance />,
+    labelKey: 'home:category.courses.dance',
+  },
+  [EVENT_CATEGORIES.THEATRE]: {
+    icon: <IconTheatre />,
+    labelKey: 'home:category.courses.theatre',
+  },
+};
 
 export const MAPPED_PLACES: Record<string, string> = {};

--- a/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -21,7 +21,6 @@ export enum EVENT_CATEGORIES {
   DANCE = 'dance',
   FOOD = 'food',
   INFLUENCE = 'influence',
-  MISC = 'misc',
   MOVIE = 'movie',
   MUSEUM = 'museum',
   MUSIC = 'music',
@@ -41,19 +40,6 @@ export const EVENT_DEFAULT_SEARCH_FILTERS: Filters = {
   keywordNot: [],
   places: [],
   publisher: null,
-  start: null,
-  text: [],
-  suitableFor: [],
-};
-
-export const COURSE_DEFAULT_SEARCH_FILTERS = {
-  categories: [],
-  dateTypes: [],
-  divisions: [],
-  end: null,
-  isFree: false,
-  alsoOngoingCourses: false,
-  places: [],
   start: null,
   text: [],
   suitableFor: [],
@@ -147,8 +133,6 @@ export const INFLUENCE_KEYWORDS = [
   'yso:p15292', // Kaupunkipolitiikka
 ];
 
-export const MISC_KEYWORDS = ['yso:p2108'];
-
 export const MOVIE_KEYWORDS = ['yso:p1235'];
 
 export const MUSEUM_KEYWORDS = [
@@ -172,7 +156,6 @@ export const MAPPED_EVENT_CATEGORIES: Record<string, string[]> = {
   [EVENT_CATEGORIES.DANCE]: DANCE_KEYWORDS,
   [EVENT_CATEGORIES.FOOD]: FOOD_KEYWORDS,
   [EVENT_CATEGORIES.INFLUENCE]: INFLUENCE_KEYWORDS,
-  [EVENT_CATEGORIES.MISC]: MISC_KEYWORDS,
   [EVENT_CATEGORIES.MOVIE]: MOVIE_KEYWORDS,
   [EVENT_CATEGORIES.MUSEUM]: MUSEUM_KEYWORDS,
   [EVENT_CATEGORIES.MUSIC]: MUSIC_KEYWORDS,
@@ -180,37 +163,6 @@ export const MAPPED_EVENT_CATEGORIES: Record<string, string[]> = {
   [EVENT_CATEGORIES.SPORT]: SPORT_KEYWORDS,
   [EVENT_CATEGORIES.THEATRE]: THEATRE_KEYWORDS,
 };
-
-// course hobby types
-export const CLUBS_KEYWORDS = [
-  'yso:p7642', // kerhot
-  'yso:p7641', // kerhotoiminta
-];
-
-export const COURSES_KEYWORDS = [
-  // kurssit, vapaa-ajan kurssit
-  'yso:p9270',
-  'kulke:301',
-  'kulke:60',
-  'kulke:625',
-];
-
-export const CAMPS_KEYWORDS = [
-  'yso:p143', // leirit
-  'yso:p21435', // kesäleirit
-  'yso:p22818', // tiedeleirit
-];
-
-export const TRIPS_KEYWORDS = [
-  'yso:p25261', // retket
-  'yso:p1103', // retkeily
-];
-
-export const WORKSHOPS_KEYWORDS = [
-  // työpajat
-  'yso:p19245',
-  'kulke:732',
-];
 
 export const eventCategories: Record<EVENT_CATEGORIES, SearchCategoryOption> = {
   [EVENT_CATEGORIES.MOVIE]: {
@@ -252,10 +204,6 @@ export const eventCategories: Record<EVENT_CATEGORIES, SearchCategoryOption> = {
   [EVENT_CATEGORIES.FOOD]: {
     icon: <IconFood />,
     labelKey: 'home:category.food',
-  },
-  [EVENT_CATEGORIES.MISC]: {
-    icon: <></>,
-    labelKey: 'home:category.misc',
   },
 };
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -1,34 +1,32 @@
 import { EventTypeId } from 'events-helsinki-components';
+import { IconSpeechbubbleText } from 'hds-react';
 import React from 'react';
 
-import IconArt from '../../../assets/icons/IconArt';
-import IconCraft from '../../../assets/icons/IconCraft';
+import IconCultureAndArts from '../../../assets/icons/IconCultureAndArts';
 import IconDance from '../../../assets/icons/IconDance';
 import IconFood from '../../../assets/icons/IconFood';
-import IconGames from '../../../assets/icons/IconGames';
-import IconLanguages from '../../../assets/icons/IconLanguages';
-import IconLiterature from '../../../assets/icons/IconLiterature';
 import IconMovies from '../../../assets/icons/IconMovies';
+import IconMuseum from '../../../assets/icons/IconMuseum';
 import IconMusic from '../../../assets/icons/IconMusic';
 import IconSports from '../../../assets/icons/IconSports';
 import IconTheatre from '../../../assets/icons/IconTheatre';
+import IconTree from '../../../assets/icons/IconTree';
 import type { Filters, SearchCategoryOption } from './types';
 
 // Page size of the event list
 export const PAGE_SIZE = 10;
 
 export enum EVENT_CATEGORIES {
-  MOVIE = 'movie_and_media',
-  LANGUAGES = 'languages',
-  LITERATURE = 'literature',
-  ARTS_AND_CULTURE = 'arts_and_culture',
-  VISUAL_ARTS = 'visual_arts',
-  HANDICRAFTS = 'handicrafts',
-  SPORT = 'sport',
-  MUSIC = 'music',
-  GAMES = 'games',
-  FOOD = 'food',
+  CULTURE = 'culture',
   DANCE = 'dance',
+  FOOD = 'food',
+  INFLUENCE = 'influence',
+  MISC = 'misc',
+  MOVIE = 'movie',
+  MUSEUM = 'museum',
+  MUSIC = 'music',
+  NATURE = 'nature',
+  SPORT = 'sport',
   THEATRE = 'theatre',
 }
 
@@ -94,187 +92,93 @@ export enum EVENT_SEARCH_FILTERS {
 }
 
 export const CATEGORY_CATALOG = {
-  [EventTypeId.Course]: {
+  [EventTypeId.General]: {
     default: [
       EVENT_CATEGORIES.MOVIE,
-      EVENT_CATEGORIES.LANGUAGES,
-      EVENT_CATEGORIES.LITERATURE,
-      EVENT_CATEGORIES.ARTS_AND_CULTURE,
-      EVENT_CATEGORIES.VISUAL_ARTS,
-      EVENT_CATEGORIES.HANDICRAFTS,
-      EVENT_CATEGORIES.SPORT,
       EVENT_CATEGORIES.MUSIC,
-      EVENT_CATEGORIES.GAMES,
+      EVENT_CATEGORIES.SPORT,
+      EVENT_CATEGORIES.MUSEUM,
+      EVENT_CATEGORIES.DANCE,
+      EVENT_CATEGORIES.CULTURE,
+      EVENT_CATEGORIES.NATURE,
+      EVENT_CATEGORIES.INFLUENCE,
+      EVENT_CATEGORIES.THEATRE,
       EVENT_CATEGORIES.FOOD,
-      EVENT_CATEGORIES.DANCE,
-      EVENT_CATEGORIES.THEATRE,
-    ],
-    landingPage: [
-      EVENT_CATEGORIES.LITERATURE,
-      EVENT_CATEGORIES.VISUAL_ARTS,
-      EVENT_CATEGORIES.HANDICRAFTS,
-      EVENT_CATEGORIES.SPORT,
-      EVENT_CATEGORIES.MUSIC,
-      EVENT_CATEGORIES.GAMES,
-      EVENT_CATEGORIES.DANCE,
-      EVENT_CATEGORIES.THEATRE,
     ],
   },
 };
 
-export const MOVIES_AND_MEDIA_COURSES_KEYWORDS = [
-  'yso:p1235', // elokuva
-  'kulke:29', // elokuvat
-  'yso:p16327', // media
-  'kulke:205', // mediataide
-  'yso:p9731', // valokuva
-  'kulke:87', // valokuvaus
-  'yso:p1979', // ?
+export const CULTURE_KEYWORDS = [
+  'kulke:33', // Teatteri
+  'kulke:51', // Sirkus
+  'kulke:205', // Elokuva ja media
+  'kulke:351', // Teatteri ja sirkus
+  'matko:teatteri', // teatteri
+  'yso:p360', // cultural events
+  'yso:p1235', // films
+  'yso:p1278', // dance (performing arts)
+  'yso:p1808', // music
+  'yso:p2625', // in Finnish teatteritaide, "theatre arts"
+  'yso:p2739', // fine arts
+  'yso:p2850', // performing arts
+  'yso:p2851', // art
+  'yso:p4934', // museums
+  'yso:p5121', // exhibitions
+  'yso:p6889', // art exhibitions
+  'yso:p7969', // literary art
+  'yso:p8113', // literature
+  'yso:p8144', // art museums
+  'yso:p9592', // modern art
+  'yso:p9593', // contemporary art
+  'yso:p10105', // contemporary dance
+  'yso:p16327', // cinema (art forms)
 ];
 
-export const LANGUAGES_COURSES_KEYWORDS = [
-  'yso:p556', // kielet
-  'yso:p38117', // kieltenopetus
+export const DANCE_KEYWORDS = ['yso:p1278'];
+
+export const FOOD_KEYWORDS = ['yso:p3670'];
+
+export const INFLUENCE_KEYWORDS = [
+  'yso:p1657', // Vaikuttaminen
+  'yso:p742', // Demokratia
+  'yso:p5164', // Osallisuus
+  'yso:p8268', // Kaavoitus
+  'yso:p15882', // Asemakaavoitus
+  'yso:p15292', // Kaupunkipolitiikka
 ];
 
-export const LITERATURE_COURSES_KEYWORDS = [
-  // sanataide, kirjallisuus, sarjakuva
-  'yso:p8113',
-  'yso:p7969',
-  'kulke:81',
-  'yso:p38773',
+export const MISC_KEYWORDS = ['yso:p2108'];
+
+export const MOVIE_KEYWORDS = ['yso:p1235'];
+
+export const MUSEUM_KEYWORDS = [
+  'matko:museo', // Museo
+  'yso:p4934', // Museot
 ];
 
-export const ARTS_AND_CULTURE_COURSES_KEYWORDS = [
-  'yso:p2625',
-  'yso:p27886',
-  'yso:p2315',
-  'yso:p16164',
-  'yso:p9058',
-  'kulke:51',
-  'yso:p1235',
-  'kulke:29',
-  'yso:p16327',
-  'kulke:205',
-  'yso:p973',
-  'yso:p2851',
-  'yso:p1148',
-  'yso:p38773',
-  'yso:p695',
-  'yso:p1808',
-  'yso:p10871',
-  'yso:p20421',
-  'yso:p2969',
-  'yso:p23171',
-  'yso:p27962',
-  'yso:p18718',
-  'yso:p18434',
-  'yso:p15521',
-  'yso:p13408',
-  'yso:p29932',
-  'yso:p768',
-  'yso:p2841',
-  'yso:p6283',
-  'yso:p1278',
-  'yso:p10105',
-  'yso:p3984',
-  'yso:p25118',
-  'yso:p10218',
-  'yso:p21524',
-  'yso:p37874',
-  'yso:p1780',
+export const MUSIC_KEYWORDS = ['yso:p1808'];
+
+export const NATURE_KEYWORDS = ['yso:p2771'];
+
+export const SPORT_KEYWORDS = [
+  'yso:p916', // Liikunta
+  'yso:p965', // Urheilu
 ];
 
-export const VISUAL_ARTS_COURSES_KEYWORDS = [
-  'kulke:81',
-  'yso:p1148',
-  'yso:p38773',
-  'yso:p8883',
-  'yso:p695',
-];
+export const THEATRE_KEYWORDS = ['yso:p2625'];
 
-export const HANDICRAFTS_COURSES_KEYWORDS = [
-  'yso:p4923',
-  'yso:p485',
-  'kulke:668',
-  'yso:p8630',
-];
-
-export const SPORT_COURSES_KEYWORDS = [
-  'yso:p916',
-  'kulke:710',
-  'yso:p17018',
-  'yso:p1963',
-  'yso:p9824',
-  'yso:p965',
-  'yso:p6409',
-  'yso:p8781',
-  'yso:p26619',
-  'yso:p13035',
-  'yso:p2041',
-];
-
-export const MUSIC_COURSES_KEYWORDS = [
-  'yso:p1808',
-  'yso:p10871',
-  'yso:p20421',
-  'yso:p2969',
-  'yso:p23171',
-  'yso:p27962',
-  'yso:p18718',
-  'yso:p18434',
-  'yso:p15521',
-  'yso:p13408',
-  'yso:p29932',
-  'yso:p768',
-  'yso:p2841',
-];
-
-export const GAMES_COURSES_KEYWORDS = [
-  'yso:p6062',
-  'yso:p2758',
-  'yso:p21628',
-  'yso:p17281',
-  'yso:p22610',
-  'yso:p4295',
-  'yso:p7990',
-];
-
-export const FOOD_COURSES_KEYWORDS = ['yso:p367', 'yso:p5529', 'yso:p28276'];
-
-export const DANCE_COURSES_KEYWORDS = [
-  'yso:p6283',
-  'yso:p1278',
-  'yso:p10105',
-  'yso:p3984',
-  'yso:p25118',
-  'yso:p10218',
-  'yso:p21524',
-  'yso:p37874',
-];
-
-export const THEATRE_COURSES_KEYWORDS = [
-  'yso:p2625',
-  'yso:p27886',
-  'yso:p2315',
-  'yso:p16164',
-  'yso:p9058',
-];
-
-// todo: replace with valid keyword ids
 export const MAPPED_EVENT_CATEGORIES: Record<string, string[]> = {
-  [EVENT_CATEGORIES.MOVIE]: MOVIES_AND_MEDIA_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.LANGUAGES]: LANGUAGES_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.LITERATURE]: LITERATURE_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.ARTS_AND_CULTURE]: ARTS_AND_CULTURE_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.VISUAL_ARTS]: VISUAL_ARTS_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.HANDICRAFTS]: HANDICRAFTS_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.SPORT]: SPORT_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.MUSIC]: MUSIC_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.GAMES]: GAMES_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.FOOD]: FOOD_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.DANCE]: DANCE_COURSES_KEYWORDS,
-  [EVENT_CATEGORIES.THEATRE]: THEATRE_COURSES_KEYWORDS,
+  [EVENT_CATEGORIES.CULTURE]: CULTURE_KEYWORDS,
+  [EVENT_CATEGORIES.DANCE]: DANCE_KEYWORDS,
+  [EVENT_CATEGORIES.FOOD]: FOOD_KEYWORDS,
+  [EVENT_CATEGORIES.INFLUENCE]: INFLUENCE_KEYWORDS,
+  [EVENT_CATEGORIES.MISC]: MISC_KEYWORDS,
+  [EVENT_CATEGORIES.MOVIE]: MOVIE_KEYWORDS,
+  [EVENT_CATEGORIES.MUSEUM]: MUSEUM_KEYWORDS,
+  [EVENT_CATEGORIES.MUSIC]: MUSIC_KEYWORDS,
+  [EVENT_CATEGORIES.NATURE]: NATURE_KEYWORDS,
+  [EVENT_CATEGORIES.SPORT]: SPORT_KEYWORDS,
+  [EVENT_CATEGORIES.THEATRE]: THEATRE_KEYWORDS,
 };
 
 // course hobby types
@@ -311,51 +215,47 @@ export const WORKSHOPS_KEYWORDS = [
 export const eventCategories: Record<EVENT_CATEGORIES, SearchCategoryOption> = {
   [EVENT_CATEGORIES.MOVIE]: {
     icon: <IconMovies />,
-    labelKey: 'home:category.courses.movieAndMedia',
-  },
-  [EVENT_CATEGORIES.LANGUAGES]: {
-    icon: <IconLanguages />,
-    labelKey: 'home:category.courses.languages',
-  },
-  [EVENT_CATEGORIES.LITERATURE]: {
-    icon: <IconLiterature />,
-    labelKey: 'home:category.courses.literature',
-  },
-  [EVENT_CATEGORIES.ARTS_AND_CULTURE]: {
-    icon: <IconArt />,
-    labelKey: 'home:category.courses.artsAndCulture',
-  },
-  [EVENT_CATEGORIES.VISUAL_ARTS]: {
-    icon: <IconArt />,
-    labelKey: 'home:category.courses.visualArts',
-  },
-  [EVENT_CATEGORIES.HANDICRAFTS]: {
-    icon: <IconCraft />,
-    labelKey: 'home:category.courses.handicrafts',
-  },
-  [EVENT_CATEGORIES.SPORT]: {
-    icon: <IconSports />,
-    labelKey: 'home:category.courses.sport',
+    labelKey: 'home:category.movie',
   },
   [EVENT_CATEGORIES.MUSIC]: {
     icon: <IconMusic />,
-    labelKey: 'home:category.courses.music',
+    labelKey: 'home:category.music',
   },
-  [EVENT_CATEGORIES.GAMES]: {
-    icon: <IconGames />,
-    labelKey: 'home:category.courses.games',
+  [EVENT_CATEGORIES.SPORT]: {
+    icon: <IconSports />,
+    labelKey: 'home:category.sport',
   },
-  [EVENT_CATEGORIES.FOOD]: {
-    icon: <IconFood />,
-    labelKey: 'home:category.courses.food',
+  [EVENT_CATEGORIES.MUSEUM]: {
+    icon: <IconMuseum />,
+    labelKey: 'home:category.museum',
   },
   [EVENT_CATEGORIES.DANCE]: {
     icon: <IconDance />,
-    labelKey: 'home:category.courses.dance',
+    labelKey: 'home:category.dance',
+  },
+  [EVENT_CATEGORIES.CULTURE]: {
+    icon: <IconCultureAndArts />,
+    labelKey: 'home:category.culture',
+  },
+  [EVENT_CATEGORIES.NATURE]: {
+    icon: <IconTree />,
+    labelKey: 'home:category.nature',
+  },
+  [EVENT_CATEGORIES.INFLUENCE]: {
+    icon: <IconSpeechbubbleText aria-hidden />,
+    labelKey: 'home:category.influence',
   },
   [EVENT_CATEGORIES.THEATRE]: {
     icon: <IconTheatre />,
-    labelKey: 'home:category.courses.theatre',
+    labelKey: 'home:category.theatre',
+  },
+  [EVENT_CATEGORIES.FOOD]: {
+    icon: <IconFood />,
+    labelKey: 'home:category.food',
+  },
+  [EVENT_CATEGORIES.MISC]: {
+    icon: <></>,
+    labelKey: 'home:category.misc',
   },
 };
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -77,24 +77,17 @@ export enum EVENT_SEARCH_FILTERS {
   SUITABLE = 'suitableFor',
 }
 
-export const CATEGORY_CATALOG = {
+export const CATEGORY_CATALOG: Record<
+  EventTypeId,
+  Record<string, EVENT_CATEGORIES[]>
+> = {
   [EventTypeId.General]: {
-    default: [
-      EVENT_CATEGORIES.MOVIE,
-      EVENT_CATEGORIES.MUSIC,
-      EVENT_CATEGORIES.SPORT,
-      EVENT_CATEGORIES.MUSEUM,
-      EVENT_CATEGORIES.DANCE,
-      EVENT_CATEGORIES.CULTURE,
-      EVENT_CATEGORIES.NATURE,
-      EVENT_CATEGORIES.INFLUENCE,
-      EVENT_CATEGORIES.THEATRE,
-      EVENT_CATEGORIES.FOOD,
-    ],
+    default: Object.values(EVENT_CATEGORIES),
   },
-};
+  [EventTypeId.Course]: {},
+} as const;
 
-export const CULTURE_KEYWORDS = [
+export const CULTURE_KEYWORDS: readonly string[] = [
   'kulke:33', // Teatteri
   'kulke:51', // Sirkus
   'kulke:205', // Elokuva ja media
@@ -118,40 +111,43 @@ export const CULTURE_KEYWORDS = [
   'yso:p9593', // contemporary art
   'yso:p10105', // contemporary dance
   'yso:p16327', // cinema (art forms)
-];
+] as const;
 
-export const DANCE_KEYWORDS = ['yso:p1278'];
+export const DANCE_KEYWORDS: readonly string[] = ['yso:p1278'] as const;
 
-export const FOOD_KEYWORDS = ['yso:p3670'];
+export const FOOD_KEYWORDS: readonly string[] = ['yso:p3670'] as const;
 
-export const INFLUENCE_KEYWORDS = [
+export const INFLUENCE_KEYWORDS: readonly string[] = [
   'yso:p1657', // Vaikuttaminen
   'yso:p742', // Demokratia
   'yso:p5164', // Osallisuus
   'yso:p8268', // Kaavoitus
   'yso:p15882', // Asemakaavoitus
   'yso:p15292', // Kaupunkipolitiikka
-];
+] as const;
 
-export const MOVIE_KEYWORDS = ['yso:p1235'];
+export const MOVIE_KEYWORDS: readonly string[] = ['yso:p1235'] as const;
 
-export const MUSEUM_KEYWORDS = [
+export const MUSEUM_KEYWORDS: readonly string[] = [
   'matko:museo', // Museo
   'yso:p4934', // Museot
-];
+] as const;
 
-export const MUSIC_KEYWORDS = ['yso:p1808'];
+export const MUSIC_KEYWORDS: readonly string[] = ['yso:p1808'] as const;
 
-export const NATURE_KEYWORDS = ['yso:p2771'];
+export const NATURE_KEYWORDS: readonly string[] = ['yso:p2771'] as const;
 
-export const SPORT_KEYWORDS = [
+export const SPORT_KEYWORDS: readonly string[] = [
   'yso:p916', // Liikunta
   'yso:p965', // Urheilu
-];
+] as const;
 
-export const THEATRE_KEYWORDS = ['yso:p2625'];
+export const THEATRE_KEYWORDS: readonly string[] = ['yso:p2625'] as const;
 
-export const MAPPED_EVENT_CATEGORIES: Record<string, string[]> = {
+export const MAPPED_EVENT_CATEGORIES: Record<
+  EVENT_CATEGORIES,
+  readonly string[]
+> = {
   [EVENT_CATEGORIES.CULTURE]: CULTURE_KEYWORDS,
   [EVENT_CATEGORIES.DANCE]: DANCE_KEYWORDS,
   [EVENT_CATEGORIES.FOOD]: FOOD_KEYWORDS,
@@ -162,7 +158,7 @@ export const MAPPED_EVENT_CATEGORIES: Record<string, string[]> = {
   [EVENT_CATEGORIES.NATURE]: NATURE_KEYWORDS,
   [EVENT_CATEGORIES.SPORT]: SPORT_KEYWORDS,
   [EVENT_CATEGORIES.THEATRE]: THEATRE_KEYWORDS,
-};
+} as const;
 
 export const eventCategories: Record<EVENT_CATEGORIES, SearchCategoryOption> = {
   [EVENT_CATEGORIES.MOVIE]: {
@@ -205,6 +201,6 @@ export const eventCategories: Record<EVENT_CATEGORIES, SearchCategoryOption> = {
     icon: <IconFood />,
     labelKey: 'home:category.food',
   },
-};
+} as const;
 
-export const MAPPED_PLACES: Record<string, string> = {};
+export const MAPPED_PLACES: Record<string, string> = {} as const;

--- a/apps/events-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
@@ -123,7 +123,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
         <FilterButton
           key={category}
           onRemove={handleFilterRemove}
-          text={translateValue('home:category.courses.', category, t)}
+          text={translateValue('home:category.', category, t)}
           type="category"
           value={category}
         />

--- a/apps/events-helsinki/src/domain/search/eventSearch/types.ts
+++ b/apps/events-helsinki/src/domain/search/eventSearch/types.ts
@@ -1,14 +1,14 @@
 import type React from 'react';
 
-import type { COURSE_CATEGORIES, EVENT_SEARCH_FILTERS } from './constants';
+import type { EVENT_CATEGORIES, EVENT_SEARCH_FILTERS } from './constants';
 
 export interface CategoryOption {
   icon: React.ReactElement;
   text: string;
-  value: COURSE_CATEGORIES;
+  value: EVENT_CATEGORIES;
 }
 
-export type SearchCategoryType = COURSE_CATEGORIES;
+export type SearchCategoryType = EVENT_CATEGORIES;
 
 export interface SearchCategoryOption {
   icon: React.ReactElement;

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -193,7 +193,7 @@ export const getEventSearchVariables = ({
 
   const getMappedPropertyValues = (
     list: string[],
-    map: Record<string, string[]>
+    map: Record<string, readonly string[]>
   ) =>
     list?.reduce<string[]>(
       (prev, val: string) => prev.concat(map[val] ?? []),

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -24,13 +24,13 @@ import isEmpty from 'lodash/isEmpty';
 import type { TFunction } from 'next-i18next';
 
 import AppConfig from '../../app/AppConfig';
-import type { COURSE_CATEGORIES, EVENT_SORT_OPTIONS } from './constants';
+import type { EVENT_CATEGORIES, EVENT_SORT_OPTIONS } from './constants';
 import {
   EVENT_SEARCH_FILTERS,
-  courseCategories,
+  eventCategories,
   MAPPED_PLACES,
   CATEGORY_CATALOG,
-  MAPPED_COURSE_CATEGORIES,
+  MAPPED_EVENT_CATEGORIES,
 } from './constants';
 import type {
   CategoryOption,
@@ -63,11 +63,11 @@ export const getCategoryOptions = (
 
 export const getEventCategoryOptions = (
   t: TFunction,
-  categories: COURSE_CATEGORIES[] = CATEGORY_CATALOG[EventTypeId.Course].default
+  categories: EVENT_CATEGORIES[] = CATEGORY_CATALOG[EventTypeId.Course].default
 ): CategoryOption[] =>
   categories
     .map((category) =>
-      getCategoryOptions(category, courseCategories[category], t)
+      getCategoryOptions(category, eventCategories[category], t)
     )
     .sort(sortExtendedCategoryOptions);
 
@@ -202,7 +202,7 @@ export const getEventSearchVariables = ({
 
   const mappedCategories = getMappedPropertyValues(
     categories,
-    MAPPED_COURSE_CATEGORIES
+    MAPPED_EVENT_CATEGORIES
   );
 
   const hasLocation = !isEmpty(divisions) || !isEmpty(places);
@@ -373,7 +373,7 @@ export const getSearchQuery = (filters: Filters): string => {
 
 /** Get a list of all the keywords that can be mapped as a category */
 export const getAllHobbyCategories = () =>
-  Object.values(MAPPED_COURSE_CATEGORIES).flat();
+  Object.values(MAPPED_EVENT_CATEGORIES).flat();
 
 /** Filter the kewords from the event that can be mapped as categories */
 export const getEventCategories = (event: EventFields) => {

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -63,7 +63,7 @@ export const getCategoryOptions = (
 
 export const getEventCategoryOptions = (
   t: TFunction,
-  categories: EVENT_CATEGORIES[] = CATEGORY_CATALOG[EventTypeId.Course].default
+  categories: EVENT_CATEGORIES[] = CATEGORY_CATALOG[EventTypeId.General].default
 ): CategoryOption[] =>
   categories
     .map((category) =>

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -85,7 +85,6 @@ const Search: React.FC = () => {
         className={styles.categoriesWrapper}
         categories={categories}
         searchFilters={{
-          // TODO: use COURSE_DEFAULT_SEARCH_FILTERS
           ...EVENT_DEFAULT_SEARCH_FILTERS,
           dateTypes,
           end,

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -1,9 +1,5 @@
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
-import {
-  useLocale,
-  useCommonTranslation,
-  EventTypeId,
-} from 'events-helsinki-components';
+import { useLocale, useCommonTranslation } from 'events-helsinki-components';
 import { useRouter } from 'next/router';
 import React from 'react';
 
@@ -12,10 +8,7 @@ import {
   getI18nPath,
   getParsedUrlQueryInput,
 } from '../../../utils/routerUtils';
-import {
-  CATEGORY_CATALOG,
-  EVENT_DEFAULT_SEARCH_FILTERS,
-} from '../eventSearch/constants';
+import { EVENT_DEFAULT_SEARCH_FILTERS } from '../eventSearch/constants';
 import { getEventCategoryOptions, getSearchQuery } from '../eventSearch/utils';
 import styles from './landingPageSearch.module.scss';
 import LandingPageSearchForm from './LandingPageSearchForm';
@@ -69,10 +62,7 @@ const Search: React.FC = () => {
     goToSearchPage(search);
   };
 
-  const categories = getEventCategoryOptions(
-    t,
-    CATEGORY_CATALOG[EventTypeId.Course].landingPage
-  );
+  const categories = getEventCategoryOptions(t);
 
   return (
     <div>

--- a/packages/common-i18n/src/locales/en/home.json
+++ b/packages/common-i18n/src/locales/en/home.json
@@ -4,7 +4,6 @@
     "dance": "Dance",
     "food": "Food",
     "influence": "Participate and influence",
-    "misc": "Other",
     "movie": "Movies",
     "museum": "Museums",
     "music": "Music",

--- a/packages/common-i18n/src/locales/fi/home.json
+++ b/packages/common-i18n/src/locales/fi/home.json
@@ -4,7 +4,6 @@
     "dance": "Tanssi",
     "food": "Ruoka",
     "influence": "Osallistu ja vaikuta",
-    "misc": "Muut",
     "movie": "Elokuva",
     "museum": "Museot",
     "music": "Musiikki",

--- a/packages/common-i18n/src/locales/sv/home.json
+++ b/packages/common-i18n/src/locales/sv/home.json
@@ -4,7 +4,6 @@
     "dance": "Dans",
     "food": "Mat",
     "influence": "Delta och påverka",
-    "misc": "Andra",
     "movie": "Film",
     "museum": "Museer",
     "music": "Musik",


### PR DESCRIPTION
## Description

 - [refactor(events-helsinki): rename course to event in *categories](https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/56/commits/a09b6b37a4ca74c42f1515855d354071c34a5d51) 
 - [feat(events-helsinki): update event categories to production values](https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/56/commits/b2d057e9581b903a551f2aacaf7dce80cefd6e0a) 
 - [refactor(events-helsinki): remove unused categories/keywords/filters](https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/56/commits/eb5ba66fe635dd58ba182229f253cf5b7e515536) 
 - [refactor(events-helsinki): add const assertions, reduce code duplication](https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/56/commits/59621d4d93cd0319721de284638941dd00107bce) 

## Issues

### Closes

**[TH-1256](https://helsinkisolutionoffice.atlassian.net/browse/TH-1256)**
**[TH-1276](https://helsinkisolutionoffice.atlassian.net/browse/TH-1276)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Current production state from tapahtumat.hel.fi:

#### Landing page categories under search bar:
![old-landingpage-categories1](https://user-images.githubusercontent.com/77663720/201701263-c79311f0-43b9-4313-80a4-7d775be43bdb.png)

#### Landing page categories in page footer:
There are no categories in the page footer in the current production tapahtumat.hel.fi

#### Advanced search categories:
![old-advancedsearch-categories1](https://user-images.githubusercontent.com/77663720/201701331-bb03b0a6-d00c-43fe-8342-9044efe11f52.png)
![old-advancedsearch-categories2](https://user-images.githubusercontent.com/77663720/201701351-3bcc3898-ee87-4a01-9800-89f4c01fdb7f.png)

#### After pressing on "Musiikki" on landing page:
![old-after_pressing_on_musiikki_on_landingpage](https://user-images.githubusercontent.com/77663720/201701379-1562df98-9ca8-4ceb-a26f-6ef7147f99a2.png)

#### Advanced search with all categories selected:
![old-advancedsearch-search_with_all_categories_selected](https://user-images.githubusercontent.com/77663720/201701398-4273c5bb-6b49-45d5-a7b4-ae909eb3f1b3.png)

#### Advanced search with "Elokuva" and "Museot" categories selected:
![old-advancedsearch-with_elokuva_and_museot_selected](https://user-images.githubusercontent.com/77663720/201701418-56d94cb5-2c42-402e-90c3-1031e5d84fd0.png)

### New state:

#### Landing page categories under search bar:
![new-landingpage-categories1](https://user-images.githubusercontent.com/77663720/201701452-11e365c6-ff58-488c-91ca-f9040fba055e.png)

#### Landing page categories in page footer:
![new-landingpage-categories2](https://user-images.githubusercontent.com/77663720/201701474-8d82b0e5-bfb5-4661-8c83-909e56d4866b.png)

#### Advanced search categories:
![new-advancedsearch-categories1](https://user-images.githubusercontent.com/77663720/201701497-ab8ed272-b089-44bc-8fe6-032accf9fc31.png)
![new-advancedsearch-categories2](https://user-images.githubusercontent.com/77663720/201701509-c5dd5808-8751-424d-95e3-8e70f8212d6b.png)
 
#### After pressing on "Musiikki" on landing page:
![new-after_pressing_on_musiikki_on_landingpage](https://user-images.githubusercontent.com/77663720/201701532-0faad630-8dca-4ec6-8de3-39e4738bb8c8.png)
 
#### Advanced search with all categories selected:
![new-advancedsearch-search_with_all_categories_selected](https://user-images.githubusercontent.com/77663720/201701552-cdae257f-0e67-40e6-bf9b-8e01e1111d41.png)
 
#### Advanced search with "Elokuva" and "Museot" categories selected:
![new-advancedsearch-with_elokuva_and_museot_selected](https://user-images.githubusercontent.com/77663720/201701562-10b04fee-8209-499b-b629-1985097e0769.png)

## Additional notes
