### PR TITLE
feat: enable HDS server side rendering support

### DIFF
--- a/apps/events-helsinki/src/pages/_document.tsx
+++ b/apps/events-helsinki/src/pages/_document.tsx
@@ -1,0 +1,1 @@
+export { Document as default } from 'events-helsinki-components';

--- a/apps/hobbies-helsinki/src/pages/_document.tsx
+++ b/apps/hobbies-helsinki/src/pages/_document.tsx
@@ -1,0 +1,1 @@
+export { Document as default } from 'events-helsinki-components';

--- a/apps/sports-helsinki/src/pages/_document.tsx
+++ b/apps/sports-helsinki/src/pages/_document.tsx
@@ -1,0 +1,1 @@
+export { Document as default } from 'events-helsinki-components';

--- a/packages/components/src/components/document/Document.tsx
+++ b/packages/components/src/components/document/Document.tsx
@@ -1,0 +1,39 @@
+import * as hds from 'hds-react';
+import { getCriticalHdsRules } from 'hds-react';
+import NextJsDocument, { Html, Head, Main, NextScript } from 'next/document';
+import type { DocumentContext, DocumentProps } from 'next/document';
+
+type Props = {
+  hdsCriticalRules: string;
+} & DocumentProps;
+
+class Document extends NextJsDocument<Props> {
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await NextJsDocument.getInitialProps(ctx);
+    const hdsCriticalRules = await getCriticalHdsRules(
+      initialProps.html,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (hds as any).hdsStyles
+    );
+
+    return { ...initialProps, hdsCriticalRules };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <style
+            data-used-styles
+            dangerouslySetInnerHTML={{ __html: this.props.hdsCriticalRules }}
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+export default Document;

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -35,3 +35,4 @@ export { default as EllipsedTextWithToggle } from './ellipsedTextWithToggle/Elli
 export { default as InfoBlock } from './infoBlock/InfoBlock';
 export { default as MapBox } from './mapBox/MapBox';
 // export { default as MapView } from './mapView/MapView';
+export { default as Document } from './document/Document';


### PR DESCRIPTION
This fixes the issue where a huge HKI logo flashes briefly when a user navigates to the site. The implementation is pretty much directly copy-pasted from [linkedregistrations-ui](https://github.com/City-of-Helsinki/linkedregistrations-ui/blob/7542320c8e2df6349799a1404fecca4a809519ae/src/pages/_document.tsx).

### Closes

**[HH-276](https://helsinkisolutionoffice.atlassian.net/browse/HH-276): Helsinki logo flashes full page size in the beginning of a page load**
