### PR TITLE
fix: rename typoed errorLoadMode to errorLoadMore

### DIFF
--- a/apps/events-helsinki/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/apps/events-helsinki/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -186,7 +186,7 @@ async function testToaster() {
 
   await waitFor(() => {
     expect(toast.error).toHaveBeenCalledWith(
-      translations.event.info.errorLoadMode
+      translations.event.info.errorLoadMore
     );
   });
 }

--- a/apps/events-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/events-helsinki/src/domain/event/queryUtils.ts
@@ -164,7 +164,7 @@ export const useSubEvents = (
           },
         });
       } catch (e) {
-        toast.error(t('info.errorLoadMode'));
+        toast.error(t('info.errorLoadMore'));
       }
       setIsFetchingMore(false);
     },

--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -77,7 +77,7 @@ const SearchPage: React.FC<{
           },
         });
       } catch (e) {
-        toast.error(t('search:errorLoadMode'));
+        toast.error(t('search:errorLoadMore'));
       }
     }
     setIsFetchingMore(false);

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -188,7 +188,7 @@ it('should show toastr message when loading next event page fails', async () => 
 
   await waitForComponentToBeLoaded();
 
-  expect(toast.error).toHaveBeenCalledWith(translations.search.errorLoadMode);
+  expect(toast.error).toHaveBeenCalledWith(translations.search.errorLoadMore);
 });
 
 it.todo('should scroll to event defined in react-router location state');

--- a/apps/hobbies-helsinki/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -186,7 +186,7 @@ async function testToaster() {
 
   await waitFor(() => {
     expect(toast.error).toHaveBeenCalledWith(
-      translations.event.info.errorLoadMode
+      translations.event.info.errorLoadMore
     );
   });
 }

--- a/apps/hobbies-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/hobbies-helsinki/src/domain/event/queryUtils.ts
@@ -166,7 +166,7 @@ export const useSubEvents = (
           },
         });
       } catch (e) {
-        toast.error(t('info.errorLoadMode'));
+        toast.error(t('info.errorLoadMore'));
       }
       setIsFetchingMore(false);
     },

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -77,7 +77,7 @@ const SearchPage: React.FC<{
           },
         });
       } catch (e) {
-        toast.error(t('search:errorLoadMode'));
+        toast.error(t('search:errorLoadMore'));
       }
     }
     setIsFetchingMore(false);

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -186,7 +186,7 @@ it('should show toastr message when loading next event page fails', async () => 
     expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
   });
 
-  expect(toast.error).toHaveBeenCalledWith(translations.search.errorLoadMode);
+  expect(toast.error).toHaveBeenCalledWith(translations.search.errorLoadMore);
 });
 
 it.todo('should scroll to event defined in react-router location state');

--- a/apps/sports-helsinki/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -186,7 +186,7 @@ async function testToaster() {
 
   await waitFor(() => {
     expect(toast.error).toHaveBeenCalledWith(
-      translations.event.info.errorLoadMode
+      translations.event.info.errorLoadMore
     );
   });
 }

--- a/apps/sports-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/sports-helsinki/src/domain/event/queryUtils.ts
@@ -164,7 +164,7 @@ export const useSubEvents = (
           },
         });
       } catch (e) {
-        toast.error(t('info.errorLoadMode'));
+        toast.error(t('info.errorLoadMore'));
       }
       setIsFetchingMore(false);
     },

--- a/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -116,7 +116,7 @@ const SearchPage: React.FC<{
           },
         });
       } catch (e) {
-        toast.error(t('search:errorLoadMode'));
+        toast.error(t('search:errorLoadMore'));
       }
     }
     setIsFetchingMore(false);

--- a/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -186,7 +186,7 @@ it('should show toastr message when loading next event page fails', async () => 
     expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
   });
 
-  expect(toast.error).toHaveBeenCalledWith(translations.search.errorLoadMode);
+  expect(toast.error).toHaveBeenCalledWith(translations.search.errorLoadMore);
 });
 
 it.todo('should scroll to event defined in react-router location state');

--- a/apps/sports-helsinki/src/domain/search/venueSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/venueSearch/SearchPage.tsx
@@ -81,7 +81,7 @@ const SearchPage: React.FC<SearchPageProps> = ({
     try {
       await fetchMore({ ...pagination });
     } catch (e) {
-      toast.error(t('search:errorLoadMode'));
+      toast.error(t('search:errorLoadMore'));
     }
     setIsFetchingMore(false);
   };

--- a/packages/common-i18n/src/locales/fi/event.json
+++ b/packages/common-i18n/src/locales/fi/event.json
@@ -37,7 +37,7 @@
     "buttonBuyTickets": "Osta liput",
     "directionsGoogle": "Reittiohjeet (Google)",
     "directionsHSL": "Reittiohjeet (HSL)",
-    "errorLoadMode": "Tapahtumien lataaminen epäonnistui",
+    "errorLoadMore": "Tapahtumien lataaminen epäonnistui",
     "extlinkFacebook": "Facebook",
     "extlinkInstagram": "Instagram",
     "extlinkTwitter": "Twitter",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -3,7 +3,7 @@
   "ariaLiveSearchReady": "{{count}} hakutulosta",
   "textFoundEvents": "{{count}} hakutulosta",
   "buttonClearFilters": "Tyhjennä hakuehdot",
-  "errorLoadMode": "Tapahtumien lataaminen epäonnistui",
+  "errorLoadMore": "Tapahtumien lataaminen epäonnistui",
   "buttonLoadMore": "Näytä lisää harrastuksia ({{count}})",
   "searchNotification": {
     "noResultsTitle": "Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta",


### PR DESCRIPTION
## Description

### fix: rename typoed errorLoadMode to errorLoadMore

refs LIIKUNTA-355 (noticed the typo while working on this ticket)

## Issues

**[LIIKUNTA-355](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-355)**

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-355]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ