### PR TITLE
Update release configs

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "apps/hobbies-helsinki": "1.1.0",
   "apps/events-helsinki": "0.3.0",
   "apps/sports-helsinki": "0.3.0",
-  "proxies/events-graphql-federation": "1.0.0"
+  "proxies/events-graphql-federation": "1.0.0",
+  "proxies/events-graphql-proxy": "0.2.10"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,8 +2,5 @@
   "apps/hobbies-helsinki": "1.1.0",
   "apps/events-helsinki": "0.3.0",
   "apps/sports-helsinki": "0.3.0",
-  "packages/eslint-config-bases": "1.5.0",
-  "packages/components": "0.0.7",
-  "packages/common-i18n": "0.0.1",
   "proxies/events-graphql-federation": "1.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ _Apps_ and _proxies_ use automatic semantic versions and are released using [Rel
 
 Each time you merge a pull request, the release-please-action will create or update a "Release PR" with the changelog and the version bump related to the changes. To create a new release for an app, this release PR is merged, which creates a new release with release notes and a new tag. This tag will be picked by Azure pipeline and trigger a new deployment to staging. From there, the release needs to be manually released to production.
 
-### Conventional commits
+### Conventional Commits
 
-Use conventional commits to ensure that the changelogs are generated correctly.
+Use [Conventional Commits](https://www.conventionalcommits.org/) to ensure that the changelogs are generated correctly.
 
 ### Configuration
 
@@ -282,12 +282,17 @@ The release-please workflow is located in the [release-please.yml](./.github/wor
 
 The configuration for release-please is located in the [release-please-config.json](./release-please-config.json) file. See vatious options in the [release-please docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).
 
-The manifest file is located in the [release-please-manifest.json](./.release-please-manifest.json) file. When adding a new app, add it to this file with the current version of the app. After this, release-please will keep track of versions with this while.
+The manifest file is located in the [release-please-manifest.json](./.release-please-manifest.json) file. 
 
+When adding a new app, add it to both the [release-please-config.json](./release-please-config.json) and [release-please-manifest.json](./.release-please-manifest.json) file with the current version of the app. After this, release-please will keep track of versions with [release-please-manifest.json](./.release-please-manifest.json).
 
 ### Troubleshoting release-please
 
-If a new release PR is not created, there's propably one of the older release PR's still in pending state: make sure there's no open release pr already. Also see if any of the closed PR's are labeled with `autorelease: pending` and change their label to `autorelease: tagged`. Then go and re-run the last merge workflow to trigger the release action.
+If you were expecting a new release PR to be created, but nothing happened, there's probably one of the older release PR's in pending state. 
+
+First make sure there's no open release PR already; if there is, the work is now included on this one (this is the normal scenario).
+
+If you do not see any open release PR related to the work, check if any of the closed PR's are labeled with `autorelease: pending` - ie. someone might have closed a release PR manually. Change the closed PR's label to `autorelease: tagged`. Then go and re-run the last merge workflow to trigger the release action - a new release PR should now appear.
 
 There's also a CLI for debugging and manually running releases available for release-please: [release-please-cli](https://github.com/googleapis/release-please/blob/main/docs/cli.md)
 

--- a/README.md
+++ b/README.md
@@ -238,18 +238,6 @@ To ensure decent performance, those features are present in the example actions:
   >    - ".eslintignore"
   > ```
 
-### 5.5 Releases, changelogs and versioning
-
-Packages and apps use automatic semantic versions and are released using [Release Please](https://github.com/googleapis/release-please).
-
-Use conventional commits to ensure that the changelog is generated correctly.
-
-> Release Please is a GitHub Action that automates releases for you. It will create a GitHub release and a GitHub Pull Request with a changelog based on conventional commits.
-
-Note! If the PR is not created, there's propably one of the older Release PR's still in pending state: See if any of the closed PR's are labeled with `autorelease: pending` 
-and change their label to `autorelease: tagged`. Then go and re-run the last merge workflow to trigger the release action.
-
-
 ## 6. Editor support
 
 ### 6.1 VSCode
@@ -274,6 +262,34 @@ More info [here](https://github.com/microsoft/vscode-eslint#mono-repository-setu
 ### Docker
 
 Building a docker image, read the [docker doc](./docs/docker/docker.md).
+
+
+## 8. Releases, changelogs and versioning
+
+_Apps_ and _proxies_ use automatic semantic versions and are released using [Release Please](https://github.com/googleapis/release-please).
+
+> Release Please is a GitHub Action that automates releases for you. It will create a GitHub release and a GitHub Pull Request with a changelog based on conventional commits.
+
+Each time you merge a pull request, the release-please-action will create or update a "Release PR" with the changelog and the version bump related to the changes. To create a new release for an app, this release PR is merged, which creates a new release with release notes and a new tag. This tag will be picked by Azure pipeline and trigger a new deployment to staging. From there, the release needs to be manually released to production.
+
+### Conventional commits
+
+Use conventional commits to ensure that the changelogs are generated correctly.
+
+### Configuration
+
+The release-please workflow is located in the [release-please.yml](./.github/workflows/release-please.yml) file.
+
+The configuration for release-please is located in the [release-please-config.json](./release-please-config.json) file. See vatious options in the [release-please docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).
+
+The manifest file is located in the [release-please-manifest.json](./.release-please-manifest.json) file. When adding a new app, add it to this file with the current version of the app. After this, release-please will keep track of versions with this while.
+
+
+### Troubleshoting release-please
+
+If a new release PR is not created, there's propably one of the older release PR's still in pending state: make sure there's no open release pr already. Also see if any of the closed PR's are labeled with `autorelease: pending` and change their label to `autorelease: tagged`. Then go and re-run the last merge workflow to trigger the release action.
+
+There's also a CLI for debugging and manually running releases available for release-please: [release-please-cli](https://github.com/googleapis/release-please/blob/main/docs/cli.md)
 
 ## FAQ
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
     "apps/hobbies-helsinki":{ "release-type": "node" },
     "apps/events-helsinki": { "release-type": "node" },
     "apps/sports-helsinki": { "release-type": "node" },
-    "proxies/events-graphql-federation": { "release-type": "rust", "package-name": "federation-router" }
+    "proxies/events-graphql-federation": { "release-type": "rust", "package-name": "federation-router" },
+    "proxies/events-graphql-proxy": { "release-type": "node" }
   },
   "plugins": ["sentence-case"]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
     "apps/hobbies-helsinki":{ "release-type": "node" },
     "apps/events-helsinki": { "release-type": "node" },
     "apps/sports-helsinki": { "release-type": "node" },
-    "proxies/events-graphql-federation": { "release-type": "rust", "package-name": "federation-router" },
+    "proxies/events-graphql-federation": { "release-type": "simple", "package-name": "federation-router" },
     "proxies/events-graphql-proxy": { "release-type": "node" }
   },
   "plugins": ["sentence-case"]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,9 +5,6 @@
     "apps/hobbies-helsinki":{ "release-type": "node" },
     "apps/events-helsinki": { "release-type": "node" },
     "apps/sports-helsinki": { "release-type": "node" },
-    "packages/eslint-config-bases": { "release-type": "node" },
-    "packages/components": { "release-type": "node" },
-    "packages/common-i18n": { "release-type": "node" },
     "proxies/events-graphql-federation": { "release-type": "rust", "package-name": "federation-router" }
   },
   "plugins": ["sentence-case"]


### PR DESCRIPTION
## Description
Remove `packages/` from releases, and add `events-graphql-proxy`. Also update documentation for releases.

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
