### PR TITLE
feat: only kids events search filter

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/AdvancedSearch.tsx
@@ -214,6 +214,17 @@ const AdvancedSearch: React.FC<Props> = ({
     goToSearch(search);
   };
 
+  const handleOnlyChildrenEventChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const search = getSearchQuery({
+      ...searchFilters,
+      onlyChildrenEvents: e.target.checked,
+    });
+
+    goToSearch(search);
+  };
+
   const clearInputValues = () => {
     setCategoryInput('');
     // setDivisionInput("");
@@ -327,15 +338,6 @@ const AdvancedSearch: React.FC<Props> = ({
             </div>
             <div className={styles.rowWrapper}>
               <div className={styles.row}>
-                {/* <div>
-                  <Checkbox
-                    className={styles.checkbox}
-                    checked={onlyChildrenEvents}
-                    id={EVENT_SEARCH_FILTERS.ONLY_CHILDREN_EVENTS}
-                    label={t("search.checkboxOnlyChildrenEvents")}
-                    onChange={handleOnlyChildrenEventChange}
-                  />
-                </div> */}
                 <div>
                   <Checkbox
                     className={styles.checkbox}
@@ -352,6 +354,19 @@ const AdvancedSearch: React.FC<Props> = ({
                     id={EVENT_SEARCH_FILTERS.ONLY_EVENING_EVENTS}
                     label={t('search.checkboxOnlyEveningEvents')}
                     onChange={handleOnlyEveningEventChange}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className={styles.rowWrapper}>
+              <div className={styles.row}>
+                <div>
+                  <Checkbox
+                    className={styles.checkbox}
+                    checked={onlyChildrenEvents}
+                    id={EVENT_SEARCH_FILTERS.ONLY_CHILDREN_EVENTS}
+                    label={t('search.checkboxOnlyChildrenEvents')}
+                    onChange={handleOnlyChildrenEventChange}
                   />
                 </div>
                 <div>

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -138,6 +138,21 @@ it.todo('should change search query after clicking autosuggest menu item');
 //   });
 // });
 
+it('should change search query after checking only children events checkbox', async () => {
+  const { router } = renderComponent();
+
+  const onlyChildrenEventsCheckbox = await screen.findByRole('checkbox', {
+    name: /näytä vain lastentapahtumat/i,
+  });
+
+  await userEvent.click(onlyChildrenEventsCheckbox);
+
+  expect(router).toMatchObject({
+    pathname,
+    query: { onlyChildrenEvents: 'true', text: 'jazz' },
+  });
+});
+
 it('should change search query after checking only evening events checkbox', async () => {
   const { router } = renderComponent();
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -65,6 +65,14 @@ describe('getEventSearchVariables function', () => {
     expect(keywords).toStrictEqual([]);
   });
 
+  it('should return correct keywordAnd if onlyChildrenEvents is selected', () => {
+    const { keywordAnd } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams('?onlyChildrenEvents=true'),
+    });
+    expect(keywordAnd).toContain('yso:p4354');
+  });
+
   it('should return start=now if start time is in past/today', () => {
     advanceTo('2020-10-06');
     const { start: start1 } = getEventSearchVariables({

--- a/apps/events-helsinki/src/domain/search/eventSearch/search.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/search.module.scss
@@ -43,7 +43,7 @@ $buttonWidth: 180px;
 
   .buttonWrapper {
     @include respond-above(m) {
-      grid-column: span 1 / 5;
+      grid-column: span 1 / 4;
     }
   }
 
@@ -56,7 +56,7 @@ $buttonWidth: 180px;
     }
 
     @include respond-above(m) {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -294,8 +294,8 @@ export const getSearchFilters = (searchParams: URLSearchParams): Filters => {
       searchParams,
       EVENT_SEARCH_FILTERS.KEYWORD_NOT
     ),
-    // onlyChildrenEvents:
-    //   searchParams.get(EVENT_SEARCH_FILTERS.ONLY_CHILDREN_EVENTS) === 'true',
+    onlyChildrenEvents:
+      searchParams.get(EVENT_SEARCH_FILTERS.ONLY_CHILDREN_EVENTS) === 'true',
     onlyEveningEvents:
       searchParams.get(EVENT_SEARCH_FILTERS.ONLY_EVENING_EVENTS) === 'true',
     onlyRemoteEvents:

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -71,6 +71,7 @@ class EventSearchPage {
     await t.typeText(this.autoSuggestInput, this.searchText);
     await t.pressKey('tab');
     await t.click(this.searchButton);
+    await t.wait(2000);
     await this.expectSearchResults();
   }
 

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -69,6 +69,7 @@ class EventSearchPage {
     // eslint-disable-next-line no-console
     console.info('EventSearchPage: doSuccessfulSearch');
     await t.typeText(this.autoSuggestInput, this.searchText);
+    await t.pressKey('tab');
     await t.click(this.searchButton);
     await this.expectSearchResults();
   }


### PR DESCRIPTION
## Description
-Adds Only event for kids search filter
-Implement the new advanced search component layout only for events helsinki

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/16116141/210076933-8e2d88b6-f1c9-4443-8785-303dc66f3a2d.png">


## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
