### PR TITLE
Add better logging for apollo client errors

### DIFF
--- a/apps/events-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/events-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -140,7 +140,8 @@ export const getDefaultCollections = (
   getRoutedInternalHref: RCHCConfig['utils']['getRoutedInternalHref'],
   currentLanguageCode: RCHCConfig['currentLanguageCode']
 ) =>
-  getCollections(page?.modules ?? [], true)?.reduce(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getCollections(page?.modules?.filter((m: any) => !!m) ?? [], true)?.reduce(
     (collectionElements: JSX.Element[], collection) => {
       const commonCollectionProps = {
         key: `collection-${Math.random()}`,

--- a/apps/events-helsinki/src/common-events/utils/headless-cms/service.tsx
+++ b/apps/events-helsinki/src/common-events/utils/headless-cms/service.tsx
@@ -10,7 +10,7 @@ import {
   PostsDocument,
   PagesDocument,
 } from 'react-helsinki-headless-cms/apollo';
-import { createApolloClient } from 'domain/clients/eventsFederationApolloClient';
+import { createApolloClient } from '../../../domain/clients/eventsFederationApolloClient';
 
 export const ARTICLES_AMOUNT_LIMIT = 100;
 export const PAGES_AMOUNT_LIMIT = 100;

--- a/apps/events-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/events-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -25,7 +25,7 @@ import {
 import type { LanguageString } from 'events-helsinki-components';
 import capitalize from 'lodash/capitalize';
 import { useMemo } from 'react';
-import { logger } from '../../logger';
+import { graphqlClientLogger } from '../../logger';
 import { rewriteInternalURLs } from '../../utils/routerUtils';
 import AppConfig from '../app/AppConfig';
 
@@ -46,7 +46,7 @@ function getHttpLink(uri: string) {
     AppConfig.allowUnauthorizedRequests &&
     new URL(uri).protocol === 'https:'
   ) {
-    logger.info('Allowing unauthorized requests');
+    graphqlClientLogger.info('Allowing unauthorized requests');
     options = {
       ...options,
       fetchOptions: {
@@ -81,10 +81,12 @@ export function createApolloClient() {
     if (graphQLErrors) {
       graphQLErrors.forEach(({ message, locations, path }) => {
         const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
+        graphqlClientLogger.error(errorMessage);
         Sentry.captureMessage(errorMessage);
       });
     }
     if (networkError) {
+      graphqlClientLogger.error(networkError);
       Sentry.captureMessage('Network error');
     }
   });

--- a/apps/events-helsinki/src/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
+++ b/apps/events-helsinki/src/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
@@ -14,10 +14,7 @@ import {
   fakeTargetGroup,
 } from '@/test-utils/mockDataUtils';
 import { createEventListRequestAndResultMocks } from '@/test-utils/mocks/eventListMocks';
-import SimilarEvents, {
-  similarEventsContainerTestId,
-  similarEventsLoadingSpinnerTestId,
-} from '../SimilarEvents';
+import SimilarEvents from '../SimilarEvents';
 
 const id = '1';
 const name = 'Event title';

--- a/apps/hobbies-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/hobbies-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -140,7 +140,8 @@ export const getDefaultCollections = (
   getRoutedInternalHref: RCHCConfig['utils']['getRoutedInternalHref'],
   currentLanguageCode: RCHCConfig['currentLanguageCode']
 ) =>
-  getCollections(page?.modules ?? [], true)?.reduce(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getCollections(page?.modules?.filter((m: any) => !!m) ?? [], true)?.reduce(
     (collectionElements: JSX.Element[], collection) => {
       const commonCollectionProps = {
         key: `collection-${Math.random()}`,

--- a/apps/hobbies-helsinki/src/common-events/utils/headless-cms/service.tsx
+++ b/apps/hobbies-helsinki/src/common-events/utils/headless-cms/service.tsx
@@ -16,7 +16,7 @@ import {
   PostsDocument,
   PagesDocument,
 } from 'react-helsinki-headless-cms/apollo';
-import { createApolloClient } from 'domain/clients/eventsFederationApolloClient';
+import { createApolloClient } from '../../../domain/clients/eventsFederationApolloClient';
 
 export const ARTICLES_AMOUNT_LIMIT = 100;
 export const PAGES_AMOUNT_LIMIT = 100;

--- a/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/hobbies-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -26,7 +26,7 @@ import {
 import type { LanguageString } from 'events-helsinki-components';
 import capitalize from 'lodash/capitalize';
 import { useMemo } from 'react';
-import { logger } from '../../logger';
+import { graphqlClientLogger } from '../../logger';
 import { rewriteInternalURLs } from '../../utils/routerUtils';
 import AppConfig from '../app/AppConfig';
 
@@ -47,7 +47,7 @@ function getHttpLink(uri: string) {
     AppConfig.allowUnauthorizedRequests &&
     new URL(uri).protocol === 'https:'
   ) {
-    logger.info('Allowing unauthorized requests');
+    graphqlClientLogger.info('Allowing unauthorized requests');
     options = {
       ...options,
       fetchOptions: {
@@ -82,10 +82,12 @@ export function createApolloClient() {
     if (graphQLErrors) {
       graphQLErrors.forEach(({ message, locations, path }) => {
         const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
+        graphqlClientLogger.error(errorMessage);
         Sentry.captureMessage(errorMessage);
       });
     }
     if (networkError) {
+      graphqlClientLogger.error(networkError);
       Sentry.captureMessage('Network error');
     }
   });

--- a/apps/sports-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/apps/sports-helsinki/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -140,7 +140,8 @@ export const getDefaultCollections = (
   getRoutedInternalHref: RCHCConfig['utils']['getRoutedInternalHref'],
   currentLanguageCode: RCHCConfig['currentLanguageCode']
 ) =>
-  getCollections(page?.modules ?? [], true)?.reduce(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getCollections(page?.modules?.filter((m: any) => !!m) ?? [], true)?.reduce(
     (collectionElements: JSX.Element[], collection) => {
       const commonCollectionProps = {
         key: `collection-${Math.random()}`,

--- a/apps/sports-helsinki/src/common-events/utils/headless-cms/service.tsx
+++ b/apps/sports-helsinki/src/common-events/utils/headless-cms/service.tsx
@@ -16,7 +16,7 @@ import {
   PostsDocument,
   PagesDocument,
 } from 'react-helsinki-headless-cms/apollo';
-import { createApolloClient } from 'domain/clients/eventsFederationApolloClient';
+import { createApolloClient } from '../../../domain/clients/eventsFederationApolloClient';
 
 export const ARTICLES_AMOUNT_LIMIT = 100;
 export const PAGES_AMOUNT_LIMIT = 100;

--- a/apps/sports-helsinki/src/domain/clients/eventsFederationApolloClient.ts
+++ b/apps/sports-helsinki/src/domain/clients/eventsFederationApolloClient.ts
@@ -26,7 +26,7 @@ import {
 } from 'events-helsinki-components';
 import capitalize from 'lodash/capitalize';
 import { useMemo } from 'react';
-import { logger } from '../../logger';
+import { graphqlClientLogger } from '../../logger';
 import { rewriteInternalURLs } from '../../utils/routerUtils';
 import AppConfig from '../app/AppConfig';
 
@@ -47,7 +47,7 @@ function getHttpLink(uri: string) {
     AppConfig.allowUnauthorizedRequests &&
     new URL(uri).protocol === 'https:'
   ) {
-    logger.info('Allowing unauthorized requests');
+    graphqlClientLogger.info('Allowing unauthorized requests');
     options = {
       ...options,
       fetchOptions: {
@@ -82,10 +82,12 @@ export function createApolloClient() {
     if (graphQLErrors) {
       graphQLErrors.forEach(({ message, locations, path }) => {
         const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
+        graphqlClientLogger.error(errorMessage);
         Sentry.captureMessage(errorMessage);
       });
     }
     if (networkError) {
+      graphqlClientLogger.error(networkError);
       Sentry.captureMessage('Network error');
     }
   });


### PR DESCRIPTION
HH-264.
- Log errors of the graphql-client by using graphql-client-logger. Use graphql-client-logger for errors given by the error link.
- Fix the issues when an empty or wrongly created CMS-page has a bad list of modules and
the page render fails while collecting the page's for the render process.
- remove unused imports

New logging when a connection to a server is lost:
```
event - compiled client and server successfully in 344 ms (2589 modules)
11:32:25 [error] [graphql-client] - FetchError: request to http://localhost:4000/ failed, reason: connect ECONNREFUSED 127.0.0.1:4000
11:32:25 [error] [staticGeneration] - Error while generating a page:
```

Fixed the getCollections issue:
```
error - TypeError: Cannot use 'in' operator to search for 'title' in null
    at /Users/nikojmakela/Code/ratkaisutoimisto/events-helsinki-monorepo/node_modules/react-helsinki-headless-cms/cjs/archiveSearchPageContent.module-02c491b5.js:2110:22
```