### PR TITLE
Tune landing page category search shortcuts

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -33,6 +33,7 @@ import {
   getEventCategoryOptions,
   getSearchFilters,
   getSearchQuery,
+  sortExtendedCategoryOptions,
 } from './utils';
 
 interface Props {
@@ -104,7 +105,9 @@ const AdvancedSearch: React.FC<Props> = ({
 
   // const divisionOptions = useDivisionOptions();
 
-  const categories = getEventCategoryOptions(t);
+  const categories = getEventCategoryOptions(t).sort(
+    sortExtendedCategoryOptions
+  );
 
   const goToSearch = (search: string): void => {
     router.push({

--- a/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -73,15 +73,33 @@ export enum EVENT_SEARCH_FILTERS {
   TEXT = 'text',
 }
 
-export const CATEGORY_CATALOG: Record<
-  EventTypeId,
-  Record<string, EVENT_CATEGORIES[]>
-> = {
+export const CATEGORY_CATALOG = {
   [EventTypeId.General]: {
-    default: Object.values(EVENT_CATEGORIES),
+    default: [
+      EVENT_CATEGORIES.MOVIE,
+      EVENT_CATEGORIES.CULTURE,
+      EVENT_CATEGORIES.SPORT,
+      EVENT_CATEGORIES.NATURE,
+      EVENT_CATEGORIES.MUSEUM,
+      EVENT_CATEGORIES.MUSIC,
+      EVENT_CATEGORIES.INFLUENCE,
+      EVENT_CATEGORIES.FOOD,
+      EVENT_CATEGORIES.DANCE,
+      EVENT_CATEGORIES.THEATRE,
+    ],
+    landingPage: [
+      EVENT_CATEGORIES.MOVIE,
+      EVENT_CATEGORIES.CULTURE,
+      EVENT_CATEGORIES.SPORT,
+      EVENT_CATEGORIES.NATURE,
+      EVENT_CATEGORIES.MUSEUM,
+      EVENT_CATEGORIES.MUSIC,
+      EVENT_CATEGORIES.DANCE,
+      EVENT_CATEGORIES.THEATRE,
+    ],
   },
   [EventTypeId.Course]: {},
-} as const;
+};
 
 export const CULTURE_KEYWORDS: readonly string[] = [
   'kulke:33', // Teatteri

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -61,11 +61,9 @@ export const getEventCategoryOptions = (
   t: TFunction,
   categories: EVENT_CATEGORIES[] = CATEGORY_CATALOG[EventTypeId.General].default
 ): CategoryOption[] =>
-  categories
-    .map((category) =>
-      getCategoryOptions(category, eventCategories[category], t)
-    )
-    .sort(sortExtendedCategoryOptions);
+  categories.map((category) =>
+    getCategoryOptions(category, eventCategories[category], t)
+  );
 
 /**
  * Get start and end dates to event list filtering

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -1,5 +1,9 @@
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
-import { useLocale, useCommonTranslation } from 'events-helsinki-components';
+import {
+  useLocale,
+  useCommonTranslation,
+  EventTypeId,
+} from 'events-helsinki-components';
 import { useRouter } from 'next/router';
 import React from 'react';
 
@@ -8,7 +12,10 @@ import {
   getI18nPath,
   getParsedUrlQueryInput,
 } from '../../../utils/routerUtils';
-import { EVENT_DEFAULT_SEARCH_FILTERS } from '../eventSearch/constants';
+import {
+  CATEGORY_CATALOG,
+  EVENT_DEFAULT_SEARCH_FILTERS,
+} from '../eventSearch/constants';
 import { getEventCategoryOptions, getSearchQuery } from '../eventSearch/utils';
 import styles from './landingPageSearch.module.scss';
 import LandingPageSearchForm from './LandingPageSearchForm';
@@ -62,7 +69,10 @@ const Search: React.FC = () => {
     goToSearchPage(search);
   };
 
-  const categories = getEventCategoryOptions(t);
+  const categories = getEventCategoryOptions(
+    t,
+    CATEGORY_CATALOG[EventTypeId.General].landingPage
+  );
 
   return (
     <div>


### PR DESCRIPTION
Removed "influence" and "food" categories from the landing page search shortcuts, and applied a custom ordering for the shortcuts that is the same for all the languages. In contrast, The advanced search page category filter still has all the categories sorted alphabetically as before.

### Closes

**[TH-1285](https://helsinkisolutionoffice.atlassian.net/browse/TH-1285)**

## Screenshots

<img width="1398" alt="Screenshot 2022-12-13 at 22 26 49" src="https://user-images.githubusercontent.com/1314604/207437611-24afce7e-1e5d-4312-b754-b647eae83e2f.png">
<img width="1375" alt="Screenshot 2022-12-13 at 22 33 36" src="https://user-images.githubusercontent.com/1314604/207437873-1b0fd40e-6071-47b5-92e4-1b3c6e28fab4.png">
