### PR TITLE
Add unified search pagination handlers to Apollo cache config and fix the cache usage in a whole

### DIFF
--- a/apps/events-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/events-helsinki/src/domain/event/queryUtils.ts
@@ -162,19 +162,6 @@ export const useSubEvents = (
           variables: {
             page,
           },
-          // updateQuery: (prevResult, { fetchMoreResult }) => {
-          //   if (!fetchMoreResult) return prevResult;
-          //   return {
-          //     ...prevResult,
-          //     eventList: {
-          //       ...fetchMoreResult.eventList,
-          //       data: [
-          //         ...prevResult.eventList.data,
-          //         ...fetchMoreResult.eventList.data,
-          //       ],
-          //     },
-          //   };
-          // },
         });
       } catch (e) {
         toast.error(t('info.errorLoadMode'));

--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -75,20 +75,6 @@ const SearchPage: React.FC<{
           variables: {
             page,
           },
-          // TODO: This should not be needed since it comes from the client's cache-strategies.
-          updateQuery: (prevResult, { fetchMoreResult }) => {
-            if (!fetchMoreResult) return prevResult;
-            return {
-              ...prevResult,
-              eventList: {
-                ...fetchMoreResult.eventList,
-                data: [
-                  ...prevResult.eventList.data,
-                  ...fetchMoreResult.eventList.data,
-                ],
-              },
-            };
-          },
         });
       } catch (e) {
         toast.error(t('search:errorLoadMode'));

--- a/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -104,9 +104,6 @@ export function createApolloClient() {
 export function createApolloCache() {
   return new InMemoryCache({
     typePolicies: {
-      RootQuery: {
-        queryType: true,
-      },
       MenuItems: {
         fields: {
           nodes: {

--- a/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -13,6 +13,7 @@ import {
   InMemoryCache,
 } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
+import { relayStylePagination } from '@apollo/client/utilities';
 import * as Sentry from '@sentry/browser';
 import fetch from 'cross-fetch';
 import {
@@ -22,6 +23,8 @@ import {
   MutableReference,
   sortMenuItems,
 } from 'events-helsinki-components';
+import type { LanguageString } from 'events-helsinki-components';
+import capitalize from 'lodash/capitalize';
 import { useMemo } from 'react';
 import { logger } from '../../logger';
 import { rewriteInternalURLs } from '../../utils/routerUtils';
@@ -114,6 +117,7 @@ export function createApolloCache() {
         },
       },
       Query: {
+        queryType: true, // This type represents the Root Query.
         fields: {
           event(_, { args, toReference }) {
             return toReference({
@@ -154,6 +158,7 @@ export function createApolloCache() {
               meta: incoming.meta,
             };
           }),
+          unifiedSearch: relayStylePagination(excludeArgs(['after'])),
         },
       },
       Keyword: {
@@ -167,6 +172,21 @@ export function createApolloCache() {
           // if selectionSet is not defined, it means that toReference function calls keyfields
           // then we want to return cache id normally.
           return defaultDataIdFromObject(object);
+        },
+      },
+      OntologyWord: {
+        fields: {
+          label: {
+            read(label: LanguageString) {
+              const { fi, en, sv } = label;
+              return {
+                ...label,
+                fi: fi ? capitalize(fi) : '',
+                en: en ? capitalize(en) : '',
+                sv: sv ? capitalize(sv) : '',
+              };
+            },
+          },
         },
       },
     },

--- a/apps/hobbies-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/hobbies-helsinki/src/domain/event/queryUtils.ts
@@ -164,19 +164,6 @@ export const useSubEvents = (
           variables: {
             page,
           },
-          // updateQuery: (prevResult, { fetchMoreResult }) => {
-          //   if (!fetchMoreResult) return prevResult;
-          //   return {
-          //     ...prevResult,
-          //     eventList: {
-          //       ...fetchMoreResult.eventList,
-          //       data: [
-          //         ...prevResult.eventList.data,
-          //         ...fetchMoreResult.eventList.data,
-          //       ],
-          //     },
-          //   };
-          // },
         });
       } catch (e) {
         toast.error(t('info.errorLoadMode'));

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -75,20 +75,6 @@ const SearchPage: React.FC<{
           variables: {
             page,
           },
-          // TODO: This should not be needed since it comes from the client's cache-strategies.
-          updateQuery: (prevResult, { fetchMoreResult }) => {
-            if (!fetchMoreResult) return prevResult;
-            return {
-              ...prevResult,
-              eventList: {
-                ...fetchMoreResult.eventList,
-                data: [
-                  ...prevResult.eventList.data,
-                  ...fetchMoreResult.eventList.data,
-                ],
-              },
-            };
-          },
         });
       } catch (e) {
         toast.error(t('search:errorLoadMode'));

--- a/apps/sports-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/sports-helsinki/src/domain/event/queryUtils.ts
@@ -164,19 +164,6 @@ export const useSubEvents = (
           variables: {
             page,
           },
-          // updateQuery: (prevResult, { fetchMoreResult }) => {
-          //   if (!fetchMoreResult) return prevResult;
-          //   return {
-          //     ...prevResult,
-          //     eventList: {
-          //       ...fetchMoreResult.eventList,
-          //       data: [
-          //         ...prevResult.eventList.data,
-          //         ...fetchMoreResult.eventList.data,
-          //       ],
-          //     },
-          //   };
-          // },
         });
       } catch (e) {
         toast.error(t('info.errorLoadMode'));

--- a/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -75,20 +75,6 @@ const SearchPage: React.FC<{
           variables: {
             page,
           },
-          // TODO: This should not be needed since it comes from the client's cache-strategies.
-          updateQuery: (prevResult, { fetchMoreResult }) => {
-            if (!fetchMoreResult) return prevResult;
-            return {
-              ...prevResult,
-              eventList: {
-                ...fetchMoreResult.eventList,
-                data: [
-                  ...prevResult.eventList.data,
-                  ...fetchMoreResult.eventList.data,
-                ],
-              },
-            };
-          },
         });
       } catch (e) {
         toast.error(t('search:errorLoadMode'));

--- a/apps/sports-helsinki/src/domain/unifiedSearch/useUnifiedSearchListQuery.ts
+++ b/apps/sports-helsinki/src/domain/unifiedSearch/useUnifiedSearchListQuery.ts
@@ -3,7 +3,7 @@ import { useSearchListQuery } from 'events-helsinki-components';
 import useUnifiedSearchVariables from './useUnifiedSearchVariables';
 
 type HookConfig = {
-  variables?: Partial<Omit<SearchListQueryVariables, 'enableHauki'>>;
+  variables?: Partial<SearchListQueryVariables>;
 };
 
 export default function useUnifiedSearchListQuery({
@@ -17,24 +17,13 @@ export default function useUnifiedSearchListQuery({
     },
   });
 
-  const handleFetchMore = (variables: Partial<SearchListQueryVariables>) =>
-    fetchMore({
-      variables,
-      // TODO: This should not be needed since it comes from the client's cache-strategies.
-      updateQuery: (prevResult, { fetchMoreResult }) => {
-        if (!fetchMoreResult) return prevResult;
-        return {
-          ...prevResult,
-          unifiedSearch: {
-            ...fetchMoreResult.unifiedSearch,
-            edges: [
-              ...(prevResult.unifiedSearch?.edges ?? []),
-              ...(fetchMoreResult.unifiedSearch?.edges ?? []),
-            ],
-          },
-        };
-      },
+  const handleFetchMore = async (
+    fetchMoreVariables: Partial<SearchListQueryVariables>
+  ) => {
+    await fetchMore({
+      variables: fetchMoreVariables,
     });
+  };
 
   return {
     fetchMore: handleFetchMore,


### PR DESCRIPTION
LIIKUNTA-338. This is pull request fixes the cache usage that was broke when the new Apollo router was taken in use. The root query was set wrong and the cache policies never hit the target. 

_Actually, it's strange that it has ever worked!_

**The pull request #89 added a temporary fix to the fetch more features, but this implementation does the same thing but more generic and the configuration is centralized.**