### PR TITLE
Create Events and Hobbies specific translations

### DIFF
--- a/apps/events-helsinki/browser-tests/page-model/landingPage.ts
+++ b/apps/events-helsinki/browser-tests/page-model/landingPage.ts
@@ -12,7 +12,7 @@ class LandingPage {
 
     await t
       .expect(
-        screen.getByRole('heading', { name: i18n.t('home:search.title') })
+        screen.getByRole('heading', { name: i18n.t('appEvents:search.title') })
           .exists
       )
       .ok();

--- a/apps/events-helsinki/src/domain/footer/Footer.tsx
+++ b/apps/events-helsinki/src/domain/footer/Footer.tsx
@@ -1,5 +1,5 @@
 import {
-  useCommonTranslation,
+  useAppEventsTranslation,
   useFooterTranslation,
   useLocale,
   resetFocusId,
@@ -16,7 +16,7 @@ import FooterCategories from './FooterCategories';
 
 const FooterSection: FunctionComponent = () => {
   const { t } = useFooterTranslation();
-  const { t: tCommon } = useCommonTranslation();
+  const { t: tAppEvents } = useAppEventsTranslation();
   const locale = useLocale();
 
   const { data } = useMenuQuery({
@@ -32,11 +32,11 @@ const FooterSection: FunctionComponent = () => {
   };
 
   return (
-    <Footer title={tCommon('eventsCommon:appName')} className={styles.footer}>
+    <Footer title={tAppEvents('appEvents:appName')} className={styles.footer}>
       <Footer.Navigation>
         <Footer.Item
           as={Link}
-          label={t('footer:searchHobbies')}
+          label={tAppEvents('appEvents:footer.searchEvents')}
           href={getI18nPath(ROUTES.SEARCH, locale)}
         />
       </Footer.Navigation>

--- a/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
+++ b/apps/events-helsinki/src/domain/footer/FooterCategories.tsx
@@ -1,5 +1,5 @@
 import { useLocale } from 'events-helsinki-components';
-import useFooterTranslation from 'events-helsinki-components/hooks/useFooterTranslation';
+import useAppEventsTranslation from 'events-helsinki-components/hooks/useAppEventsTranslation';
 import type { FunctionComponent } from 'react';
 import React from 'react';
 import CategoryFilter from '../../common-events/components/category/CategoryFilter';
@@ -15,7 +15,7 @@ import {
 import styles from './footerCategories.module.scss';
 
 const FooterCategories: FunctionComponent = () => {
-  const { t } = useFooterTranslation();
+  const { t } = useAppEventsTranslation();
   const locale = useLocale();
 
   const getCategoryLink = (category: CategoryOption) => {
@@ -34,7 +34,7 @@ const FooterCategories: FunctionComponent = () => {
   };
 
   const categories = getEventCategoryOptions(t);
-  const footerTitle = t(`footer:titleEventsCategories`);
+  const footerTitle = t(`appEvents:footer.titleEventsCategories`);
 
   return (
     <div className={styles.topFooterWrapper}>

--- a/apps/events-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
+++ b/apps/events-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
@@ -4,7 +4,7 @@ import nextI18nextConfig from '../../../next-i18next.config';
 
 const COMMON_TRANSLATIONS = [
   'common',
-  'eventsCommon',
+  'appEvents',
   'footer',
   'notFound',
   'home',

--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -5,6 +5,7 @@ import {
   Checkbox,
   DateSelector,
   MultiSelectDropdown,
+  useAppEventsTranslation,
   useLocale,
 } from 'events-helsinki-components';
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
@@ -44,6 +45,7 @@ const AdvancedSearch: React.FC<Props> = ({
   'data-testid': dataTestId,
 }) => {
   const { t } = useTranslation('search');
+  const { t: tAppEvents } = useAppEventsTranslation();
   const locale = useLocale();
   const router = useRouter();
   const params: { place?: string } = router.query;
@@ -252,7 +254,7 @@ const AdvancedSearch: React.FC<Props> = ({
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{t('title')}</h2>
+            <h2>{tAppEvents('appEvents:search.title')}</h2>
             <div className={styles.rowWrapper}>
               <div className={classNames(styles.row, styles.autoSuggestRow)}>
                 <div>

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -5,6 +5,7 @@ import {
   MobileDateSelector,
   useLocale,
   useHomeTranslation,
+  useAppEventsTranslation,
 } from 'events-helsinki-components';
 import { Button, IconSearch } from 'hds-react';
 import { SecondaryLink } from 'react-helsinki-headless-cms';
@@ -45,11 +46,12 @@ export default function LandingPageSearchForm({
   handleMenuOptionClick,
 }: LandingPageSearchFormProps) {
   const { t } = useHomeTranslation();
+  const { t: tAppEvents } = useAppEventsTranslation();
   const locale = useLocale();
 
   return (
     <div className={classnames(className, styles.landingPageSearch)}>
-      <h2>{t('home:search.title')}</h2>
+      <h2>{tAppEvents('appEvents:search.title')}</h2>
       <div className={styles.searchRow}>
         <div className={styles.autosuggestWrapper}>
           <SearchAutosuggest
@@ -92,7 +94,7 @@ export default function LandingPageSearchForm({
               onClick={handleSubmit}
               variant="success"
             >
-              {t('home:eventSearch.buttonSearch')}
+              {t('home:search.buttonSearch')}
             </Button>
           </div>
         </div>
@@ -103,7 +105,7 @@ export default function LandingPageSearchForm({
           className={styles.link}
           href={getI18nPath(ROUTES.SEARCH, locale)}
         >
-          {t('home:eventSearch.linkAdvancedSearch')}
+          {t('home:search.linkAdvancedSearch')}
         </SecondaryLink>
       </div>
     </div>

--- a/apps/events-helsinki/src/hooks/useRHHCConfig.tsx
+++ b/apps/events-helsinki/src/hooks/useRHHCConfig.tsx
@@ -67,7 +67,7 @@ export default function useRHHCConfig(
         '/shared-assets/images/event_placeholder_C.jpg',
         '/shared-assets/images/event_placeholder_D.jpg',
       ],
-      siteName: commonTranslation('eventsCommon:appName'),
+      siteName: commonTranslation('appEvents:appName'),
       currentLanguageCode: locale.toUpperCase(),
       apolloClient: cmsApolloClient,
       eventsApolloClient: eventsApolloClient,

--- a/apps/hobbies-helsinki/browser-tests/page-model/landingPage.ts
+++ b/apps/hobbies-helsinki/browser-tests/page-model/landingPage.ts
@@ -12,7 +12,7 @@ class LandingPage {
 
     await t
       .expect(
-        screen.getByRole('heading', { name: i18n.t('home:search.title') })
+        screen.getByRole('heading', { name: i18n.t('appHobbies:search.title') })
           .exists
       )
       .ok();

--- a/apps/hobbies-helsinki/src/domain/footer/Footer.tsx
+++ b/apps/hobbies-helsinki/src/domain/footer/Footer.tsx
@@ -1,5 +1,5 @@
 import {
-  useCommonTranslation,
+  useAppHobbiesTranslation,
   useFooterTranslation,
   useLocale,
   resetFocusId,
@@ -16,7 +16,7 @@ import FooterCategories from './FooterCategories';
 
 const FooterSection: FunctionComponent = () => {
   const { t } = useFooterTranslation();
-  const { t: tCommon } = useCommonTranslation();
+  const { t: tAppHobbies } = useAppHobbiesTranslation();
   const locale = useLocale();
 
   const { data } = useMenuQuery({
@@ -32,11 +32,11 @@ const FooterSection: FunctionComponent = () => {
   };
 
   return (
-    <Footer title={tCommon('hobbiesCommon:appName')} className={styles.footer}>
+    <Footer title={tAppHobbies('appHobbies:appName')} className={styles.footer}>
       <Footer.Navigation>
         <Footer.Item
           as={Link}
-          label={t('footer:searchHobbies')}
+          label={tAppHobbies('appHobbies:footer.searchHobbies')}
           href={getI18nPath(ROUTES.SEARCH, locale)}
         />
       </Footer.Navigation>

--- a/apps/hobbies-helsinki/src/domain/footer/FooterCategories.tsx
+++ b/apps/hobbies-helsinki/src/domain/footer/FooterCategories.tsx
@@ -1,5 +1,5 @@
 import { useLocale } from 'events-helsinki-components';
-import useFooterTranslation from 'events-helsinki-components/hooks/useFooterTranslation';
+import useAppHobbiesTranslation from 'events-helsinki-components/hooks/useAppHobbiesTranslation';
 import type { FunctionComponent } from 'react';
 import React from 'react';
 import CategoryFilter from '../../common-events/components/category/CategoryFilter';
@@ -18,7 +18,7 @@ import {
 import styles from './footerCategories.module.scss';
 
 const FooterCategories: FunctionComponent = () => {
-  const { t } = useFooterTranslation();
+  const { t } = useAppHobbiesTranslation();
   const locale = useLocale();
 
   const getCategoryLink = (category: CategoryOption) => {
@@ -40,7 +40,7 @@ const FooterCategories: FunctionComponent = () => {
     t,
     CATEGORY_CATALOG.Course.default
   );
-  const footerTitle = t(`footer:titleEventsCategories`);
+  const footerTitle = t('appHobbies:footer.titleCoursesCategories');
 
   return (
     <div className={styles.topFooterWrapper}>

--- a/apps/hobbies-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
+++ b/apps/hobbies-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
@@ -4,7 +4,7 @@ import nextI18nextConfig from '../../../next-i18next.config';
 
 const COMMON_TRANSLATIONS = [
   'common',
-  'hobbiesCommon',
+  'appHobbies',
   'footer',
   'notFound',
   'home',

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -6,6 +6,8 @@ import {
   DateSelector,
   MultiSelectDropdown,
   RangeDropdown,
+  useAppEventsTranslation,
+  useAppHobbiesTranslation,
   useLocale,
 } from 'events-helsinki-components';
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
@@ -55,6 +57,7 @@ const AdvancedSearch: React.FC<Props> = ({
   'data-testid': dataTestId,
 }) => {
   const { t } = useTranslation('search');
+  const { t: tAppHobbies } = useAppHobbiesTranslation();
   const locale = useLocale();
   const router = useRouter();
   const params: { place?: string } = router.query;
@@ -257,7 +260,7 @@ const AdvancedSearch: React.FC<Props> = ({
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{t('title')}</h2>
+            <h2>{tAppHobbies('appHobbies:search.title')}</h2>
             <div className={styles.rowWrapper}>
               <div className={classNames(styles.row, styles.autoSuggestRow)}>
                 <div>

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -5,6 +5,7 @@ import {
   MobileDateSelector,
   useLocale,
   useHomeTranslation,
+  useAppHobbiesTranslation,
 } from 'events-helsinki-components';
 import { Button, IconSearch } from 'hds-react';
 import { SecondaryLink } from 'react-helsinki-headless-cms';
@@ -45,11 +46,12 @@ export default function LandingPageSearchForm({
   handleMenuOptionClick,
 }: LandingPageSearchFormProps) {
   const { t } = useHomeTranslation();
+  const { t: tAppHobbies } = useAppHobbiesTranslation();
   const locale = useLocale();
 
   return (
     <div className={classnames(className, styles.landingPageSearch)}>
-      <h2>{t('home:search.title')}</h2>
+      <h2>{tAppHobbies('appHobbies:search.title')}</h2>
       <div className={styles.searchRow}>
         <div className={styles.autosuggestWrapper}>
           <SearchAutosuggest
@@ -92,7 +94,7 @@ export default function LandingPageSearchForm({
               iconLeft={<IconSearch />}
               onClick={handleSubmit}
             >
-              {t('home:eventSearch.buttonSearch')}
+              {t('home:search.buttonSearch')}
             </Button>
           </div>
         </div>
@@ -103,7 +105,7 @@ export default function LandingPageSearchForm({
           className={styles.link}
           href={getI18nPath(ROUTES.SEARCH, locale)}
         >
-          {t('home:eventSearch.linkAdvancedSearch')}
+          {t('home:search.linkAdvancedSearch')}
         </SecondaryLink>
       </div>
     </div>

--- a/apps/hobbies-helsinki/src/hooks/useRHHCConfig.tsx
+++ b/apps/hobbies-helsinki/src/hooks/useRHHCConfig.tsx
@@ -67,7 +67,7 @@ export default function useRHHCConfig(
         '/shared-assets/images/event_placeholder_C.jpg',
         '/shared-assets/images/event_placeholder_D.jpg',
       ],
-      siteName: commonTranslation('hobbiesCommon:appName'),
+      siteName: commonTranslation('appHobbies:appName'),
       currentLanguageCode: locale.toUpperCase(),
       apolloClient: cmsApolloClient,
       eventsApolloClient: eventsApolloClient,

--- a/packages/common-i18n/src/I18nNamespaces.ts
+++ b/packages/common-i18n/src/I18nNamespaces.ts
@@ -1,17 +1,17 @@
+import type appEvents from './locales/fi/appEvents.json';
+import type appHobbies from './locales/fi/appHobbies.json';
 import type cms from './locales/fi/cms.json';
 import type common from './locales/fi/common.json';
 import type event from './locales/fi/event.json';
-import type eventsCommon from './locales/fi/eventsCommon.json';
 import type footer from './locales/fi/footer.json';
-import type hobbiesCommon from './locales/fi/hobbiesCommon.json';
 import type home from './locales/fi/home.json';
 import type notFound from './locales/fi/notFound.json';
 import type search from './locales/fi/search.json';
 
 export type I18nNamespaces = {
   common: typeof common;
-  hobbiesCommon: typeof hobbiesCommon;
-  eventsCommon: typeof eventsCommon;
+  appHobbies: typeof appHobbies;
+  appEvents: typeof appEvents;
   home: typeof home;
   cms: typeof cms;
   footer: typeof footer;

--- a/packages/common-i18n/src/locales/en/appEvents.json
+++ b/packages/common-i18n/src/locales/en/appEvents.json
@@ -1,0 +1,16 @@
+{
+  "appName": "Events",
+  "footer": {
+    "searchEvents": "Events calendar",
+    "titleEventsCategories": "Popular events categories"
+  },
+  "home": {
+    "eventSearch": {
+      "placeholder": "Enter a keyword, eg rock or yoga",
+      "title": "What are you looking for?"
+    }
+  },
+  "search": {
+    "title": "Find something to do"
+  }
+}

--- a/packages/common-i18n/src/locales/en/appHobbies.json
+++ b/packages/common-i18n/src/locales/en/appHobbies.json
@@ -1,0 +1,16 @@
+{
+  "appName": "Hobbies",
+  "footer": {
+    "searchHobbies": "Hobbies",
+    "titleCoursesCategories": "Popular courses categories"
+  },
+  "home": {
+    "courseSearch": {
+      "placeholder": "Enter a keyword, eg. French or cooking",
+      "title": "Search for hobbies"
+    }
+  },
+  "search": {
+    "title": "Find hobbies"
+  }
+}

--- a/packages/common-i18n/src/locales/en/eventsCommon.json
+++ b/packages/common-i18n/src/locales/en/eventsCommon.json
@@ -1,3 +1,0 @@
-{
-  "appName": "Events"
-}

--- a/packages/common-i18n/src/locales/en/footer.json
+++ b/packages/common-i18n/src/locales/en/footer.json
@@ -4,10 +4,6 @@
   "linkFeedback": "Give feedback",
   "linkFeedbackUrl": "https://www.hel.fi/helsinki/en/administration/participate/feedback/",
   "searchCollections": "We recommend",
-  "searchEvents": "Events calendar",
-  "searchHobbies": "Hobbies",
-  "titleEventsCategories": "Popular events categories",
-  "titleCoursesCategories": "Popular courses categories",
   "backToTop": "Back to top",
   "copyright": "Copyright",
   "allRightsReserved": "All rights reserved"

--- a/packages/common-i18n/src/locales/en/hobbiesCommon.json
+++ b/packages/common-i18n/src/locales/en/hobbiesCommon.json
@@ -1,3 +1,0 @@
-{
-  "appName": "Hobbies"
-}

--- a/packages/common-i18n/src/locales/en/home.json
+++ b/packages/common-i18n/src/locales/en/home.json
@@ -42,21 +42,11 @@
   },
   "search": {
     "linkAdvancedSearch": "Advanced search",
-    "title": "Find hobbies",
     "labelSearchField": "What are you looking for",
     "popularCategories": "Popular categories",
     "placeholder": "Write search word",
     "showPopularCategories": "Show most popular categories",
-    "hidePopularCategories": "Hide most popular categories"
-  },
-  "eventSearch": {
-    "buttonSearch": "Search",
-    "placeholder": "Enter a keyword, eg rock or yoga",
-    "title": "Search for events"
-  },
-  "courseSearch": {
-    "buttonSearch": "Search",
-    "placeholder": "Enter a keyword, eg. French or cooking",
-    "title": "Search for hobbies"
+    "hidePopularCategories": "Hide most popular categories",
+    "buttonSearch": "Search"
   }
 }

--- a/packages/common-i18n/src/locales/fi/appEvents.json
+++ b/packages/common-i18n/src/locales/fi/appEvents.json
@@ -1,0 +1,16 @@
+{
+  "appName": "Tapahtumat",
+  "footer": {
+    "searchEvents": "Tapahtumakalenteri",
+    "titleEventsCategories": "Suositut tapahtumien kategoriat"
+  },
+  "home": {
+    "eventSearch": {
+      "placeholder": "Kirjoita hakusana, esim. rock tai jooga",
+      "title": "Mitä etsit?"
+    }
+  },
+  "search": {
+    "title": "Löydä tapahtumia"
+  }
+}

--- a/packages/common-i18n/src/locales/fi/appHobbies.json
+++ b/packages/common-i18n/src/locales/fi/appHobbies.json
@@ -1,0 +1,16 @@
+{
+  "appName": "Harrastukset",
+  "footer": {
+    "searchHobbies": "Harrastukset haku",
+    "titleCoursesCategories": "Suositut harrastuskategoriat"
+  },
+  "home": {
+    "courseSearch": {
+      "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto",
+      "title": "Löydä harrastuksia"
+    }
+  },
+  "search": {
+    "title": "Löydä harrastus"
+  }
+}

--- a/packages/common-i18n/src/locales/fi/eventsCommon.json
+++ b/packages/common-i18n/src/locales/fi/eventsCommon.json
@@ -1,3 +1,0 @@
-{
-  "appName": "Tapahtumat"
-}

--- a/packages/common-i18n/src/locales/fi/footer.json
+++ b/packages/common-i18n/src/locales/fi/footer.json
@@ -4,10 +4,6 @@
   "linkFeedback": "Anna palautetta",
   "linkFeedbackUrl": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta",
   "searchCollections": "Suosittelemme",
-  "searchEvents": "Tapahtumakalenteri",
-  "searchHobbies": "Harrastukset haku",
-  "titleEventsCategories": "Suositut tapahtumien kategoriat",
-  "titleCoursesCategories": "Suositut harrastuskategoriat",
   "backToTop": "Takaisin alkuun",
   "copyright": "Copyright",
   "allRightsReserved": "Kaikki oikeudet pidätetään"

--- a/packages/common-i18n/src/locales/fi/hobbiesCommon.json
+++ b/packages/common-i18n/src/locales/fi/hobbiesCommon.json
@@ -1,3 +1,0 @@
-{
-  "appName": "Harrastukset"
-}

--- a/packages/common-i18n/src/locales/fi/home.json
+++ b/packages/common-i18n/src/locales/fi/home.json
@@ -41,22 +41,12 @@
     "title": "Oho, nyt iski 404!"
   },
   "search": {
+    "linkAdvancedSearch": "Tarkennettu haku",
     "popularCategories": "Suosituimmat kategoriat",
     "placeholder": "Kirjoita hakusana",
     "showPopularCategories": "Näytä suosituimmat kategoriat",
     "hidePopularCategories": "Piilota suosituimmat kategoriat",
     "labelSearchField": "Mitä etsit?",
-    "title": "Löydä harrastuksia"
-  },
-  "eventSearch": {
-    "linkAdvancedSearch": "Tarkennettu haku",
-    "buttonSearch": "Hae",
-    "placeholder": "Kirjoita hakusana, esim. rock tai jooga",
-    "title": "Löydä tapahtumia"
-  },
-  "courseSearch": {
-    "buttonSearch": "Hae",
-    "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto",
-    "title": "Löydä harrastuksia"
+    "buttonSearch": "Hae"
   }
 }

--- a/packages/common-i18n/src/locales/sv/appEvents.json
+++ b/packages/common-i18n/src/locales/sv/appEvents.json
@@ -1,0 +1,16 @@
+{
+  "appName": "Evenemang",
+  "footer": {
+    "searchEvents": "Evenemangskalender",
+    "titleEventsCategories": "Populära evenemangskategorier"
+  },
+  "home": {
+    "eventSearch": {
+      "placeholder": "Ange ett sökord, t. ex. rock eller yoga",
+      "title": "Vad letar du efter?"
+    }
+  },
+  "search": {
+    "title": "Sök saker att göra"
+  }
+}

--- a/packages/common-i18n/src/locales/sv/appHobbies.json
+++ b/packages/common-i18n/src/locales/sv/appHobbies.json
@@ -1,0 +1,16 @@
+{
+  "appName": "Hobbyer",
+  "footer": {
+    "searchHobbies": "Hobbyer",
+    "titleCoursesCategories": "Populära hobbykategorier"
+  },
+  "home": {
+    "courseSearch": {
+      "placeholder": "Ange ett sökord, t. ex. rock eller yoga",
+      "title": "Hitta hobbyer"
+    }
+  },
+  "search": {
+    "title": "Hitta hobby"
+  }
+}

--- a/packages/common-i18n/src/locales/sv/eventsCommon.json
+++ b/packages/common-i18n/src/locales/sv/eventsCommon.json
@@ -1,3 +1,0 @@
-{
-  "appName": "Evenemang"
-}

--- a/packages/common-i18n/src/locales/sv/footer.json
+++ b/packages/common-i18n/src/locales/sv/footer.json
@@ -4,10 +4,6 @@
   "linkFeedback": "Ge respons",
   "linkFeedbackUrl": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback/",
   "searchCollections": "Vi rekommenderar",
-  "searchEvents": "Evenemangskalender",
-  "searchHobbies": "Hobbyer",
-  "titleEventsCategories": "Populära evenemangskategorier",
-  "titleCoursesCategories": "Populära hobbykategorier",
   "backToTop": "Tillbaka upp",
   "copyright": "Copyright",
   "allRightsReserved": "Alla rättigheter förbehållna"

--- a/packages/common-i18n/src/locales/sv/hobbiesCommon.json
+++ b/packages/common-i18n/src/locales/sv/hobbiesCommon.json
@@ -1,3 +1,0 @@
-{
-  "appName": "Hobbyer"
-}

--- a/packages/common-i18n/src/locales/sv/home.json
+++ b/packages/common-i18n/src/locales/sv/home.json
@@ -40,24 +40,13 @@
     "text": "Av en eller annan orsak så hittas inte sidan du letade efter.",
     "title": "Oj nej, nu blev det 404!"
   },
-
   "search": {
     "linkAdvancedSearch": "Avancerad sökning",
     "labelSearchField": "Vad letar du efter?",
-    "title": "Hitta hobbyer",
     "popularCategories": "Populära kategorier",
     "placeholder": "Skriv sökord",
     "showPopularCategories": "Visa de mest populära kategorierna",
-    "hidePopularCategories": "Dölj de mest populära kategorierna"
-  },
-  "eventSearch": {
-    "buttonSearch": "Sök",
-    "placeholder": "Ange ett sökord, t. ex. rock eller yoga",
-    "title": "Hitta evenemang"
-  },
-  "courseSearch": {
-    "buttonSearch": "Sök",
-    "placeholder": "Ange ett sökord, t. ex. rock eller yoga",
-    "title": "Hitta hobbyer"
+    "hidePopularCategories": "Dölj de mest populära kategorierna",
+    "buttonSearch": "Sök"
   }
 }

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -33,7 +33,6 @@
     }
   },
   "textFoundEvents": "{{count}} sökresultat",
-  "title": "Hitta hobby",
   "betaButtonArialLabel": "Vill du ge oss respons på utvecklingsversionen av hobbysöksidan?",
   "betaNotificationText": "Vill du ge oss respons på utvecklingsversionen av hobbysöksidan? <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Gå till responsformuläret {{openInNewTab}}\">Gå till responsformuläret.</a>",
   "betaResultsNotificationText": "Vi arbetar med att vidareutveckla webbsidan. För tillfället innehåller tjänsten enbart hobbyer för barn och unga.",

--- a/packages/common-i18n/src/tests/initI18n.ts
+++ b/packages/common-i18n/src/tests/initI18n.ts
@@ -2,6 +2,8 @@ import i18n from 'i18next';
 // eslint-disable-next-line no-restricted-imports
 import { initReactI18next } from 'react-i18next';
 
+import appEvents_en from '../locales/en/appEvents.json';
+import appHobbies_en from '../locales/en/appHobbies.json';
 import cms_en from '../locales/en/cms.json';
 import common_en from '../locales/en/common.json';
 import event_en from '../locales/en/event.json';
@@ -9,6 +11,8 @@ import footer_en from '../locales/en/footer.json';
 import home_en from '../locales/en/home.json';
 import notFound_en from '../locales/en/notFound.json';
 import search_en from '../locales/en/search.json';
+import appEvents from '../locales/fi/appEvents.json';
+import appHobbies from '../locales/fi/appHobbies.json';
 import cms from '../locales/fi/cms.json';
 import common from '../locales/fi/common.json';
 import event from '../locales/fi/event.json';
@@ -16,6 +20,8 @@ import footer from '../locales/fi/footer.json';
 import home from '../locales/fi/home.json';
 import notFound from '../locales/fi/notFound.json';
 import search from '../locales/fi/search.json';
+import appEvents_sv from '../locales/sv/appEvents.json';
+import appHobbies_sv from '../locales/sv/appHobbies.json';
 import cms_sv from '../locales/sv/cms.json';
 import common_sv from '../locales/sv/common.json';
 import event_sv from '../locales/sv/event.json';
@@ -32,6 +38,8 @@ export const translations = {
   home,
   notFound,
   search,
+  appEvents,
+  appHobbies,
 };
 
 export const config = {
@@ -53,6 +61,8 @@ export const config = {
       home: home_en,
       notFound: notFound_en,
       search: search_en,
+      appEvents: appEvents_en,
+      appHobbies: appHobbies_en,
     },
     sv: {
       cms: cms_sv,
@@ -62,6 +72,8 @@ export const config = {
       home: home_sv,
       notFound: notFound_sv,
       search: search_sv,
+      appEvents: appEvents_sv,
+      appHobbies: appHobbies_sv,
     },
   },
 };

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -17,3 +17,5 @@ export { default as useFooterTranslation } from './useFooterTranslation';
 export { default as useNotFoundTranslation } from './useNotFoundTranslation';
 export { default as useSearchTranslation } from './useSearchTranslation';
 export { default as useEventTranslation } from './useEventTranslation';
+export { default as useAppEventsTranslation } from './useAppEventsTranslation';
+export { default as useAppHobbiesTranslation } from './useAppHobbiesTranslation';

--- a/packages/components/src/hooks/useAppEventsTranslation.ts
+++ b/packages/components/src/hooks/useAppEventsTranslation.ts
@@ -1,0 +1,7 @@
+import { useTranslation } from 'next-i18next';
+import { appEventsConfig } from '../translations/appEvents.config';
+
+const useAppEventsTranslation = () =>
+  useTranslation(appEventsConfig.i18nNamespaces);
+
+export default useAppEventsTranslation;

--- a/packages/components/src/hooks/useAppHobbiesTranslation.ts
+++ b/packages/components/src/hooks/useAppHobbiesTranslation.ts
@@ -1,0 +1,7 @@
+import { useTranslation } from 'next-i18next';
+import { appHobbiesConfig } from '../translations/appHobbies.config';
+
+const useAppHobbiesTranslation = () =>
+  useTranslation(appHobbiesConfig.i18nNamespaces);
+
+export default useAppHobbiesTranslation;

--- a/packages/components/src/translations/appEvents.config.ts
+++ b/packages/components/src/translations/appEvents.config.ts
@@ -1,0 +1,10 @@
+import type { I18nActiveNamespaces } from '@/lib/i18n';
+
+export type AppEventsConfig = {
+  i18nNamespaces: I18nActiveNamespaces<'appEvents'>;
+};
+
+export const appEventsConfig: AppEventsConfig = {
+  /** Namespaces that should be loaded for this page */
+  i18nNamespaces: ['appEvents'],
+};

--- a/packages/components/src/translations/appHobbies.config.ts
+++ b/packages/components/src/translations/appHobbies.config.ts
@@ -1,0 +1,10 @@
+import type { I18nActiveNamespaces } from '@/lib/i18n';
+
+export type AppHobbiesConfig = {
+  i18nNamespaces: I18nActiveNamespaces<'appHobbies'>;
+};
+
+export const appHobbiesConfig: AppHobbiesConfig = {
+  /** Namespaces that should be loaded for this page */
+  i18nNamespaces: ['appHobbies'],
+};

--- a/packages/components/src/translations/common.config.ts
+++ b/packages/components/src/translations/common.config.ts
@@ -1,12 +1,10 @@
 import type { I18nActiveNamespaces } from '@/lib/i18n';
 
 export type CommonConfig = {
-  i18nNamespaces: I18nActiveNamespaces<
-    'common' | 'hobbiesCommon' | 'eventsCommon'
-  >;
+  i18nNamespaces: I18nActiveNamespaces<'common' | 'appHobbies' | 'appEvents'>;
 };
 
 export const commonConfig: CommonConfig = {
   /** Namespaces that should be loaded for this page */
-  i18nNamespaces: ['common', 'hobbiesCommon', 'eventsCommon'],
+  i18nNamespaces: ['common', 'appHobbies', 'appEvents'],
 };


### PR DESCRIPTION
## Description

Renamed already existing translation namespaces `eventsCommon` and `hobbiesCommon` to `appEvents` and `appHobbies`. The idea is to use those for all app specific translations. Most of the current obvious app-specific translations are relocated into those namespaces in this PR. There are also some tweaks to the event app translation content ([TH-1275](https://helsinkisolutionoffice.atlassian.net/browse/TH-1275)).

It would be probably preferable to have these app-specific translation files inside the app folders instead of the common-i18n package where there are now, but I could not find an easy way to achieve that, so that isn't done yet.

## Issues

### Closes

**[TH-1273](https://helsinkisolutionoffice.atlassian.net/browse/TH-1273): Create Events and Hobbies specific translations in the monorepo**

**[TH-1275](https://helsinkisolutionoffice.atlassian.net/browse/TH-1275): Change site headings**
