### PR TITLE
fix: pagination with query update

### DIFF
--- a/apps/events-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/events-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -160,7 +160,7 @@ export function createApolloCache() {
   });
 }
 
-export default function initializeGatewayApolloClient(
+export default function initializeFederationApolloClient(
   initialState: NormalizedCacheObject = {}
 ): ApolloClient<NormalizedCacheObject> {
   return initializeApolloClient<
@@ -177,7 +177,7 @@ export function useApolloClient(
   initialState: NormalizedCacheObject = {}
 ): ApolloClient<NormalizedCacheObject> {
   return useMemo(
-    () => initializeGatewayApolloClient(initialState),
+    () => initializeFederationApolloClient(initialState),
     [initialState]
   );
 }

--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -75,6 +75,20 @@ const SearchPage: React.FC<{
           variables: {
             page,
           },
+          // TODO: This should not be needed since it comes from the client's cache-strategies.
+          updateQuery: (prevResult, { fetchMoreResult }) => {
+            if (!fetchMoreResult) return prevResult;
+            return {
+              ...prevResult,
+              eventList: {
+                ...fetchMoreResult.eventList,
+                data: [
+                  ...prevResult.eventList.data,
+                  ...fetchMoreResult.eventList.data,
+                ],
+              },
+            };
+          },
         });
       } catch (e) {
         toast.error(t('search:errorLoadMode'));

--- a/apps/hobbies-helsinki/src/domain/app/getHobbiesStaticProps.ts
+++ b/apps/hobbies-helsinki/src/domain/app/getHobbiesStaticProps.ts
@@ -6,7 +6,7 @@ import type { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 
 import { staticGenerationLogger } from '../../logger';
 import { getLocaleOrError } from '../../utils/routerUtils';
-import initializeApolloClient from '../clients/eventsFederationApolloClient';
+import initializeFederationApolloClient from '../clients/eventsFederationApolloClient';
 import AppConfig from './AppConfig';
 
 const GLOBAL_QUERY = gql`
@@ -52,7 +52,7 @@ export default async function getHobbiesStaticProps<P = Record<string, any>>(
     hobbiesContext: HobbiesContext
   ) => Promise<GetStaticPropsResult<P>>
 ) {
-  const apolloClient = initializeApolloClient();
+  const apolloClient = initializeFederationApolloClient();
 
   try {
     await getGlobalCMSData({ client: apolloClient, context });

--- a/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -173,7 +173,7 @@ export function createApolloCache() {
   });
 }
 
-export default function initializeGatewayApolloClient(
+export default function initializeFederationApolloClient(
   initialState: NormalizedCacheObject = {}
 ): ApolloClient<NormalizedCacheObject> {
   return initializeApolloClient<
@@ -190,7 +190,7 @@ export function useApolloClient(
   initialState: NormalizedCacheObject = {}
 ): ApolloClient<NormalizedCacheObject> {
   return useMemo(
-    () => initializeGatewayApolloClient(initialState),
+    () => initializeFederationApolloClient(initialState),
     [initialState]
   );
 }

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -75,6 +75,20 @@ const SearchPage: React.FC<{
           variables: {
             page,
           },
+          // TODO: This should not be needed since it comes from the client's cache-strategies.
+          updateQuery: (prevResult, { fetchMoreResult }) => {
+            if (!fetchMoreResult) return prevResult;
+            return {
+              ...prevResult,
+              eventList: {
+                ...fetchMoreResult.eventList,
+                data: [
+                  ...prevResult.eventList.data,
+                  ...fetchMoreResult.eventList.data,
+                ],
+              },
+            };
+          },
         });
       } catch (e) {
         toast.error(t('search:errorLoadMode'));

--- a/apps/sports-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/sports-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -173,7 +173,7 @@ export function createApolloCache() {
   });
 }
 
-export default function initializeGatewayApolloClient(
+export default function initializeFederationApolloClient(
   initialState: NormalizedCacheObject = {}
 ): ApolloClient<NormalizedCacheObject> {
   return initializeApolloClient<
@@ -190,7 +190,7 @@ export function useApolloClient(
   initialState: NormalizedCacheObject = {}
 ): ApolloClient<NormalizedCacheObject> {
   return useMemo(
-    () => initializeGatewayApolloClient(initialState),
+    () => initializeFederationApolloClient(initialState),
     [initialState]
   );
 }

--- a/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -75,6 +75,20 @@ const SearchPage: React.FC<{
           variables: {
             page,
           },
+          // TODO: This should not be needed since it comes from the client's cache-strategies.
+          updateQuery: (prevResult, { fetchMoreResult }) => {
+            if (!fetchMoreResult) return prevResult;
+            return {
+              ...prevResult,
+              eventList: {
+                ...fetchMoreResult.eventList,
+                data: [
+                  ...prevResult.eventList.data,
+                  ...fetchMoreResult.eventList.data,
+                ],
+              },
+            };
+          },
         });
       } catch (e) {
         toast.error(t('search:errorLoadMode'));

--- a/apps/sports-helsinki/src/domain/unifiedSearch/useUnifiedSearchListQuery.ts
+++ b/apps/sports-helsinki/src/domain/unifiedSearch/useUnifiedSearchListQuery.ts
@@ -20,6 +20,20 @@ export default function useUnifiedSearchListQuery({
   const handleFetchMore = (variables: Partial<SearchListQueryVariables>) =>
     fetchMore({
       variables,
+      // TODO: This should not be needed since it comes from the client's cache-strategies.
+      updateQuery: (prevResult, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prevResult;
+        return {
+          ...prevResult,
+          unifiedSearch: {
+            ...fetchMoreResult.unifiedSearch,
+            edges: [
+              ...(prevResult.unifiedSearch?.edges ?? []),
+              ...(fetchMoreResult.unifiedSearch?.edges ?? []),
+            ],
+          },
+        };
+      },
     });
 
   return {


### PR DESCRIPTION
LIIKUNTA-338. Important fix!

NOTE: This fix should not be needed, since the query update strategy should come from the client's cache strategies. This was not needed before the new Apollo Router was taken in use and it should not be needed after that either. Some other solution should be found.