### PR TITLE
TH-1289 | fix(th-1289): make buttonLoadMore text unrelated to hobbies i.e. generic

### DIFF
--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -37,7 +37,7 @@
     }
   },
   "textFoundEvents": "{{count}} search results",
-  "buttonLoadMore": "Show more hobbies ({{count}})",
+  "buttonLoadMore": "Show more ({{count}})",
   "searchNotification": {
     "noResultsTitle": "Sorry, no search results were found for the search criteria you selected.",
     "noResultsText": "No search results were found for the search criteria you selected. Try to change search terms or change to event search.",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -4,7 +4,7 @@
   "textFoundEvents": "{{count}} hakutulosta",
   "buttonClearFilters": "Tyhjennä hakuehdot",
   "errorLoadMore": "Tapahtumien lataaminen epäonnistui",
-  "buttonLoadMore": "Näytä lisää harrastuksia ({{count}})",
+  "buttonLoadMore": "Näytä lisää ({{count}})",
   "searchNotification": {
     "noResultsTitle": "Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta",
     "noResultsText": "Valitsemillasi hakuehdoilla ei löytynyt harrastuksia. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -40,7 +40,7 @@
   "betaButtonArialLabel": "Vill du ge oss respons på utvecklingsversionen av hobbysöksidan?",
   "betaNotificationText": "Vill du ge oss respons på utvecklingsversionen av hobbysöksidan? <a href=\"{{url}}\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Gå till responsformuläret {{openInNewTab}}\">Gå till responsformuläret.</a>",
   "betaResultsNotificationText": "Vi arbetar med att vidareutveckla webbsidan. För tillfället innehåller tjänsten enbart hobbyer för barn och unga.",
-  "buttonLoadMore": "Visa fler hobbyew ({{count}})",
+  "buttonLoadMore": "Visa fler ({{count}})",
   "searchNotification": {
     "noResultsTitle": "Tyvärr hittades inga resultat för de sökkriterier du valt.",
     "noResultsText": "Tyvärr hittades inga resultat för de sökkriterier du valt. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",


### PR DESCRIPTION
## Description

### fix(th-1289): make buttonLoadMore text unrelated to hobbies i.e. generic

Practically `"Show more hobbies (<count>)"` -> `"Show more (<count>)`.

## Issues

### Closes

**[TH-1289](https://helsinkisolutionoffice.atlassian.net/browse/TH-1289)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[TH-1289]: https://helsinkisolutionoffice.atlassian.net/browse/TH-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ