### PR TITLE
fix: remove .kuva from events-graphql-federation-*.test.kuva.hel.ninja

### DIFF
--- a/apps/events-helsinki/.env.local.example
+++ b/apps/events-helsinki/.env.local.example
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_CMS_ORIGIN="https://tapahtumat.hkih.stage.geniem.io"
-NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT="https://events-graphql-federation-events.test.kuva.hel.ninja/"
+NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT="https://events-graphql-federation-events.test.hel.ninja/"
 NEXT_PUBLIC_LINKEDEVENTS_EVENT_ENDPOINT="https://api.hel.fi/linkedevents/v1/event"
 NEXT_PUBLIC_APP_ORIGIN="http://localhost:3000"
 NEXT_PUBLIC_IMAGE_PROXY_URL="https://images.weserv.nl/?w=1024&url="

--- a/apps/events-helsinki/.env.test
+++ b/apps/events-helsinki/.env.test
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000
-NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT=https://events-graphql-federation-events.test.kuva.hel.ninja/
+NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT=https://events-graphql-federation-events.test.hel.ninja/
 NEXT_PUBLIC_CMS_ORIGIN=https://tapahtumat.hkih.stage.geniem.io
 NEXT_PUBLIC_LINKEDEVENTS_EVENT_ENDPOINT=https://api.hel.fi/linkedevents/v1/event
 NEXT_PUBLIC_IMAGE_PROXY_URL=https://images.weserv.nl/?w=1024&url=

--- a/apps/hobbies-helsinki/.env.local.example
+++ b/apps/hobbies-helsinki/.env.local.example
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT="https://events-graphql-federation-hobbies.test.kuva.hel.ninja/"
+NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT="https://events-graphql-federation-hobbies.test.hel.ninja/"
 NEXT_PUBLIC_CMS_ORIGIN="https://harrastus.hkih.stage.geniem.io"
 NEXT_PUBLIC_LINKEDEVENTS_EVENT_ENDPOINT="https://api.hel.fi/linkedevents/v1/event"
 NEXT_PUBLIC_APP_ORIGIN="http://localhost:3000"

--- a/apps/hobbies-helsinki/.env.test
+++ b/apps/hobbies-helsinki/.env.test
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000
-NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT=https://events-graphql-federation-hobbies.test.kuva.hel.ninja/
+NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT=https://events-graphql-federation-hobbies.test.hel.ninja/
 NEXT_PUBLIC_CMS_ORIGIN=https://harrastus.hkih.stage.geniem.io
 NEXT_PUBLIC_LINKEDEVENTS_EVENT_ENDPOINT=https://api.hel.fi/linkedevents/v1/event
 NEXT_PUBLIC_IMAGE_PROXY_URL=https://images.weserv.nl/?w=1024&url=

--- a/apps/sports-helsinki/.env.local.example
+++ b/apps/sports-helsinki/.env.local.example
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT="https://events-graphql-federation-sports.test.kuva.hel.ninja/"
+NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT="https://events-graphql-federation-sports.test.hel.ninja/"
 NEXT_PUBLIC_CMS_ORIGIN="https://liikunta.hkih.stage.geniem.io"
 NEXT_PUBLIC_LINKEDEVENTS_EVENT_ENDPOINT="https://api.hel.fi/linkedevents/v1/event"
 NEXT_PUBLIC_APP_ORIGIN="http://localhost:3000"

--- a/apps/sports-helsinki/.env.test
+++ b/apps/sports-helsinki/.env.test
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000
-NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT=https://events-graphql-federation-hobbies.test.kuva.hel.ninja/
+NEXT_PUBLIC_FEDERATION_ROUTER_ENDPOINT=https://events-graphql-federation-hobbies.test.hel.ninja/
 NEXT_PUBLIC_CMS_ORIGIN=https://liikunta.hkih.stage.geniem.io
 NEXT_PUBLIC_LINKEDEVENTS_EVENT_ENDPOINT=https://api.hel.fi/linkedevents/v1/event
 NEXT_PUBLIC_IMAGE_PROXY_URL=https://images.weserv.nl/?w=1024&url=

--- a/proxies/events-graphql-federation/README.md
+++ b/proxies/events-graphql-federation/README.md
@@ -17,9 +17,9 @@ Apollo's Supergraph-demo repository: https://github.com/apollographql/supergraph
 
 ### Staging
 
-- Hobbies-Helsinki: https://events-graphql-federation-hobbies.test.kuva.hel.ninja/
-- Events-Helsinki: https://events-graphql-federation-events.test.kuva.hel.ninja/
-- Sports-Helsinki: https://events-graphql-federation-sports.test.kuva.hel.ninja/
+- Hobbies-Helsinki: https://events-graphql-federation-hobbies.test.hel.ninja/
+- Events-Helsinki: https://events-graphql-federation-events.test.hel.ninja/
+- Sports-Helsinki: https://events-graphql-federation-sports.test.hel.ninja/
 
 ## Local development
 


### PR DESCRIPTION
## Description

### fix: remove .kuva from events-graphql-federation-*.test.kuva.hel.ninja

The ".kuva." containing URLs have been removed from use.

## Issues

`-`

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
