### PR TITLE
fix: course selection carousels

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -73,7 +73,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha65",
+    "react-helsinki-headless-cms": "1.0.0-alpha69",
     "react-i18next": "11.18.6",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/events-helsinki/src/common-events/utils/headless-cms/service.tsx
+++ b/apps/events-helsinki/src/common-events/utils/headless-cms/service.tsx
@@ -39,7 +39,7 @@ export const getAllArticles = async (): Promise<PageInfo[]> => {
         locale: node.language.code.toLowerCase(),
         slug: node.slug,
       });
-      node.translations?.forEach((translation) => {
+      node.translations?.forEach((translation: PageType['translations']) => {
         if (
           translation?.uri &&
           translation.slug &&
@@ -86,7 +86,7 @@ export const getAllPages = async (): Promise<PageInfo[]> => {
         locale: node.language.code.toLowerCase(),
         slug: node.slug,
       });
-      node.translations?.forEach((translation) => {
+      node.translations?.forEach((translation: PageType['translations']) => {
         if (
           translation?.uri &&
           translation.slug &&

--- a/apps/hobbies-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/hobbies-helsinki/config/jest/mockDataUtils.ts
@@ -59,6 +59,7 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       audience: [],
       keywords: [fakeKeyword()],
       location: fakePlace(),
+      locationExtraInfo: null,
       startTime: '2020-07-13T05:51:05.761000Z',
       endTime: null,
       datePublished: null,

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -73,7 +73,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha65",
+    "react-helsinki-headless-cms": "1.0.0-alpha69",
     "react-i18next": "11.18.6",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/hobbies-helsinki/src/common-events/utils/headless-cms/service.tsx
+++ b/apps/hobbies-helsinki/src/common-events/utils/headless-cms/service.tsx
@@ -45,7 +45,7 @@ export const getAllArticles = async (): Promise<PageInfo[]> => {
         locale: node.language.code.toLowerCase(),
         slug: node.slug,
       });
-      node.translations?.forEach((translation) => {
+      node.translations?.forEach((translation: PageType['translations']) => {
         if (
           translation?.uri &&
           translation.slug &&
@@ -92,7 +92,7 @@ export const getAllPages = async (): Promise<PageInfo[]> => {
         locale: node.language.code.toLowerCase(),
         slug: node.slug,
       });
-      node.translations?.forEach((translation) => {
+      node.translations?.forEach((translation: PageType['translations']) => {
         if (
           translation?.uri &&
           translation.slug &&

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -73,7 +73,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha65",
+    "react-helsinki-headless-cms": "1.0.0-alpha69",
     "react-i18next": "11.18.6",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/sports-helsinki/src/common-events/utils/headless-cms/service.tsx
+++ b/apps/sports-helsinki/src/common-events/utils/headless-cms/service.tsx
@@ -45,7 +45,7 @@ export const getAllArticles = async (): Promise<PageInfo[]> => {
         locale: node.language.code.toLowerCase(),
         slug: node.slug,
       });
-      node.translations?.forEach((translation) => {
+      node.translations?.forEach((translation: PageType['translations']) => {
         if (
           translation?.uri &&
           translation.slug &&
@@ -92,7 +92,7 @@ export const getAllPages = async (): Promise<PageInfo[]> => {
         locale: node.language.code.toLowerCase(),
         slug: node.slug,
       });
-      node.translations?.forEach((translation) => {
+      node.translations?.forEach((translation: PageType['translations']) => {
         if (
           translation?.uri &&
           translation.slug &&

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -62,7 +62,7 @@
     "react-content-loader": "6.2.0",
     "react-datepicker": "4.8.0",
     "react-dom": ">=17.0.2",
-    "react-helsinki-headless-cms": "1.0.0-alpha65",
+    "react-helsinki-headless-cms": "1.0.0-alpha69",
     "react-i18next": "11.18.6",
     "sanitize-html": "2.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13159,7 +13159,7 @@ __metadata:
     react-content-loader: "npm:6.2.0"
     react-datepicker: "npm:4.8.0"
     react-dom: "npm:>=17.0.2"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha65"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha69"
     react-i18next: "npm:11.18.6"
     require-from-string: "npm:2.0.2"
     rimraf: "npm:3.0.2"
@@ -13335,7 +13335,7 @@ __metadata:
     react-content-loader: "npm:^6.2.0"
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha65"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha69"
     react-i18next: "npm:11.18.6"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"
@@ -15504,7 +15504,7 @@ __metadata:
     react-content-loader: "npm:^6.2.0"
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha65"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha69"
     react-i18next: "npm:11.18.6"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"
@@ -23543,9 +23543,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha65":
-  version: 1.0.0-alpha65
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha65"
+"react-helsinki-headless-cms@npm:1.0.0-alpha69":
+  version: 1.0.0-alpha69
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha69"
   dependencies:
     hds-design-tokens: "npm:^2.3.0"
     html-react-parser: "npm:^1.4.8"
@@ -23559,7 +23559,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: 7f8f3ab1bc4b212575e394958ed1a6aaf7d991f4bb66f186cea1de905e1dcabea5588fb4d3399d28e7d3baf9ac4ecac873388793d21175bbfb3b1612491fa96b
+  checksum: 57f9842bc2345dccc3f060d38ca162dbadde9721b5532d410fa6614920302cadb68f191087a8f1a454623a09322581461b2f25690342afb2ca11f5a7cf2fc217
   languageName: node
   linkType: hard
 
@@ -25842,7 +25842,7 @@ __metadata:
     react-content-loader: "npm:^6.2.0"
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha65"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha69"
     react-i18next: "npm:11.18.6"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"


### PR DESCRIPTION
HH-266.
HCRC-lib's event selection carousel did not work properly for the course-event-type.
The event-type must always be given when fetching courses - even then when fetching with direct ids.