### PR TITLE
fix: button styles and text theming refactoring

### DIFF
--- a/apps/events-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/events-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -174,6 +174,7 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
                   {registrationUrl && (
                     <Visible className={styles.registrationButtonWrapper}>
                       <Button
+                        variant="success"
                         className={buttonStyles.buttonCoatBlue}
                         aria-label={t('hero.ariaLabelEnrol')}
                         onClick={() => window.open(registrationUrl)}

--- a/apps/events-helsinki/src/domain/footer/footer.module.scss
+++ b/apps/events-helsinki/src/domain/footer/footer.module.scss
@@ -3,4 +3,8 @@
   margin-top: calc(var(--spacing-xl) * -1);
   position: relative;
   --footer-background: var(--color-engel-medium-light) !important;
+  a,
+  a:visited {
+    color: var(--color-black-90);
+  }
 }

--- a/apps/events-helsinki/src/domain/search/eventSearch/search.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/search.module.scss
@@ -45,15 +45,6 @@ $buttonWidth: 180px;
     @include respond-above(m) {
       grid-column: span 1 / 5;
     }
-    button {
-      span {
-        color: white;
-      }
-    }
-
-    svg * {
-      color: var(--color-white);
-    }
   }
 
   .row {

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
@@ -2,7 +2,6 @@
 
 .landingPageSearch {
   margin-top: -13.5rem;
-  color: var(--color-white);
   background-color: #464646;
   padding: var(--spacing-l) var(--spacing-m);
   z-index: 1;

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
@@ -44,10 +44,6 @@
   a:focus-visible {
     outline: 2px solid var(--color-white);
   }
-
-  svg * {
-    color: var(--color-white);
-  }
 }
 
 .autosuggestWrapper {
@@ -90,14 +86,4 @@
 .buttonWrapper {
   width: 100%;
   margin-bottom: 1.25rem;
-
-  button {
-    span {
-      color: white;
-    }
-  }
-
-  svg * {
-    color: var(--color-white);
-  }
 }

--- a/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -174,6 +174,7 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
                   {registrationUrl && (
                     <Visible className={styles.registrationButtonWrapper}>
                       <Button
+                        theme="coat"
                         className={buttonStyles.buttonCoatBlue}
                         aria-label={t('hero.ariaLabelEnrol')}
                         onClick={() => window.open(registrationUrl)}

--- a/apps/hobbies-helsinki/src/domain/event/eventInfo/EventInfo.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventInfo/EventInfo.tsx
@@ -346,10 +346,10 @@ const PriceInfo: React.FC<{ event: EventFields }> = ({ event }) => {
       {offerInfoUrl && (
         <Visible below="s" className={styles.buyButtonWrapper}>
           <Button
+            theme="coat"
             aria-label={t('info.ariaLabelBuyTickets')}
             fullWidth={true}
             onClick={moveToBuyTicketsPage}
-            variant="success"
           >
             {t('info.buttonBuyTickets')}
           </Button>

--- a/apps/hobbies-helsinki/src/domain/footer/footer.module.scss
+++ b/apps/hobbies-helsinki/src/domain/footer/footer.module.scss
@@ -3,4 +3,8 @@
   margin-top: calc(var(--spacing-xl) * -1);
   position: relative;
   --footer-background: var(--color-engel-medium-light) !important;
+  a,
+  a:visited {
+    color: var(--color-black-90);
+  }
 }

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/search.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/search.module.scss
@@ -45,16 +45,6 @@ $buttonWidth: 180px;
     @include respond-above(m) {
       grid-column: span 1 / 5;
     }
-
-    button {
-      span {
-        color: white;
-      }
-    }
-
-    svg * {
-      color: var(--color-white);
-    }
   }
 
   .row {

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
@@ -2,7 +2,6 @@
 
 .landingPageSearch {
   margin-top: -13.5rem;
-  color: var(--color-white);
   background-color: #464646;
   padding: var(--spacing-l) var(--spacing-m);
   z-index: 1;

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
@@ -44,10 +44,6 @@
   a:focus-visible {
     outline: 2px solid white;
   }
-
-  svg * {
-    color: var(--color-white);
-  }
 }
 
 .autosuggestWrapper {
@@ -95,9 +91,5 @@
     span {
       color: white;
     }
-  }
-
-  svg * {
-    color: var(--color-white);
   }
 }

--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -4,12 +4,10 @@ html,
 #__next,
 main {
   height: 100%;
+  color: var(--color-black-90);
 }
 
 * {
-  //padding: 0;
-  //margin: 0;
-  color: var(--color-black-90);
   box-sizing: border-box;
   font-family: $font-family-base;
 }

--- a/packages/components/src/components/filterButton/filterButton.module.scss
+++ b/packages/components/src/components/filterButton/filterButton.module.scss
@@ -19,7 +19,6 @@
     cursor: pointer;
 
     svg {
-      color: var(--color-white);
       vertical-align: middle;
       margin: 0;
     }


### PR DESCRIPTION
## Description
Fixed buttons colors and also the default color black-90 moved to html level from *, so it does not override extra styles (for example button spans now dont have to be set), so extra stylings are cleaned.

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
