### PR TITLE
TH-1273 & TH-1275 | Fix search related translations

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -254,7 +254,7 @@ const AdvancedSearch: React.FC<Props> = ({
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{tAppEvents('appEvents:home.eventSearch.title')}</h2>
+            <h2>{t('search.labelSearchField')}</h2>
             <div className={styles.rowWrapper}>
               <div className={classNames(styles.row, styles.autoSuggestRow)}>
                 <div>
@@ -262,7 +262,9 @@ const AdvancedSearch: React.FC<Props> = ({
                     name="search"
                     onChangeSearchValue={setAutosuggestInput}
                     onOptionClick={handleMenuOptionClick}
-                    placeholder={t('search.placeholder')}
+                    placeholder={tAppEvents(
+                      'appEvents:search.search.placeholder'
+                    )}
                     searchValue={autosuggestInput}
                   />
                 </div>

--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -254,7 +254,7 @@ const AdvancedSearch: React.FC<Props> = ({
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{tAppEvents('appEvents:search.title')}</h2>
+            <h2>{tAppEvents('appEvents:home.eventSearch.title')}</h2>
             <div className={styles.rowWrapper}>
               <div className={classNames(styles.row, styles.autoSuggestRow)}>
                 <div>

--- a/apps/events-helsinki/src/domain/search/eventSearch/EventSearchPageContainer.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/EventSearchPageContainer.tsx
@@ -1,15 +1,15 @@
-import { useSearchTranslation } from 'events-helsinki-components';
+import { useAppEventsTranslation } from 'events-helsinki-components';
 import React from 'react';
 
 import AdvancedSearch from './AdvancedSearch';
 import SearchPage from './SearchPage';
 
 const EventSearchPageContainer: React.FC = () => {
-  const { t } = useSearchTranslation();
+  const { t: tAppEvents } = useAppEventsTranslation();
   return (
     <SearchPage
       SearchComponent={AdvancedSearch}
-      pageTitle={t('search:title')}
+      pageTitle={tAppEvents('appEvents:search.pageTitle')}
     />
   );
 };

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -96,7 +96,7 @@ it('should clear all filters and search field', async () => {
   expect(router).toMatchObject({ pathname, query: { text: 'jazz' } });
 
   const searchInput = screen.getByPlaceholderText(
-    'Kirjoita hakusana, esim. ranska tai ruoanlaitto'
+    'Kirjoita hakusana, esim. rock tai jooga'
   );
 
   await userEvent.click(

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -51,7 +51,7 @@ export default function LandingPageSearchForm({
 
   return (
     <div className={classnames(className, styles.landingPageSearch)}>
-      <h2>{tAppEvents('appEvents:search.title')}</h2>
+      <h2>{tAppEvents('appEvents:home.search.title')}</h2>
       <div className={styles.searchRow}>
         <div className={styles.autosuggestWrapper}>
           <SearchAutosuggest

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -1,3 +1,4 @@
+import { useAppEventsTranslation } from 'events-helsinki-components';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect } from 'react';
@@ -17,6 +18,7 @@ export default function Search() {
   const router = useRouter();
   const scrollTo = router.query?.scrollTo;
   const listRef = useRef<HTMLUListElement | null>(null);
+  const { t: tAppEvents } = useAppEventsTranslation();
 
   useEffect(() => {
     const listElement = listRef.current;
@@ -43,7 +45,7 @@ export default function Search() {
         content={
           <SearchPage
             SearchComponent={AdvancedSearch}
-            pageTitle={'eventSearch.title'}
+            pageTitle={tAppEvents('appEvents:search.pageTitle')}
           />
         }
         footer={<FooterSection />}

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -260,7 +260,7 @@ const AdvancedSearch: React.FC<Props> = ({
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{tAppHobbies('appHobbies:search.title')}</h2>
+            <h2>{tAppHobbies('appHobbies:home.courseSearch.title')}</h2>
             <div className={styles.rowWrapper}>
               <div className={classNames(styles.row, styles.autoSuggestRow)}>
                 <div>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -6,7 +6,6 @@ import {
   DateSelector,
   MultiSelectDropdown,
   RangeDropdown,
-  useAppEventsTranslation,
   useAppHobbiesTranslation,
   useLocale,
 } from 'events-helsinki-components';
@@ -260,7 +259,7 @@ const AdvancedSearch: React.FC<Props> = ({
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{tAppHobbies('appHobbies:home.courseSearch.title')}</h2>
+            <h2>{t('search.labelSearchField')}</h2>
             <div className={styles.rowWrapper}>
               <div className={classNames(styles.row, styles.autoSuggestRow)}>
                 <div>
@@ -268,7 +267,9 @@ const AdvancedSearch: React.FC<Props> = ({
                     name="search"
                     onChangeSearchValue={setAutosuggestInput}
                     onOptionClick={handleMenuOptionClick}
-                    placeholder={t('search.placeholder')}
+                    placeholder={tAppHobbies(
+                      'appHobbies:search.search.placeholder'
+                    )}
                     searchValue={autosuggestInput}
                   />
                 </div>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/EventSearchPageContainer.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/EventSearchPageContainer.tsx
@@ -1,15 +1,15 @@
-import { useSearchTranslation } from 'events-helsinki-components';
+import { useAppHobbiesTranslation } from 'events-helsinki-components';
 import React from 'react';
 
 import AdvancedSearch from './AdvancedSearch';
 import SearchPage from './SearchPage';
 
 const EventSearchPageContainer: React.FC = () => {
-  const { t } = useSearchTranslation();
+  const { t: tAppHobbies } = useAppHobbiesTranslation();
   return (
     <SearchPage
       SearchComponent={AdvancedSearch}
-      pageTitle={t('search:title')}
+      pageTitle={tAppHobbies('appHobbies:search.pageTitle')}
     />
   );
 };

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -51,7 +51,7 @@ export default function LandingPageSearchForm({
 
   return (
     <div className={classnames(className, styles.landingPageSearch)}>
-      <h2>{tAppHobbies('appHobbies:search.title')}</h2>
+      <h2>{tAppHobbies('appHobbies:home.search.title')}</h2>
       <div className={styles.searchRow}>
         <div className={styles.autosuggestWrapper}>
           <SearchAutosuggest

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -1,3 +1,4 @@
+import { useAppHobbiesTranslation } from 'events-helsinki-components';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect } from 'react';
@@ -14,6 +15,7 @@ import SearchPage from '../../domain/search/eventSearch/SearchPage';
 import { getLocaleOrError } from '../../utils/routerUtils';
 
 export default function Search() {
+  const { t: tAppHobbies } = useAppHobbiesTranslation();
   const router = useRouter();
   const scrollTo = router.query?.scrollTo;
   const listRef = useRef<HTMLUListElement | null>(null);
@@ -43,7 +45,7 @@ export default function Search() {
         content={
           <SearchPage
             SearchComponent={AdvancedSearch}
-            pageTitle={'eventSearch.title'}
+            pageTitle={tAppHobbies('appHobbies:search.pageTitle')}
           />
         }
         footer={<FooterSection />}

--- a/apps/sports-helsinki/src/domain/footer/Footer.tsx
+++ b/apps/sports-helsinki/src/domain/footer/Footer.tsx
@@ -36,7 +36,7 @@ const FooterSection: FunctionComponent = () => {
       <Footer.Navigation>
         <Footer.Item
           as={Link}
-          label={tAppSports('appSports:footer.searchHobbies')}
+          label={tAppSports('appSports:footer.searchSports')}
           href={getI18nPath(ROUTES.SEARCH, locale)}
         />
       </Footer.Navigation>

--- a/apps/sports-helsinki/src/domain/footer/FooterCategories.tsx
+++ b/apps/sports-helsinki/src/domain/footer/FooterCategories.tsx
@@ -39,7 +39,7 @@ const FooterCategories: FunctionComponent = () => {
     t,
     CATEGORY_CATALOG.Course.default
   );
-  const footerTitle = t('appSports:footer.titleCoursesCategories');
+  const footerTitle = t(`appSports:footer.titleSportsCategories`);
 
   return (
     <div className={styles.topFooterWrapper}>

--- a/apps/sports-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -259,7 +259,7 @@ const AdvancedSearch: React.FC<Props> = ({
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{tAppSports('appSports:search.title')}</h2>
+            <h2>{t('search.labelSearchField')}</h2>
             <div className={styles.rowWrapper}>
               <div className={classNames(styles.row, styles.autoSuggestRow)}>
                 <div>
@@ -267,7 +267,9 @@ const AdvancedSearch: React.FC<Props> = ({
                     name="search"
                     onChangeSearchValue={setAutosuggestInput}
                     onOptionClick={handleMenuOptionClick}
-                    placeholder={t('search.placeholder')}
+                    placeholder={tAppSports(
+                      'appSports:search.search.placeholder'
+                    )}
                     searchValue={autosuggestInput}
                   />
                 </div>

--- a/apps/sports-helsinki/src/domain/search/eventSearch/EventSearchPageContainer.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/EventSearchPageContainer.tsx
@@ -1,15 +1,15 @@
-import { useSearchTranslation } from 'events-helsinki-components';
+import { useAppSportsTranslation } from 'events-helsinki-components';
 import React from 'react';
 
 import AdvancedSearch from './AdvancedSearch';
 import SearchPage from './SearchPage';
 
 const EventSearchPageContainer: React.FC = () => {
-  const { t } = useSearchTranslation();
+  const { t: tAppSports } = useAppSportsTranslation();
   return (
     <SearchPage
       SearchComponent={AdvancedSearch}
-      pageTitle={t('search:title')}
+      pageTitle={tAppSports('appSports:search.pageTitle')}
     />
   );
 };

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -51,7 +51,7 @@ export default function LandingPageSearchForm({
 
   return (
     <div className={classnames(className, styles.landingPageSearch)}>
-      <h2>{tAppSports('appSports:search.title')}</h2>
+      <h2>{tAppSports('appSports:home.search.title')}</h2>
       <div className={styles.searchRow}>
         <div className={styles.autosuggestWrapper}>
           <SearchAutosuggest

--- a/apps/sports-helsinki/src/domain/search/venueSearch/VenueSearch.tsx
+++ b/apps/sports-helsinki/src/domain/search/venueSearch/VenueSearch.tsx
@@ -1,10 +1,6 @@
 import type { ParsedUrlQueryInput } from 'querystring';
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
-import {
-  buildQueryFromObject,
-  useAppSportsTranslation,
-  useLocale,
-} from 'events-helsinki-components';
+import { buildQueryFromObject, useLocale } from 'events-helsinki-components';
 import { Button, IconSearch } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
@@ -24,7 +20,6 @@ const SimpleVenueSearch: React.FC<{
   'data-testid'?: string;
 }> = ({ scrollToResultList, 'data-testid': dataTestId }) => {
   const { t } = useTranslation('search');
-  const { t: tAppSports } = useAppSportsTranslation();
   const locale = useLocale();
   const router = useRouter();
 
@@ -91,7 +86,7 @@ const SimpleVenueSearch: React.FC<{
       <ContentContainer className={styles.contentContainer}>
         <form onSubmit={handleSubmit}>
           <div className={styles.searchWrapper}>
-            <h2>{tAppSports('appSports:search.title')}</h2>
+            <h2>{t('search.labelSearchField')}</h2>
             <div className={styles.rowWrapper}>
               <div>
                 <SearchAutosuggest

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -1,3 +1,4 @@
+import { useAppSportsTranslation } from 'events-helsinki-components';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect } from 'react';
@@ -16,6 +17,7 @@ export default function Search() {
   const router = useRouter();
   const scrollTo = router.query?.scrollTo;
   const listRef = useRef<HTMLUListElement | null>(null);
+  const { t: tAppSports } = useAppSportsTranslation();
 
   useEffect(() => {
     const listElement = listRef.current;
@@ -42,7 +44,7 @@ export default function Search() {
         content={
           <SearchPage
             SearchComponent={SimpleVenueSearch}
-            pageTitle={'eventSearch.title'}
+            pageTitle={tAppSports('appSports:search.pageTitle')}
           />
         }
         footer={<FooterSection />}

--- a/packages/common-i18n/src/locales/en/appEvents.json
+++ b/packages/common-i18n/src/locales/en/appEvents.json
@@ -5,12 +5,14 @@
     "titleEventsCategories": "Popular events categories"
   },
   "home": {
-    "eventSearch": {
-      "placeholder": "Enter a keyword, eg rock or yoga",
-      "title": "What are you looking for?"
+    "search": {
+      "title": "Find something to do"
     }
   },
   "search": {
-    "title": "Find something to do"
+    "pageTitle": "Find events",
+    "search": {
+      "placeholder": "Enter a keyword, eg rock or yoga"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/en/appHobbies.json
+++ b/packages/common-i18n/src/locales/en/appHobbies.json
@@ -5,12 +5,14 @@
     "titleCoursesCategories": "Popular courses categories"
   },
   "home": {
-    "courseSearch": {
-      "placeholder": "Enter a keyword, eg. French or cooking",
-      "title": "What are you looking for?"
+    "search": {
+      "title": "Find hobbies"
     }
   },
   "search": {
-    "title": "Find hobbies"
+    "pageTitle": "Find hobbies",
+    "search": {
+      "placeholder": "Enter a keyword, eg. French or cooking"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/en/appHobbies.json
+++ b/packages/common-i18n/src/locales/en/appHobbies.json
@@ -7,7 +7,7 @@
   "home": {
     "courseSearch": {
       "placeholder": "Enter a keyword, eg. French or cooking",
-      "title": "Search for hobbies"
+      "title": "What are you looking for?"
     }
   },
   "search": {

--- a/packages/common-i18n/src/locales/en/appSports.json
+++ b/packages/common-i18n/src/locales/en/appSports.json
@@ -1,16 +1,18 @@
 {
   "appName": "Sports",
   "footer": {
-    "searchHobbies": "Sports",
-    "titleCoursesCategories": "Popular sports categories"
+    "searchSports": "Sports",
+    "titleSportsCategories": "Popular sports categories"
   },
   "home": {
-    "courseSearch": {
-      "placeholder": "Enter a keyword, eg. swimming hall or yoga",
+    "search": {
       "title": "Search for sports"
     }
   },
   "search": {
-    "title": "Find sport"
+    "pageTitle": "Find sport",
+    "search": {
+      "placeholder": "Enter a keyword, eg. swimming hall or yoga"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -33,7 +33,6 @@
     }
   },
   "textFoundEvents": "{{count}} search results",
-  "title": "Find hobby",
   "buttonLoadMore": "Show more hobbies ({{count}})",
   "searchNotification": {
     "noResultsTitle": "Sorry, no search results were found for the search criteria you selected.",

--- a/packages/common-i18n/src/locales/fi/appEvents.json
+++ b/packages/common-i18n/src/locales/fi/appEvents.json
@@ -5,12 +5,14 @@
     "titleEventsCategories": "Suositut tapahtumien kategoriat"
   },
   "home": {
-    "eventSearch": {
-      "placeholder": "Kirjoita hakusana, esim. rock tai jooga",
-      "title": "Mitä etsit?"
+    "search": {
+      "title": "Löydä tapahtumia"
     }
   },
   "search": {
-    "title": "Löydä tapahtumia"
+    "pageTitle": "Löydä tapahtumia",
+    "search": {
+      "placeholder": "Kirjoita hakusana, esim. rock tai jooga"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/fi/appHobbies.json
+++ b/packages/common-i18n/src/locales/fi/appHobbies.json
@@ -7,10 +7,10 @@
   "home": {
     "courseSearch": {
       "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto",
-      "title": "Löydä harrastuksia"
+      "title": "Mitä etsit?"
     }
   },
   "search": {
-    "title": "Löydä harrastus"
+    "title": "Löydä harrastuksia"
   }
 }

--- a/packages/common-i18n/src/locales/fi/appHobbies.json
+++ b/packages/common-i18n/src/locales/fi/appHobbies.json
@@ -5,12 +5,14 @@
     "titleCoursesCategories": "Suositut harrastuskategoriat"
   },
   "home": {
-    "courseSearch": {
-      "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto",
-      "title": "Mitä etsit?"
+    "search": {
+      "title": "Löydä harrastuksia"
     }
   },
   "search": {
-    "title": "Löydä harrastuksia"
+    "pageTitle": "Löydä harrastuksia",
+    "search": {
+      "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/fi/appSports.json
+++ b/packages/common-i18n/src/locales/fi/appSports.json
@@ -1,16 +1,18 @@
 {
   "appName": "Liikunta",
   "footer": {
-    "searchHobbies": "Liikunta haku",
-    "titleCoursesCategories": "Suositut liikuntakategoriat"
+    "searchSports": "Liikunta haku",
+    "titleSportsCategories": "Suositut liikuntakategoriat"
   },
   "home": {
-    "courseSearch": {
-      "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto",
+    "search": {
       "title": "Löydä liikuntaa"
     }
   },
   "search": {
-    "title": "Löydä liikuntaa"
+    "pageTitle": "Löydä liikuntaa",
+    "search": {
+      "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -1,5 +1,4 @@
 {
-  "title": "Löydä harrastus",
   "ariaLiveLoading": "Haetaan tapahtumia",
   "ariaLiveSearchReady": "{{count}} hakutulosta",
   "textFoundEvents": "{{count}} hakutulosta",

--- a/packages/common-i18n/src/locales/sv/appEvents.json
+++ b/packages/common-i18n/src/locales/sv/appEvents.json
@@ -5,12 +5,14 @@
     "titleEventsCategories": "Populära evenemangskategorier"
   },
   "home": {
-    "eventSearch": {
-      "placeholder": "Ange ett sökord, t. ex. rock eller yoga",
-      "title": "Vad letar du efter?"
+    "search": {
+      "title": "Sök saker att göra"
     }
   },
   "search": {
-    "title": "Sök saker att göra"
+    "pageTitle": "Sök saker att göra",
+    "search": {
+      "placeholder": "Ange ett sökord, t. ex. rock eller yoga"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/sv/appHobbies.json
+++ b/packages/common-i18n/src/locales/sv/appHobbies.json
@@ -7,10 +7,10 @@
   "home": {
     "courseSearch": {
       "placeholder": "Ange ett sökord, t. ex. rock eller yoga",
-      "title": "Hitta hobbyer"
+      "title": "Vad letar du efter?"
     }
   },
   "search": {
-    "title": "Hitta hobby"
+    "title": "Hitta hobbyer"
   }
 }

--- a/packages/common-i18n/src/locales/sv/appHobbies.json
+++ b/packages/common-i18n/src/locales/sv/appHobbies.json
@@ -5,12 +5,14 @@
     "titleCoursesCategories": "Populära hobbykategorier"
   },
   "home": {
-    "courseSearch": {
-      "placeholder": "Ange ett sökord, t. ex. rock eller yoga",
-      "title": "Vad letar du efter?"
+    "search": {
+      "title": "Hitta hobbyer"
     }
   },
   "search": {
-    "title": "Hitta hobbyer"
+    "pageTitle": "Hitta hobbyer",
+    "search": {
+      "placeholder": "Ange ett sökord, t. ex. rock eller yoga"
+    }
   }
 }

--- a/packages/common-i18n/src/locales/sv/appSports.json
+++ b/packages/common-i18n/src/locales/sv/appSports.json
@@ -1,16 +1,18 @@
 {
   "appName": "Idrott och motion Helsingfors",
   "footer": {
-    "searchHobbies": "Motion",
-    "titleCoursesCategories": "Populära kategorier"
+    "searchSports": "Motion",
+    "titleSportsCategories": "Populära kategorier"
   },
   "home": {
-    "courseSearch": {
-      "placeholder": "Ange ett sökord, t. ex. simhall eller yoga",
+    "search": {
       "title": "Hitta motion"
     }
   },
   "search": {
-    "title": "Hitta motion"
+    "pageTitle": "Hitta motion",
+    "search": {
+      "placeholder": "Ange ett sökord, t. ex. simhall eller yoga"
+    }
   }
 }

--- a/packages/common-tests/browser-tests/page-model/landingPage.ts
+++ b/packages/common-tests/browser-tests/page-model/landingPage.ts
@@ -19,7 +19,7 @@ class LandingPage {
     await t
       .expect(
         screen.getByRole('heading', {
-          name: i18n.t(`${this.appNamespace}:search.title`),
+          name: i18n.t(`${this.appNamespace}:home.search.title`),
         }).exists
       )
       .ok();


### PR DESCRIPTION
## Description

Changed a couple of search-related translation texts of events and hobbies, and also reorganized the translations a bit to make the structure more logical and easier to reason about. There is still room for improvement in that area.

## Issues

### Closes
**[TH-1273](https://helsinkisolutionoffice.atlassian.net/browse/TH-1273): Create Events and Hobbies specific translations in the monorepo**
**[TH-1275](https://helsinkisolutionoffice.atlassian.net/browse/TH-1275): Change site headings**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
