### PR TITLE
Fix the dynamic pages get static path

### DIFF
--- a/apps/events-helsinki/browser-tests/roles/allCookiesUser.ts
+++ b/apps/events-helsinki/browser-tests/roles/allCookiesUser.ts
@@ -1,0 +1,15 @@
+import { Role } from 'testcafe';
+import { getEnvUrl } from '../../../../packages/common-tests/browser-tests';
+import EventsConsentModal from '../page-models/events-consent-modal';
+
+export const acceptAllCookies = async () => {
+  const cookieConsentModal = new EventsConsentModal();
+  //   await cookieConsentModal.isOpened();
+  await cookieConsentModal.clickAcceptAllCookies();
+};
+
+const userAcceptingAllCookies = Role(getEnvUrl('/'), async () => {
+  await acceptAllCookies();
+});
+
+export default userAcceptingAllCookies;

--- a/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
+++ b/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
@@ -22,4 +22,6 @@ test('Verify searching', async () => {
   await acceptAllCookies();
   const searchPage = new EventSearchPage('appEvents');
   await searchPage.verify();
+  await searchPage.doSuccessfulSearch();
+  await searchPage.doUnsuccessfulSearch();
 });

--- a/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
+++ b/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
@@ -1,0 +1,25 @@
+import { initTestI18n as i18n } from '../../../../packages/common-i18n/src/';
+import {
+  EventSearchPage,
+  getEnvUrl,
+} from '../../../../packages/common-tests/browser-tests';
+import { ROUTES } from '../../src/constants';
+import EventsConsentModal from '../page-models/events-consent-modal';
+
+fixture('Search page')
+  .page(getEnvUrl(ROUTES.SEARCH))
+  .beforeEach(async () => i18n.changeLanguage('default'));
+
+// TODO: Load this from fixture or something
+// so that it does not need to be repeated in every test
+const acceptAllCookies = async () => {
+  const cookieConsentModal = new EventsConsentModal();
+  //   await cookieConsentModal.isOpened();
+  await cookieConsentModal.clickAcceptAllCookies();
+};
+
+test('Verify searching', async () => {
+  await acceptAllCookies();
+  const searchPage = new EventSearchPage('appEvents');
+  await searchPage.verify();
+});

--- a/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
+++ b/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
@@ -4,22 +4,14 @@ import {
   getEnvUrl,
 } from '../../../../packages/common-tests/browser-tests';
 import { ROUTES } from '../../src/constants';
-import EventsConsentModal from '../page-models/events-consent-modal';
+import allCookiesUser from '../roles/allCookiesUser';
 
 fixture('Search page')
   .page(getEnvUrl(ROUTES.SEARCH))
   .beforeEach(async () => i18n.changeLanguage('default'));
 
-// TODO: Load this from fixture or something
-// so that it does not need to be repeated in every test
-const acceptAllCookies = async () => {
-  const cookieConsentModal = new EventsConsentModal();
-  //   await cookieConsentModal.isOpened();
-  await cookieConsentModal.clickAcceptAllCookies();
-};
-
-test('Verify searching', async () => {
-  await acceptAllCookies();
+test('Verify searching', async (t) => {
+  await t.useRole(allCookiesUser);
   const searchPage = new EventSearchPage('appEvents');
   await searchPage.verify();
   await searchPage.doSuccessfulSearch();

--- a/apps/events-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/events-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -43,8 +43,6 @@ export const removeInternalDoublePrefix = (slugs: string[]) => {
       slugs.shift();
     }
   });
-  // eslint-disable-next-line no-console
-  console.log('removeInternalDoublePrefix', { slugs });
   return slugs;
 };
 

--- a/apps/events-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/events-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -34,10 +34,26 @@ export const getUriID = (slugs: string[], locale: AppLanguage): string => {
   return `/${slugs.join('/')}/`;
 };
 
+export const removeInternalDoublePrefix = (slugs: string[]) => {
+  [
+    AppConfig.cmsArticlesContextPath.replace('/', ''),
+    AppConfig.cmsPagesContextPath.replace('/', ''),
+  ].forEach((internalUriSegment) => {
+    if (slugs[0] === internalUriSegment) {
+      slugs.shift();
+    }
+  });
+  // eslint-disable-next-line no-console
+  console.log('removeInternalDoublePrefix', { slugs });
+  return slugs;
+};
+
 export const getSlugFromUri = (uri?: string | null): string[] | null => {
   const uriWithoutLang = stripLocaleFromUri(uri ?? '');
   if (uriWithoutLang) {
-    return uriWithoutLang.split('/').filter((i) => i);
+    return removeInternalDoublePrefix(
+      uriWithoutLang.split('/').filter((i) => i)
+    );
   }
   return null;
 };

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -77,7 +77,7 @@ export async function getStaticPaths() {
   const pagePageInfos = await getAllPages();
   const paths = pagePageInfos
     .map((pageInfo) => ({
-      params: { slug: getSlugFromUri(pageInfo.slug) },
+      params: { slug: getSlugFromUri(pageInfo.uri) },
       locale: pageInfo.locale,
     }))
     // Remove the pages without a slug

--- a/apps/hobbies-helsinki/browser-tests/roles/allCookiesUser.ts
+++ b/apps/hobbies-helsinki/browser-tests/roles/allCookiesUser.ts
@@ -1,0 +1,15 @@
+import { Role } from 'testcafe';
+import { getEnvUrl } from '../../../../packages/common-tests/browser-tests';
+import HobbiesConsentModal from '../page-models/hobbies-consent-modal';
+
+export const acceptAllCookies = async () => {
+  const cookieConsentModal = new HobbiesConsentModal();
+  //   await cookieConsentModal.isOpened();
+  await cookieConsentModal.clickAcceptAllCookies();
+};
+
+const userAcceptingAllCookies = Role(getEnvUrl('/'), async () => {
+  await acceptAllCookies();
+});
+
+export default userAcceptingAllCookies;

--- a/apps/hobbies-helsinki/browser-tests/search-page/search-page.testcafe.ts
+++ b/apps/hobbies-helsinki/browser-tests/search-page/search-page.testcafe.ts
@@ -4,22 +4,16 @@ import {
   getEnvUrl,
 } from '../../../../packages/common-tests/browser-tests';
 import { ROUTES } from '../../src/constants';
-import HobbiesConsentModal from '../page-models/hobbies-consent-modal';
+import allCookiesUser from '../roles/allCookiesUser';
 
 fixture('Search page')
   .page(getEnvUrl(ROUTES.SEARCH))
   .beforeEach(async () => i18n.changeLanguage('default'));
 
-// TODO: Load this from fixture or something
-// so that it does not need to be repeated in every test
-const acceptAllCookies = async () => {
-  const cookieConsentModal = new HobbiesConsentModal();
-  //   await cookieConsentModal.isOpened();
-  await cookieConsentModal.clickAcceptAllCookies();
-};
-
-test('Verify searching', async () => {
-  await acceptAllCookies();
+test('Verify searching', async (t) => {
+  await t.useRole(allCookiesUser);
   const searchPage = new EventSearchPage('appHobbies');
   await searchPage.verify();
+  await searchPage.doSuccessfulSearch();
+  await searchPage.doUnsuccessfulSearch();
 });

--- a/apps/hobbies-helsinki/browser-tests/search-page/search-page.testcafe.ts
+++ b/apps/hobbies-helsinki/browser-tests/search-page/search-page.testcafe.ts
@@ -1,0 +1,25 @@
+import { initTestI18n as i18n } from '../../../../packages/common-i18n/src/';
+import {
+  EventSearchPage,
+  getEnvUrl,
+} from '../../../../packages/common-tests/browser-tests';
+import { ROUTES } from '../../src/constants';
+import HobbiesConsentModal from '../page-models/hobbies-consent-modal';
+
+fixture('Search page')
+  .page(getEnvUrl(ROUTES.SEARCH))
+  .beforeEach(async () => i18n.changeLanguage('default'));
+
+// TODO: Load this from fixture or something
+// so that it does not need to be repeated in every test
+const acceptAllCookies = async () => {
+  const cookieConsentModal = new HobbiesConsentModal();
+  //   await cookieConsentModal.isOpened();
+  await cookieConsentModal.clickAcceptAllCookies();
+};
+
+test('Verify searching', async () => {
+  await acceptAllCookies();
+  const searchPage = new EventSearchPage('appHobbies');
+  await searchPage.verify();
+});

--- a/apps/hobbies-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/hobbies-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -43,8 +43,6 @@ export const removeInternalDoublePrefix = (slugs: string[]) => {
       slugs.shift();
     }
   });
-  // eslint-disable-next-line no-console
-  console.log('removeInternalDoublePrefix', { slugs });
   return slugs;
 };
 

--- a/apps/hobbies-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/hobbies-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -34,10 +34,26 @@ export const getUriID = (slugs: string[], locale: AppLanguage): string => {
   return `/${slugs.join('/')}/`;
 };
 
+export const removeInternalDoublePrefix = (slugs: string[]) => {
+  [
+    AppConfig.cmsArticlesContextPath.replace('/', ''),
+    AppConfig.cmsPagesContextPath.replace('/', ''),
+  ].forEach((internalUriSegment) => {
+    if (slugs[0] === internalUriSegment) {
+      slugs.shift();
+    }
+  });
+  // eslint-disable-next-line no-console
+  console.log('removeInternalDoublePrefix', { slugs });
+  return slugs;
+};
+
 export const getSlugFromUri = (uri?: string | null): string[] | null => {
   const uriWithoutLang = stripLocaleFromUri(uri ?? '');
   if (uriWithoutLang) {
-    return uriWithoutLang.split('/').filter((i) => i);
+    return removeInternalDoublePrefix(
+      uriWithoutLang.split('/').filter((i) => i)
+    );
   }
   return null;
 };

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -77,7 +77,7 @@ export async function getStaticPaths() {
   const pagePageInfos = await getAllPages();
   const paths = pagePageInfos
     .map((pageInfo) => ({
-      params: { slug: getSlugFromUri(pageInfo.slug) },
+      params: { slug: getSlugFromUri(pageInfo.uri) },
       locale: pageInfo.locale,
     }))
     // Remove the pages without a slug

--- a/apps/sports-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/sports-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -43,8 +43,6 @@ export const removeInternalDoublePrefix = (slugs: string[]) => {
       slugs.shift();
     }
   });
-  // eslint-disable-next-line no-console
-  console.log('removeInternalDoublePrefix', { slugs });
   return slugs;
 };
 

--- a/apps/sports-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/sports-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -34,10 +34,26 @@ export const getUriID = (slugs: string[], locale: AppLanguage): string => {
   return `/${slugs.join('/')}/`;
 };
 
+export const removeInternalDoublePrefix = (slugs: string[]) => {
+  [
+    AppConfig.cmsArticlesContextPath.replace('/', ''),
+    AppConfig.cmsPagesContextPath.replace('/', ''),
+  ].forEach((internalUriSegment) => {
+    if (slugs[0] === internalUriSegment) {
+      slugs.shift();
+    }
+  });
+  // eslint-disable-next-line no-console
+  console.log('removeInternalDoublePrefix', { slugs });
+  return slugs;
+};
+
 export const getSlugFromUri = (uri?: string | null): string[] | null => {
   const uriWithoutLang = stripLocaleFromUri(uri ?? '');
   if (uriWithoutLang) {
-    return uriWithoutLang.split('/').filter((i) => i);
+    return removeInternalDoublePrefix(
+      uriWithoutLang.split('/').filter((i) => i)
+    );
   }
   return null;
 };

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -77,7 +77,7 @@ export async function getStaticPaths() {
   const pagePageInfos = await getAllPages();
   const paths = pagePageInfos
     .map((pageInfo) => ({
-      params: { slug: getSlugFromUri(pageInfo.slug) },
+      params: { slug: getSlugFromUri(pageInfo.uri) },
       locale: pageInfo.locale,
     }))
     // Remove the pages without a slug

--- a/packages/common-tests/browser-tests/page-model/consent-modal.ts
+++ b/packages/common-tests/browser-tests/page-model/consent-modal.ts
@@ -5,9 +5,11 @@ abstract class ConsentModal {
   protected abstract get appName(): string;
 
   private get title() {
-    return screen.findByRole('heading', {
-      name: `${this.appName} käyttää evästeitä`,
-    });
+    return screen
+      .findByRole('heading', {
+        name: `${this.appName} käyttää evästeitä`,
+      })
+      .with({ timeout: 3000 });
   }
 
   private get acceptAllCookiesButton() {
@@ -33,10 +35,10 @@ abstract class ConsentModal {
   }
 
   public async isOpened() {
-    await t.expect(this.title.exists).ok();
+    await t.expect(this.title.exists).ok({ timeout: 3000 });
   }
   public async isClosed() {
-    await t.expect(this.title.exists).notOk();
+    await t.expect(this.title.exists).notOk({ timeout: 3000 });
   }
 }
 

--- a/packages/common-tests/browser-tests/page-model/consent-modal.ts
+++ b/packages/common-tests/browser-tests/page-model/consent-modal.ts
@@ -1,6 +1,9 @@
 import { screen } from '@testing-library/testcafe';
 import { t } from 'testcafe';
 
+// TODO: If the ConsentModal could be used as a generic class,
+// the  implementing classes could be deleted from the apps.
+// More details: https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/95#discussion_r1050459925
 abstract class ConsentModal {
   protected abstract get appName(): string;
 

--- a/packages/common-tests/browser-tests/page-model/consent-modal.ts
+++ b/packages/common-tests/browser-tests/page-model/consent-modal.ts
@@ -5,11 +5,9 @@ abstract class ConsentModal {
   protected abstract get appName(): string;
 
   private get title() {
-    return screen
-      .findByRole('heading', {
-        name: `${this.appName} käyttää evästeitä`,
-      })
-      .with({ timeout: 3000 });
+    return screen.findByRole('heading', {
+      name: `${this.appName} käyttää evästeitä`,
+    });
   }
 
   private get acceptAllCookiesButton() {
@@ -35,10 +33,10 @@ abstract class ConsentModal {
   }
 
   public async isOpened() {
-    await t.expect(this.title.exists).ok({ timeout: 3000 });
+    await t.expect(this.title.exists).ok();
   }
   public async isClosed() {
-    await t.expect(this.title.exists).notOk({ timeout: 3000 });
+    await t.expect(this.title.exists).notOk();
   }
 }
 

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -53,31 +53,37 @@ class EventSearchPage {
     return screen.queryByText(notFoundText);
   }
 
-  public async makeSuccessfulSearch() {
-    await t.typeText(this.autoSuggestInput, this.searchText);
-    await t.click(this.searchButton);
+  public async expectSearchResults() {
     t.expect(this.notFoundResult.exists).notOk;
     const results = this.results;
     await t.expect(results.count).gte(1); // At least one result should be found
     await t.expect(results.count).lte(10); // max 10 result per page
   }
 
-  public async makeUnsuccessfulSearch() {
+  public async expectNoSearchResults() {
+    t.expect(this.notFoundResult.exists).ok;
+    await t.expect(this.results.count).eql(0); // no cards returned
+  }
+
+  public async doSuccessfulSearch() {
+    await t.typeText(this.autoSuggestInput, this.searchText);
+    await t.click(this.searchButton);
+    await this.expectSearchResults();
+  }
+
+  public async doUnsuccessfulSearch() {
     await t.typeText(
       this.autoSuggestInput,
       'thisisatextthatverylikelycannotbefound'
     );
     await t.click(this.searchButton);
-    t.expect(this.notFoundResult.exists).ok;
-    await t.expect(this.results.count).eql(0); // no cards returned
+    await this.expectNoSearchResults();
   }
 
   public async verify() {
     // eslint-disable-next-line no-console
     console.log('EventSearchPage: verify');
     await t.expect(this.searchFormHeading.exists).ok();
-    await this.makeSuccessfulSearch();
-    await this.makeUnsuccessfulSearch();
   }
 }
 

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -80,7 +80,9 @@ class EventSearchPage {
       this.autoSuggestInput,
       'thisisatextthatverylikelycannotbefound'
     );
+    await t.pressKey('tab'); // The menu can be too big, so that it hides the search button, so an unfocus event must be triggered.
     await t.click(this.searchButton);
+    await t.wait(2000);
     await this.expectNoSearchResults();
   }
 

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -66,12 +66,16 @@ class EventSearchPage {
   }
 
   public async doSuccessfulSearch() {
+    // eslint-disable-next-line no-console
+    console.info('EventSearchPage: doSuccessfulSearch');
     await t.typeText(this.autoSuggestInput, this.searchText);
     await t.click(this.searchButton);
     await this.expectSearchResults();
   }
 
   public async doUnsuccessfulSearch() {
+    // eslint-disable-next-line no-console
+    console.info('EventSearchPage: doUnsuccessfulSearch');
     await t.typeText(
       this.autoSuggestInput,
       'thisisatextthatverylikelycannotbefound'
@@ -82,7 +86,7 @@ class EventSearchPage {
 
   public async verify() {
     // eslint-disable-next-line no-console
-    console.log('EventSearchPage: verify');
+    console.info('EventSearchPage: verify');
     await t.expect(this.searchFormHeading.exists).ok();
   }
 }

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -1,0 +1,84 @@
+import { screen } from '@testing-library/testcafe';
+import { t } from 'testcafe';
+import { initTestI18n as i18n } from '../../../common-i18n/src';
+import type { AppNamespace } from '../types/app-namespace';
+
+class EventSearchPage {
+  searchText = 'helsinki';
+  private appNamespace: 'appHobbies' | 'appEvents' | 'appSports';
+
+  constructor(appNamespace: AppNamespace) {
+    this.appNamespace = appNamespace;
+  }
+
+  protected get searchFormHeading() {
+    const searchHeadingText = i18n.t(`search:search.labelSearchField`);
+    return screen.getByRole('heading', {
+      name: searchHeadingText,
+    });
+  }
+
+  protected get searchButton() {
+    const searchButtonText = i18n.t(`search:search.buttonSearch`);
+    return screen.getByRole('button', {
+      name: searchButtonText,
+    });
+  }
+
+  protected get autoSuggestInput() {
+    const searchPlaceholderText = i18n.t(
+      `${this.appNamespace}:search.search.placeholder`
+    );
+    return screen.getByPlaceholderText(searchPlaceholderText);
+  }
+
+  protected get buttonLoadMore() {
+    const loadMoreText = i18n.t('search:buttonLoadMore');
+    return screen.queryByRole('button', {
+      name: loadMoreText,
+    });
+  }
+
+  protected get results() {
+    const cardLinkRoleName = i18n
+      .t('event:eventCard.ariaLabelLink')
+      .replace('{{name}}', '*.');
+    return screen.queryAllByRole('link', {
+      name: new RegExp(cardLinkRoleName, 'i'),
+    });
+  }
+
+  protected get notFoundResult() {
+    const notFoundText = i18n.t('search:searchNotification');
+    return screen.queryByText(notFoundText);
+  }
+
+  public async makeSuccessfulSearch() {
+    await t.typeText(this.autoSuggestInput, this.searchText);
+    await t.click(this.searchButton);
+    t.expect(this.notFoundResult.exists).notOk;
+    const results = this.results;
+    await t.expect(results.count).gte(1); // At least one result should be found
+    await t.expect(results.count).lte(10); // max 10 result per page
+  }
+
+  public async makeUnsuccessfulSearch() {
+    await t.typeText(
+      this.autoSuggestInput,
+      'thisisatextthatverylikelycannotbefound'
+    );
+    await t.click(this.searchButton);
+    t.expect(this.notFoundResult.exists).ok;
+    await t.expect(this.results.count).eql(0); // no cards returned
+  }
+
+  public async verify() {
+    // eslint-disable-next-line no-console
+    console.log('EventSearchPage: verify');
+    await t.expect(this.searchFormHeading.exists).ok();
+    await this.makeSuccessfulSearch();
+    await this.makeUnsuccessfulSearch();
+  }
+}
+
+export default EventSearchPage;

--- a/packages/common-tests/browser-tests/page-model/index.ts
+++ b/packages/common-tests/browser-tests/page-model/index.ts
@@ -1,3 +1,4 @@
 export { default as ConsentModal } from './consent-modal';
 export { default as Header } from './header';
 export { default as LandingPage } from './landingPage';
+export { default as EventSearchPage } from './eventSearchPage';


### PR DESCRIPTION
HH-255. This PR was originally to handle the dynamic pages root-path so that it would always be translated, but I couldn't find a reasonable way to implement such a feature this time. However, these were done while investigating and planning the (self) requested feature:
1. add browser test base for a search page
2. Fix the dynamic pages get static path

The pages were generated wrongly on build time - the path was not right!