### PR TITLE
refactor: set jest tests' timeouts to 50s in jest.config.js files

### DIFF
--- a/apps/events-helsinki/jest.config.js
+++ b/apps/events-helsinki/jest.config.js
@@ -30,6 +30,7 @@ const config = {
   },
   setupFilesAfterEnv: ['<rootDir>/../.jest/setupTests.ts'],
   testMatch: ['<rootDir>/**/*.{spec,test}.{js,jsx,ts,tsx}'],
+  testTimeout: 50000, // ms
   moduleNameMapper: {
     // For @testing-library/react
     '^@/test-utils$': '<rootDir>/../config/jest/test-utils',

--- a/apps/events-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/events-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -143,7 +143,7 @@ it('should render info and load other events + similar events', async () => {
     expect(
       screen.getByRole('link', { name: keyword.name })
     ).toBeInTheDocument();
-  }, 10000);
+  });
 
   await screen.findByText('Tapahtuman muut ajat');
 
@@ -159,7 +159,7 @@ it('should render info and load other events + similar events', async () => {
   expect(screen.getByTestId(otherEventTimesListTestId).children).toHaveLength(
     otherEventTimesCount
   );
-}, 50000);
+});
 
 it('should show error info when event is closed', async () => {
   advanceTo('2020-10-10');

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -159,7 +159,7 @@ it('all the event cards should be visible and load more button should load more 
   //   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   //   expect(await screen.findByText(event.name.fi!)).toBeInTheDocument();
   // });
-}, 10000);
+});
 
 it('should show toastr message when loading next event page fails', async () => {
   toast.error = jest.fn();

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -88,7 +88,7 @@ it('for accessibility violations', async () => {
 
   const results = await axe(container);
   expect(results).toHaveNoViolations();
-}, 50000); // FIXME: Why does this take so long?
+}); // FIXME: Why does this take so long?
 
 it('should clear all filters and search field', async () => {
   const { router } = renderComponent();
@@ -226,7 +226,7 @@ it('should change search query after selecting start date and pressing submit bu
     pathname,
     query: { start: '2020-10-06', text: 'jazz' },
   });
-}, 50000); // FIXME: Why does this take so long to test?
+}); // FIXME: Why does this take so long to test?
 
 it('should change search query after clicking category menu item', async () => {
   const { router } = renderComponent();

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx
@@ -124,5 +124,5 @@ describe('Landing page', () => {
       pathname: searchPath,
       query: { start: '2020-10-06' },
     });
-  }, 50000);
+  });
 });

--- a/apps/hobbies-helsinki/jest.config.js
+++ b/apps/hobbies-helsinki/jest.config.js
@@ -30,6 +30,7 @@ const config = {
   },
   setupFilesAfterEnv: ['<rootDir>/../.jest/setupTests.ts'],
   testMatch: ['<rootDir>/**/*.{spec,test}.{js,jsx,ts,tsx}'],
+  testTimeout: 50000, // ms
   moduleNameMapper: {
     // For @testing-library/react
     '^@/test-utils$': '<rootDir>/../config/jest/test-utils',

--- a/apps/hobbies-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -143,7 +143,7 @@ it('should render info and load other events + similar events', async () => {
     expect(
       screen.getByRole('link', { name: keyword.name })
     ).toBeInTheDocument();
-  }, 10000);
+  });
 
   await screen.findByText('Tapahtuman muut ajat');
 
@@ -159,7 +159,7 @@ it('should render info and load other events + similar events', async () => {
   expect(screen.getByTestId(otherEventTimesListTestId).children).toHaveLength(
     otherEventTimesCount
   );
-}, 50000);
+});
 
 it('should show error info when event is closed', async () => {
   advanceTo('2020-10-10');

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -153,7 +153,7 @@ it('all the event cards should be visible and load more button should load more 
   //   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   //   expect(await screen.findByText(event.name.fi!)).toBeInTheDocument();
   // });
-}, 10000);
+});
 
 it('should show toastr message when loading next event page fails', async () => {
   toast.error = jest.fn();

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -88,7 +88,7 @@ it('for accessibility violations', async () => {
 
   const results = await axe(container);
   expect(results).toHaveNoViolations();
-}, 50000); // FIXME: Why does this take so long?
+}); // FIXME: Why does this take so long?
 
 it('should clear all filters and search field', async () => {
   const { router } = renderComponent();
@@ -196,7 +196,7 @@ it('should change search query after selecting start date and pressing submit bu
     pathname,
     query: { start: '2020-10-06', text: 'jazz' },
   });
-}, 50000); // FIXME: Why does this take so long to test?
+}); // FIXME: Why does this take so long to test?
 
 it('should change search query after clicking category menu item', async () => {
   const { router } = renderComponent();

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx
@@ -124,5 +124,5 @@ describe('Landing page', () => {
       pathname: searchPath,
       query: { start: '2020-10-06' },
     });
-  }, 50000);
+  });
 });

--- a/apps/sports-helsinki/jest.config.js
+++ b/apps/sports-helsinki/jest.config.js
@@ -30,6 +30,7 @@ const config = {
   },
   setupFilesAfterEnv: ['<rootDir>/../.jest/setupTests.ts'],
   testMatch: ['<rootDir>/**/*.{spec,test}.{js,jsx,ts,tsx}'],
+  testTimeout: 50000, // ms
   moduleNameMapper: {
     // For @testing-library/react
     '^@/test-utils$': '<rootDir>/../config/jest/test-utils',

--- a/apps/sports-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -148,7 +148,7 @@ it('should render info and load other events + similar events', async () => {
     expect(
       screen.getByRole('link', { name: keyword.name })
     ).toBeInTheDocument();
-  }, 10000);
+  });
 
   await screen.findByText('Tapahtuman muut ajat');
 
@@ -164,7 +164,7 @@ it('should render info and load other events + similar events', async () => {
   expect(screen.getByTestId(otherEventTimesListTestId).children).toHaveLength(
     otherEventTimesCount
   );
-}, 50000);
+});
 
 it('should show error info when event is closed', async () => {
   advanceTo('2020-10-10');

--- a/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -153,7 +153,7 @@ it('all the event cards should be visible and load more button should load more 
   //   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   //   expect(await screen.findByText(event.name.fi!)).toBeInTheDocument();
   // });
-}, 10000);
+});
 
 it('should show toastr message when loading next event page fails', async () => {
   toast.error = jest.fn();

--- a/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/Search.test.tsx
@@ -87,7 +87,7 @@ it('for accessibility violations', async () => {
 
   const results = await axe(container);
   expect(results).toHaveNoViolations();
-}, 50000); // FIXME: Why does this take so long?
+}); // FIXME: Why does this take so long?
 
 it('should clear all filters and search field', async () => {
   const { router } = renderComponent();

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -35,6 +35,7 @@ const config = {
     '<rootDir>/../.jest/setupTests.ts',
   ],
   testMatch: ['<rootDir>/**/*.{spec,test}.{js,jsx,ts,tsx}'],
+  testTimeout: 50000, // ms
   moduleNameMapper: {
     '.+\\.(css|styl|less|sass|scss)$': 'identity-obj-proxy',
     // https://jestjs.io/docs/webpack#handling-static-assets

--- a/packages/components/src/components/dateRangePicker/__tests/DateRangePicker.test.tsx
+++ b/packages/components/src/components/dateRangePicker/__tests/DateRangePicker.test.tsx
@@ -75,7 +75,7 @@ describe('date range input', () => {
     expect(onChangeEndDate).toHaveBeenCalledWith(
       utcToZonedTime(new Date('2020-10-15'), 'UTC')
     );
-  }, 25000);
+  });
 
   it('should call onChangeStartDate', async () => {
     const startDate = new Date('2020-10-10');

--- a/proxies/events-graphql-proxy/jest.config.js
+++ b/proxies/events-graphql-proxy/jest.config.js
@@ -30,6 +30,7 @@ const config = {
   },
   setupFilesAfterEnv: ['<rootDir>/../.jest/setupTests.ts'],
   testMatch: ['<rootDir>/**/*.{spec,test}.{js,jsx,ts,tsx}'],
+  testTimeout: 50000, // ms
   moduleNameMapper: {
     ...getTsConfigBasePaths(),
   },


### PR DESCRIPTION
## Description

### refactor: set jest tests' timeouts to 50s in jest.config.js files

 - remove specific tests' timeout overrides
 - set jest tests' timeouts to the highest used override (50s = 50000ms) in jest.config.js files using testTimeout

refs LIIKUNTA-355 (noticed that sometimes some tests need high timeout)

## Issues

### Closes

### Related

**[LIIKUNTA-355](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-355)** (noticed that sometimes some tests need high timeout)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-355]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ