### PR TITLE
fix: stylings of input outlines

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -73,7 +73,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha74",
+    "react-helsinki-headless-cms": "1.0.0-alpha75",
     "react-i18next": "11.18.6",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/events-helsinki/src/common-events/components/search/SearchAutosuggest.tsx
+++ b/apps/events-helsinki/src/common-events/components/search/SearchAutosuggest.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
 import {
   AutoSuggestMenu,
@@ -35,6 +36,7 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
   const input = React.useRef<HTMLInputElement | null>(null);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const internalInputValue = useDebounce(searchValue, 300);
+  const [isAutosugestFocused, setIsAutosugestFocused] = React.useState(false);
 
   const { data: keywordsData, loading: loadingKeywords } = useKeywordListQuery({
     skip: !internalInputValue,
@@ -187,6 +189,12 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
 
   const handleInputFocus = () => {
     ensureMenuIsOpen();
+    setIsAutosugestFocused(true);
+  };
+
+  const handleInputBlur = () => {
+    ensureMenuIsOpen();
+    setIsAutosugestFocused(false);
   };
 
   React.useEffect(() => {
@@ -210,7 +218,10 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
       onClick={handleComponentClick}
-      className={styles.searchAutosuggest}
+      className={classNames(
+        styles.searchAutosuggest,
+        isAutosugestFocused && styles.focused
+      )}
       ref={container}
     >
       <div className={styles.iconWrapper}>
@@ -223,6 +234,7 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
           name={name}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
           placeholder={placeholder}
           type="text"
           value={searchValue}

--- a/apps/events-helsinki/src/common-events/components/search/searchAutosuggest.module.scss
+++ b/apps/events-helsinki/src/common-events/components/search/searchAutosuggest.module.scss
@@ -6,6 +6,11 @@
   padding: 0 1rem;
   align-items: center;
   box-sizing: border-box;
+  border: 2px solid var(--color-white);
+  &.focused {
+    outline: 3px solid var(--color-coat-of-arms);
+    outline-offset: 2px;
+  }
 
   .iconWrapper {
     display: flex;

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -73,7 +73,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha74",
+    "react-helsinki-headless-cms": "1.0.0-alpha75",
     "react-i18next": "11.18.6",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/hobbies-helsinki/src/common-events/components/search/SearchAutosuggest.tsx
+++ b/apps/hobbies-helsinki/src/common-events/components/search/SearchAutosuggest.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
 import {
   AutoSuggestMenu,
@@ -34,6 +35,7 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
   const container = React.useRef<HTMLDivElement | null>(null);
   const input = React.useRef<HTMLInputElement | null>(null);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  const [isAutosugestFocused, setIsAutosugestFocused] = React.useState(false);
   const internalInputValue = useDebounce(searchValue, 300);
 
   const { data: keywordsData, loading: loadingKeywords } = useKeywordListQuery({
@@ -187,6 +189,12 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
 
   const handleInputFocus = () => {
     ensureMenuIsOpen();
+    setIsAutosugestFocused(true);
+  };
+
+  const handleInputBlur = () => {
+    ensureMenuIsOpen();
+    setIsAutosugestFocused(false);
   };
 
   React.useEffect(() => {
@@ -210,7 +218,10 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
       onClick={handleComponentClick}
-      className={styles.searchAutosuggest}
+      className={classNames(
+        styles.searchAutosuggest,
+        isAutosugestFocused && styles.focused
+      )}
       ref={container}
     >
       <div className={styles.iconWrapper}>
@@ -223,6 +234,7 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
           name={name}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
           placeholder={placeholder}
           type="text"
           value={searchValue}

--- a/apps/hobbies-helsinki/src/common-events/components/search/searchAutosuggest.module.scss
+++ b/apps/hobbies-helsinki/src/common-events/components/search/searchAutosuggest.module.scss
@@ -6,6 +6,11 @@
   padding: 0 1rem;
   align-items: center;
   box-sizing: border-box;
+  border: 2px solid var(--color-white);
+  &.focused {
+    outline: 3px solid var(--color-coat-of-arms);
+    outline-offset: 2px;
+  }
 
   .iconWrapper {
     display: flex;

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha74",
+    "react-helsinki-headless-cms": "1.0.0-alpha75",
     "react-i18next": "11.18.6",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/sports-helsinki/src/common-events/components/search/SearchAutosuggest.tsx
+++ b/apps/sports-helsinki/src/common-events/components/search/SearchAutosuggest.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { AutosuggestMenuOption } from 'events-helsinki-components';
 import {
   AutoSuggestMenu,
@@ -34,6 +35,7 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
   const container = React.useRef<HTMLDivElement | null>(null);
   const input = React.useRef<HTMLInputElement | null>(null);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  const [isAutosugestFocused, setIsAutosugestFocused] = React.useState(false);
   const internalInputValue = useDebounce(searchValue, 300);
 
   const { data: keywordsData, loading: loadingKeywords } = useKeywordListQuery({
@@ -187,6 +189,12 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
 
   const handleInputFocus = () => {
     ensureMenuIsOpen();
+    setIsAutosugestFocused(true);
+  };
+
+  const handleInputBlur = () => {
+    ensureMenuIsOpen();
+    setIsAutosugestFocused(false);
   };
 
   React.useEffect(() => {
@@ -210,7 +218,10 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
       onClick={handleComponentClick}
-      className={styles.searchAutosuggest}
+      className={classNames(
+        styles.searchAutosuggest,
+        isAutosugestFocused && styles.focused
+      )}
       ref={container}
     >
       <div className={styles.iconWrapper}>
@@ -223,6 +234,7 @@ const SearchAutosuggest: React.FC<SearchAutosuggestProps> = ({
           name={name}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
           placeholder={placeholder}
           type="text"
           value={searchValue}

--- a/apps/sports-helsinki/src/common-events/components/search/searchAutosuggest.module.scss
+++ b/apps/sports-helsinki/src/common-events/components/search/searchAutosuggest.module.scss
@@ -6,6 +6,11 @@
   padding: 0 1rem;
   align-items: center;
   box-sizing: border-box;
+  border: 2px solid var(--color-white);
+  &.focused {
+    outline: 3px solid var(--color-coat-of-arms);
+    outline-offset: 2px;
+  }
 
   .iconWrapper {
     display: flex;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -62,7 +62,7 @@
     "react-content-loader": "6.2.0",
     "react-datepicker": "4.8.0",
     "react-dom": ">=17.0.2",
-    "react-helsinki-headless-cms": "1.0.0-alpha74",
+    "react-helsinki-headless-cms": "1.0.0-alpha75",
     "react-i18next": "11.18.6",
     "sanitize-html": "2.7.2"
   },

--- a/packages/components/src/components/dateSelector/dateSelector.module.scss
+++ b/packages/components/src/components/dateSelector/dateSelector.module.scss
@@ -15,8 +15,8 @@
     align-items: center;
 
     &:focus {
-      outline: 2px solid var(--color-primary-black);
-      outline-offset: -2px;
+      outline: 3px solid var(--color-coat-of-arms);
+      outline-offset: 2px;
     }
   }
 

--- a/packages/components/src/components/dateSelector/dateSelectorMenu.module.scss
+++ b/packages/components/src/components/dateSelector/dateSelectorMenu.module.scss
@@ -32,7 +32,7 @@
     }
 
     &:focus {
-      outline: 2px solid var(--color-primary-black);
+      outline: 2px solid var(--color-coat-of-arms);
       outline-offset: -2px;
     }
   }

--- a/packages/components/src/components/dropdownMenu/dropdownMenu.module.scss
+++ b/packages/components/src/components/dropdownMenu/dropdownMenu.module.scss
@@ -38,7 +38,7 @@
     }
 
     &:focus {
-      outline: 2px solid var(--color-primary-black);
+      outline: 2px solid var(--color-coat-of-arms);
       outline-offset: 0;
     }
   }

--- a/packages/components/src/components/multiSelectDropdown/multiSelectDropdown.module.scss
+++ b/packages/components/src/components/multiSelectDropdown/multiSelectDropdown.module.scss
@@ -20,7 +20,8 @@
     outline: none;
 
     &:focus {
-      border-color: var(--color-primary-black);
+      outline: 3px solid var(--color-coat-of-arms);
+      outline-offset: 2px;
     }
 
     svg {

--- a/packages/components/src/components/rangeDropdown/rangeDropdown.module.scss
+++ b/packages/components/src/components/rangeDropdown/rangeDropdown.module.scss
@@ -21,7 +21,8 @@
     outline: none;
 
     &:focus {
-      border-color: var(--color-primary-black);
+      outline: 3px solid var(--color-coat-of-arms);
+      outline-offset: 2px;
     }
 
     svg {

--- a/packages/components/src/components/search/autosuggestMenu.module.scss
+++ b/packages/components/src/components/search/autosuggestMenu.module.scss
@@ -29,7 +29,7 @@
         margin: 0;
       }
       &:focus {
-        outline: 2px solid var(--color-primary-black);
+        outline: 2px solid var(--color-coat-of-arms);
         outline-offset: 2px;
       }
     }

--- a/packages/components/src/components/search/searchAutosuggest.module.scss
+++ b/packages/components/src/components/search/searchAutosuggest.module.scss
@@ -6,6 +6,11 @@
   padding: 0 1rem;
   align-items: center;
   box-sizing: border-box;
+  border: 2px solid var(--color-white);
+  &.focused {
+    outline: 3px solid var(--color-coat-of-arms);
+    outline-offset: 2px;
+  }
 
   .iconWrapper {
     display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13690,7 +13690,7 @@ __metadata:
     react-content-loader: "npm:6.2.0"
     react-datepicker: "npm:4.8.0"
     react-dom: "npm:>=17.0.2"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha74"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha75"
     react-i18next: "npm:11.18.6"
     require-from-string: "npm:2.0.2"
     rimraf: "npm:3.0.2"
@@ -13866,7 +13866,7 @@ __metadata:
     react-content-loader: "npm:^6.2.0"
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha74"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha75"
     react-i18next: "npm:11.18.6"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"
@@ -16035,7 +16035,7 @@ __metadata:
     react-content-loader: "npm:^6.2.0"
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha74"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha75"
     react-i18next: "npm:11.18.6"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"
@@ -24109,9 +24109,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha74":
-  version: 1.0.0-alpha74
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha74"
+"react-helsinki-headless-cms@npm:1.0.0-alpha75":
+  version: 1.0.0-alpha75
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha75"
   dependencies:
     hds-design-tokens: "npm:^2.3.0"
     html-react-parser: "npm:^1.4.8"
@@ -24125,7 +24125,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: 0ce668bf1b94f5f063cae9510463fa4394ef95e8380aab584d55feefe9d72dcdf21b2a0828d850f0b9fe9f6f84b00504463068a03dbe21dc48ba60f85260b707
+  checksum: ee6eabca4c1d45eab2741301ce70375e473ee6c63a2951a508eb01ea531fceed103aca60e403fd2a0847a760a2ff9444603ea312ec193b86548690045139806d
   languageName: node
   linkType: hard
 
@@ -26415,7 +26415,7 @@ __metadata:
     react-content-loader: "npm:^6.2.0"
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha74"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha75"
     react-i18next: "npm:11.18.6"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"


### PR DESCRIPTION
## Description
All input fields in search forms (both frontpage and course search) now refactored to have coat of arms outline color due to the contrast issues
Border is removed from archive search box
Outline on focus fixed for autosuggest field

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/16116141/209123592-dea37b10-157c-4f18-a6d1-231fe34b4d08.png">


## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
