### PR TITLE
feat: cookie consent lang from ui

### DIFF
--- a/apps/events-helsinki/src/pages/_app.tsx
+++ b/apps/events-helsinki/src/pages/_app.tsx
@@ -97,7 +97,10 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
             ) : (
               <>
                 <Component {...pageProps} />
-                <EventsCookieConsent appName={t('appEvents:appName')} />
+                <EventsCookieConsent
+                  allowLanguageSwitch={false}
+                  appName={t('appEvents:appName')}
+                />
               </>
             )}
           </MatomoProvider>

--- a/apps/events-helsinki/src/styles/globals.scss
+++ b/apps/events-helsinki/src/styles/globals.scss
@@ -61,3 +61,7 @@ button {
   /* Microsoft Edge */
   color: var(--color-primary-black);
 }
+
+#cookie-consent-language-selector-button {
+  display: none;
+}

--- a/apps/hobbies-helsinki/src/pages/_app.tsx
+++ b/apps/hobbies-helsinki/src/pages/_app.tsx
@@ -97,7 +97,10 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
             ) : (
               <>
                 <Component {...pageProps} />
-                <EventsCookieConsent appName={t('appHobbies:appName')} />
+                <EventsCookieConsent
+                  allowLanguageSwitch={false}
+                  appName={t('appHobbies:appName')}
+                />
               </>
             )}
           </MatomoProvider>

--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -33,3 +33,7 @@ button {
   background-color: transparent;
   cursor: pointer;
 }
+
+#cookie-consent-language-selector-button {
+  display: none;
+}

--- a/apps/sports-helsinki/src/pages/_app.tsx
+++ b/apps/sports-helsinki/src/pages/_app.tsx
@@ -97,7 +97,10 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
             ) : (
               <>
                 <Component {...pageProps} />
-                <EventsCookieConsent appName={t('appSports:appName')} />
+                <EventsCookieConsent
+                  allowLanguageSwitch={false}
+                  appName={t('appSports:appName')}
+                />
               </>
             )}
           </MatomoProvider>

--- a/apps/sports-helsinki/src/styles/globals.scss
+++ b/apps/sports-helsinki/src/styles/globals.scss
@@ -33,3 +33,7 @@ button {
   background-color: transparent;
   cursor: pointer;
 }
+
+#cookie-consent-language-selector-button {
+  display: none;
+}

--- a/packages/components/src/components/eventsCookieConsent/EventsCookieConsent.tsx
+++ b/packages/components/src/components/eventsCookieConsent/EventsCookieConsent.tsx
@@ -4,13 +4,16 @@ import React from 'react';
 import { MAIN_CONTENT_ID } from '../../constants';
 import { useConsentTranslation } from '../../hooks';
 import useLocale from '../../hooks/useLocale';
-import type { Language } from '../../types';
 
 type Props = {
   appName: string;
+  allowLanguageSwitch?: boolean;
 };
 
-const EventsCookieConsent: React.FC<Props> = ({ appName }) => {
+const EventsCookieConsent: React.FC<Props> = ({
+  appName,
+  allowLanguageSwitch = true,
+}) => {
   const locale = useLocale();
   const { t, i18n } = useConsentTranslation();
   const [language, setLanguage] =
@@ -18,10 +21,12 @@ const EventsCookieConsent: React.FC<Props> = ({ appName }) => {
 
   const onLanguageChange = React.useCallback(
     (newLang: string) => {
-      setLanguage(newLang as ContentSource['currentLanguage']);
-      i18n.changeLanguage(newLang);
+      if (allowLanguageSwitch) {
+        setLanguage(newLang as ContentSource['currentLanguage']);
+        i18n.changeLanguage(newLang);
+      }
     },
-    [i18n, setLanguage]
+    [i18n, setLanguage, allowLanguageSwitch]
   );
   const contentSource: ContentSource = React.useMemo(
     () => ({


### PR DESCRIPTION
## Description
The cookie consent language switch is hidden from UI with css as HDS does not support to hide it through props (it will be reported)
Now in our cookie consent the language switch action can be disabled so with css it will be not possible to update the value even if the css is "removed" and consent language switch is used.

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
