### PR TITLE
chore(router): update the CMS schema

### DIFF
--- a/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
@@ -11,8 +11,8 @@ import { useConfig } from 'react-helsinki-headless-cms';
 import { scroller } from 'react-scroll';
 import { toast } from 'react-toastify';
 import type { SearchPage } from 'domain/search/combinedSearch/types';
-import { removeQueryParamsFromRouter } from 'utils/routerUtils';
 import { SEARCH_ROUTES } from '../../../../constants';
+import { removeQueryParamsFromRouter } from '../../../../utils/routerUtils';
 import { getNextPage } from '../utils';
 import useEventSearchFilters from './useEventSearchFilters';
 

--- a/apps/sports-helsinki/src/domain/search/venueSearch/hooks/useSearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/venueSearch/hooks/useSearchPage.tsx
@@ -13,8 +13,8 @@ import { toast } from 'react-toastify';
 import AppConfig from 'domain/app/AppConfig';
 import type { SearchPage } from 'domain/search/combinedSearch/types';
 import useUnifiedSearchListQuery from 'domain/unifiedSearch/useUnifiedSearchListQuery';
-import { removeQueryParamsFromRouter } from 'utils/routerUtils';
 import { SEARCH_ROUTES } from '../../../../constants';
+import { removeQueryParamsFromRouter } from '../../../../utils/routerUtils';
 
 const BLOCK_SIZE = 10;
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,6 +69,7 @@
     "react-helsinki-headless-cms": "1.0.0-alpha83",
     "react-i18next": "11.18.6",
     "react-leaflet": "4.2.0",
+    "react-toastify": "^9.0.3",
     "sanitize-html": "2.7.2"
   },
   "peerDependencies": {

--- a/proxies/events-graphql-federation/subgraphs/cms/cms.graphql
+++ b/proxies/events-graphql-federation/subgraphs/cms/cms.graphql
@@ -2602,6 +2602,17 @@ type LocationsSelected {
   "Module title"
   title: String
 }
+"Collection Module: LocationsSelectedCarousel"
+type LocationsSelectedCarousel {
+  "List of location IDs"
+  locations: [Int]
+  "Module type"
+  module: String
+  "List of modules"
+  modules: [CollectionModulesUnionType]
+  "Module title"
+  title: String
+}
 "Layout: LayoutCollection"
 type LayoutCollection {
   "Collection"
@@ -6233,6 +6244,7 @@ union PageModulesUnionType =
   | EventSearchCarousel
   | EventSelectedCarousel
   | LocationsSelected
+  | LocationsSelectedCarousel
   | LayoutCollection
   | LayoutContact
   | LayoutArticles
@@ -6246,12 +6258,14 @@ union CollectionModulesUnionType =
   | EventSearchCarousel
   | EventSelectedCarousel
   | LocationsSelected
+  | LocationsSelectedCarousel
 union PostModulesUnionType =
     EventSearch
   | EventSelected
   | EventSearchCarousel
   | EventSelectedCarousel
   | LocationsSelected
+  | LocationsSelectedCarousel
   | LayoutCollection
   | LayoutContact
   | LayoutArticles

--- a/proxies/events-graphql-federation/supergraph.graphql
+++ b/proxies/events-graphql-federation/supergraph.graphql
@@ -1,72 +1,58 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION) {
+  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+{
   query: Query
   mutation: Mutation
   subscription: Subscription
 }
 
-directive @join__field(
-  graph: join__Graph!
-  requires: join__FieldSet
-  provides: join__FieldSet
-  type: String
-  external: Boolean
-  override: String
-  usedOverridden: Boolean
-) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
-directive @join__implements(
-  graph: join__Graph!
-  interface: String!
-) repeatable on OBJECT | INTERFACE
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
-directive @join__type(
-  graph: join__Graph!
-  key: join__FieldSet
-  extension: Boolean! = false
-  resolvable: Boolean! = true
-) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-directive @link(
-  url: String
-  as: String
-  for: link__Purpose
-  import: [link__Import]
-) repeatable on SCHEMA
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-"""
-TODO: take this from service map / TPREK
-"""
-type AccessibilityProfile @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: take this from service map / TPREK"""
+type AccessibilityProfile
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   todo: String
 }
 
-type AccessibilitySentences @join__type(graph: VENUES) {
+type AccessibilitySentences
+  @join__type(graph: VENUES)
+{
   groupName: String
   sentences: [String]
 }
 
-"""
-TODO: give real structure
-"""
-type Address @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: give real structure"""
+type Address
+  @join__type(graph: UNIFIED_SEARCH)
+{
   postalCode: String
   streetAddress: LanguageString
   city: LanguageString
 }
 
-type AdministrativeDivision @join__type(graph: UNIFIED_SEARCH) {
+type AdministrativeDivision
+  @join__type(graph: UNIFIED_SEARCH)
+{
   id: ID
   type: String
   municipality: String
   name: LanguageString
 }
 
-type Audience @join__type(graph: EVENTS) {
+type Audience
+  @join__type(graph: EVENTS)
+{
   id: ID
   name: LocalizedObject
   internalId: String
@@ -77,35 +63,27 @@ type Audience @join__type(graph: EVENTS) {
 """
 Avatars are profile images for users. WordPress by default uses the Gravatar service to host and fetch avatars from.
 """
-type Avatar @join__type(graph: CMS) {
+type Avatar
+  @join__type(graph: CMS)
+{
   """
   URL for the default image or a default type. Accepts &#039;404&#039; (return a 404 instead of a default image), &#039;retro&#039; (8bit), &#039;monsterid&#039; (monster), &#039;wavatar&#039; (cartoon face), &#039;indenticon&#039; (the &#039;quilt&#039;), &#039;mystery&#039;, &#039;mm&#039;, or &#039;mysteryman&#039; (The Oyster Man), &#039;blank&#039; (transparent GIF), or &#039;gravatar_default&#039; (the Gravatar logo).
   """
   default: String
 
-  """
-  HTML attributes to insert in the IMG element. Is not sanitized.
-  """
+  """HTML attributes to insert in the IMG element. Is not sanitized."""
   extraAttr: String
 
-  """
-  Whether to always show the default image, never the Gravatar.
-  """
+  """Whether to always show the default image, never the Gravatar."""
   forceDefault: Boolean
 
-  """
-  Whether the avatar was successfully found.
-  """
+  """Whether the avatar was successfully found."""
   foundAvatar: Boolean
 
-  """
-  Height of the avatar image.
-  """
+  """Height of the avatar image."""
   height: Int
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
   """
@@ -113,9 +91,7 @@ type Avatar @join__type(graph: CMS) {
   """
   rating: String
 
-  """
-  Type of url scheme to use. Typically HTTP vs. HTTPS.
-  """
+  """Type of url scheme to use. Typically HTTP vs. HTTPS."""
   scheme: String
 
   """
@@ -123,43 +99,35 @@ type Avatar @join__type(graph: CMS) {
   """
   size: Int
 
-  """
-  URL for the gravatar image source.
-  """
+  """URL for the gravatar image source."""
   url: String
 
-  """
-  Width of the avatar image.
-  """
+  """Width of the avatar image."""
   width: Int
 }
 
 """
 What rating to display avatars up to. Accepts 'G', 'PG', 'R', 'X', and are judged in that order. Default is the value of the 'avatar_rating' option
 """
-enum AvatarRatingEnum @join__type(graph: CMS) {
-  """
-  Indicates a G level avatar rating level.
-  """
+enum AvatarRatingEnum
+  @join__type(graph: CMS)
+{
+  """Indicates a G level avatar rating level."""
   G
 
-  """
-  Indicates a PG level avatar rating level.
-  """
+  """Indicates a PG level avatar rating level."""
   PG
 
-  """
-  Indicates an R level avatar rating level.
-  """
+  """Indicates an R level avatar rating level."""
   R
 
-  """
-  Indicates an X level avatar rating level.
-  """
+  """Indicates an X level avatar rating level."""
   X
 }
 
-type BannerPage @join__type(graph: EVENTS) {
+type BannerPage
+  @join__type(graph: EVENTS)
+{
   title: LocalizedObject
   description: LocalizedObject
   keywords: LocalizedCmsKeywords
@@ -173,14 +141,14 @@ type BannerPage @join__type(graph: EVENTS) {
   socialMediaImage: LocalizedCmsImage
 }
 
-enum CacheControlScope @join__type(graph: UNIFIED_SEARCH) {
+enum CacheControlScope
+  @join__type(graph: UNIFIED_SEARCH)
+{
   PUBLIC
   PRIVATE
 }
 
-"""
-The category type
-"""
+"""The category type"""
 type Category implements Node & TermNode & UniformResourceIdentifiable & DatabaseIdentifier & HierarchicalTermNode & MenuItemLinkable
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "TermNode")
@@ -188,19 +156,16 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
   @join__implements(graph: CMS, interface: "HierarchicalTermNode")
   @join__implements(graph: CMS, interface: "MenuItemLinkable")
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   The ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
   """
   ancestors(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -214,23 +179,15 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     before: String
   ): CategoryToAncestorsCategoryConnection
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
+  """The id field matches the WP_Post-&gt;ID field."""
   categoryId: Int @deprecated(reason: "Deprecated in favor of databaseId")
 
-  """
-  Connection between the category type and the category type
-  """
+  """Connection between the category type and the category type"""
   children(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -243,24 +200,16 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: CategoryToCategoryConnectionWhereArgs
   ): CategoryToCategoryConnection
 
-  """
-  Connection between the category type and the ContentNode type
-  """
+  """Connection between the category type and the ContentNode type"""
   contentNodes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -273,39 +222,25 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: CategoryToContentNodeConnectionWhereArgs
   ): CategoryToContentNodeConnection
 
-  """
-  The number of objects connected to the object
-  """
+  """The number of objects connected to the object"""
   count: Int
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   databaseId: Int!
 
-  """
-  The description of the object
-  """
+  """The description of the object"""
   description: String
 
-  """
-  Connection between the TermNode type and the EnqueuedScript type
-  """
+  """Connection between the TermNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -319,18 +254,12 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     before: String
   ): TermNodeToEnqueuedScriptConnection
 
-  """
-  Connection between the TermNode type and the EnqueuedStylesheet type
-  """
+  """Connection between the TermNode type and the EnqueuedStylesheet type"""
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -344,68 +273,42 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     before: String
   ): TermNodeToEnqueuedStylesheetConnection
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  List available translations for this post
-  """
+  """List available translations for this post"""
   language: Language
 
-  """
-  The link to the term
-  """
+  """The link to the term"""
   link: String
 
-  """
-  The human friendly name of the object.
-  """
+  """The human friendly name of the object."""
   name: String
 
-  """
-  Connection between the category type and the category type
-  """
+  """Connection between the category type and the category type"""
   parent: CategoryToParentCategoryConnectionEdge
 
-  """
-  Database id of the parent node
-  """
+  """Database id of the parent node"""
   parentDatabaseId: Int
 
-  """
-  The globally unique identifier of the parent node.
-  """
+  """The globally unique identifier of the parent node."""
   parentId: ID
 
-  """
-  Connection between the category type and the post type
-  """
+  """Connection between the category type and the post type"""
   posts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -418,157 +321,109 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: CategoryToPostConnectionWhereArgs
   ): CategoryToPostConnection
 
-  """
-  An alphanumeric identifier for the object unique to its type.
-  """
+  """An alphanumeric identifier for the object unique to its type."""
   slug: String
 
-  """
-  Connection between the category type and the Taxonomy type
-  """
+  """Connection between the category type and the Taxonomy type"""
   taxonomy: CategoryToTaxonomyConnectionEdge
 
-  """
-  The name of the taxonomy that the object is associated with
-  """
+  """The name of the taxonomy that the object is associated with"""
   taxonomyName: String
 
-  """
-  The ID of the term group that this term object belongs to
-  """
+  """The ID of the term group that this term object belongs to"""
   termGroupId: Int
 
-  """
-  The taxonomy ID that the object is associated with
-  """
+  """The taxonomy ID that the object is associated with"""
   termTaxonomyId: Int
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): Category
 
-  """
-  List all translated versions of this term
-  """
+  """List all translated versions of this term"""
   translations: [Category]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum CategoryIdType @join__type(graph: CMS) {
-  """
-  The Database ID for the node
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum CategoryIdType
+  @join__type(graph: CMS)
+{
+  """The Database ID for the node"""
   DATABASE_ID
 
-  """
-  The hashed Global ID
-  """
+  """The hashed Global ID"""
   ID
 
-  """
-  The name of the node
-  """
+  """The name of the node"""
   NAME
 
-  """
-  Url friendly name of the node
-  """
+  """Url friendly name of the node"""
   SLUG
 
-  """
-  The URI for the node
-  """
+  """The URI for the node"""
   URI
 }
 
-"""
-Connection between the category type and the category type
-"""
-type CategoryToAncestorsCategoryConnection @join__type(graph: CMS) {
-  """
-  Edges for the CategoryToAncestorsCategoryConnection connection
-  """
+"""Connection between the category type and the category type"""
+type CategoryToAncestorsCategoryConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the CategoryToAncestorsCategoryConnection connection"""
   edges: [CategoryToAncestorsCategoryConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Category]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type CategoryToAncestorsCategoryConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type CategoryToAncestorsCategoryConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Category
 }
 
-"""
-Connection between the category type and the category type
-"""
-type CategoryToCategoryConnection @join__type(graph: CMS) {
-  """
-  Edges for the CategoryToCategoryConnection connection
-  """
+"""Connection between the category type and the category type"""
+type CategoryToCategoryConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the CategoryToCategoryConnection connection"""
   edges: [CategoryToCategoryConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Category]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type CategoryToCategoryConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type CategoryToCategoryConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Category
 }
 
-"""
-Arguments for filtering the CategoryToCategoryConnection connection
-"""
-input CategoryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the CategoryToCategoryConnection connection"""
+input CategoryToCategoryConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -609,19 +464,13 @@ input CategoryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -629,14 +478,10 @@ input CategoryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -644,9 +489,7 @@ input CategoryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -654,69 +497,49 @@ input CategoryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the category type and the ContentNode type
-"""
-type CategoryToContentNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the CategoryToContentNodeConnection connection
-  """
+"""Connection between the category type and the ContentNode type"""
+type CategoryToContentNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the CategoryToContentNodeConnection connection"""
   edges: [CategoryToContentNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type CategoryToContentNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type CategoryToContentNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentNode
 }
 
-"""
-Arguments for filtering the CategoryToContentNodeConnection connection
-"""
-input CategoryToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+"""Arguments for filtering the CategoryToContentNodeConnection connection"""
+input CategoryToContentNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypesOfCategoryEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -724,29 +547,19 @@ input CategoryToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -754,114 +567,80 @@ input CategoryToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the category type and the category type
-"""
-type CategoryToParentCategoryConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the category type and the category type"""
+type CategoryToParentCategoryConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Category
 }
 
-"""
-Connection between the category type and the post type
-"""
-type CategoryToPostConnection @join__type(graph: CMS) {
-  """
-  Edges for the CategoryToPostConnection connection
-  """
+"""Connection between the category type and the post type"""
+type CategoryToPostConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the CategoryToPostConnection connection"""
   edges: [CategoryToPostConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Post]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type CategoryToPostConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type CategoryToPostConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Post
 }
 
-"""
-Arguments for filtering the CategoryToPostConnection connection
-"""
-input CategoryToPostConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the CategoryToPostConnection connection"""
+input CategoryToPostConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -869,9 +648,7 @@ input CategoryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Category ID
-  """
+  """Category ID"""
   categoryId: Int
 
   """
@@ -879,9 +656,7 @@ input CategoryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryIn: [ID]
 
-  """
-  Use Category Slug
-  """
+  """Use Category Slug"""
   categoryName: String
 
   """
@@ -889,9 +664,7 @@ input CategoryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -899,29 +672,19 @@ input CategoryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -929,101 +692,69 @@ input CategoryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Tag Slug
-  """
+  """Tag Slug"""
   tag: String
 
-  """
-  Use Tag ID
-  """
+  """Use Tag ID"""
   tagId: String
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagIn: [ID]
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagNotIn: [ID]
 
-  """
-  Array of tag slugs, used to display objects from one tag OR another
-  """
+  """Array of tag slugs, used to display objects from one tag OR another"""
   tagSlugAnd: [String]
 
-  """
-  Array of tag slugs, used to exclude objects in specified tags
-  """
+  """Array of tag slugs, used to exclude objects in specified tags"""
   tagSlugIn: [String]
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the category type and the Taxonomy type
-"""
-type CategoryToTaxonomyConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the category type and the Taxonomy type"""
+type CategoryToTaxonomyConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Taxonomy
 }
 
-type CmsImage @join__type(graph: EVENTS) {
+type CmsImage
+  @join__type(graph: EVENTS)
+{
   photographerCredit: LocalizedObject
   url: String
   title: String
 }
 
-"""
-The collection type
-"""
+"""The collection type"""
 type Collection implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithRevisions
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -1032,51 +763,33 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   @join__implements(graph: CMS, interface: "NodeWithTemplate")
   @join__implements(graph: CMS, interface: "NodeWithTitle")
   @join__implements(graph: CMS, interface: "NodeWithRevisions")
-  @join__type(graph: CMS) {
-  """
-  Background Color
-  """
+  @join__type(graph: CMS)
+{
+  """Background Color"""
   backgroundColor: String
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  collectionId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """The id field matches the WP_Post-&gt;ID field."""
+  collectionId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  Description
-  """
+  """Description"""
   description: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -1084,23 +797,15 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -1118,14 +823,10 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -1139,9 +840,7 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
     before: String
   ): ContentNodeToEnqueuedStylesheetConnection
 
-  """
-  Vanhentumisaika
-  """
+  """Vanhentumisaika"""
   expirationTime: String
 
   """
@@ -1149,54 +848,34 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   """
   guid: String
 
-  """
-  The globally unique identifier of the collection-cpt object.
-  """
+  """The globally unique identifier of the collection-cpt object."""
   id: ID!
 
-  """
-  Image
-  """
+  """Image"""
   image: String
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  True if the node is a revision of another node
-  """
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  Polylang language
-  """
+  """Polylang language"""
   language: Language
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -1209,24 +888,16 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   """
   modifiedGmt: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [CollectionModulesUnionType]
 
-  """
-  Connection between the collection type and the collection type
-  """
+  """Connection between the collection type and the collection type"""
   preview: CollectionToPreviewConnectionEdge
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -1234,18 +905,12 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   """
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 
-  """
-  Connection between the collection type and the collection type
-  """
+  """Connection between the collection type and the collection type"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -1258,20 +923,14 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: CollectionToRevisionConnectionWhereArgs
   ): CollectionToRevisionConnection
 
-  """
-  The SEO Framework data of the collection
-  """
+  """The SEO Framework data of the collection"""
   seo: SEO
 
-  """
-  Show on front page
-  """
+  """Show on front page"""
   showOnFrontPage: Boolean
 
   """
@@ -1279,28 +938,18 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to the node
-  """
+  """The template assigned to the node"""
   template: ContentTemplate
 
-  """
-  Connection between the collection type and the TermNode type
-  """
+  """Connection between the collection type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -1313,9 +962,7 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: CollectionToTermNodeConnectionWhereArgs
   ): CollectionToTermNodeConnection
 
@@ -1323,40 +970,28 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): Collection
 
-  """
-  List all translated versions of this post
-  """
+  """List all translated versions of this post"""
   translations: [Collection]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum CollectionIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum CollectionIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
   """
@@ -1364,71 +999,52 @@ enum CollectionIdType @join__type(graph: CMS) {
   """
   SLUG
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-union CollectionModulesUnionType @join__type(graph: CMS) =
-    EventSearch
-  | EventSelected
-  | EventSearchCarousel
-  | EventSelectedCarousel
-  | LocationsSelected
+union CollectionModulesUnionType
+  @join__type(graph: CMS)
+ = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel
 
-"""
-Connection between the collection type and the collection type
-"""
-type CollectionToPreviewConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the collection type and the collection type"""
+type CollectionToPreviewConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Collection
 }
 
-"""
-Connection between the collection type and the collection type
-"""
-type CollectionToRevisionConnection @join__type(graph: CMS) {
-  """
-  Edges for the collectionToRevisionConnection connection
-  """
+"""Connection between the collection type and the collection type"""
+type CollectionToRevisionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the collectionToRevisionConnection connection"""
   edges: [CollectionToRevisionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Collection]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type CollectionToRevisionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type CollectionToRevisionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Collection
 }
 
-"""
-Arguments for filtering the collectionToRevisionConnection connection
-"""
-input CollectionToRevisionConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the collectionToRevisionConnection connection"""
+input CollectionToRevisionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -1436,29 +1052,19 @@ input CollectionToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -1466,91 +1072,63 @@ input CollectionToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the collection type and the TermNode type
-"""
-type CollectionToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the CollectionToTermNodeConnection connection
-  """
+"""Connection between the collection type and the TermNode type"""
+type CollectionToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the CollectionToTermNodeConnection connection"""
   edges: [CollectionToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type CollectionToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type CollectionToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the CollectionToTermNodeConnection connection
-"""
-input CollectionToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the CollectionToTermNodeConnection connection"""
+input CollectionToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -1591,19 +1169,13 @@ input CollectionToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -1611,14 +1183,10 @@ input CollectionToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -1626,9 +1194,7 @@ input CollectionToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -1636,34 +1202,25 @@ input CollectionToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-A Comment object
-"""
+"""A Comment object"""
 type Comment implements Node & DatabaseIdentifier
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   User agent used to post the comment. This field is equivalent to WP_Comment-&gt;comment_agent and the value matching the &quot;comment_agent&quot; column in SQL.
   """
@@ -1674,9 +1231,7 @@ type Comment implements Node & DatabaseIdentifier
   """
   approved: Boolean
 
-  """
-  The author of the comment
-  """
+  """The author of the comment"""
   author: CommentToCommenterConnectionEdge
 
   """
@@ -1684,29 +1239,21 @@ type Comment implements Node & DatabaseIdentifier
   """
   authorIp: String
 
-  """
-  ID for the comment, unique among comments.
-  """
+  """ID for the comment, unique among comments."""
   commentId: Int @deprecated(reason: "Deprecated in favor of databaseId")
 
-  """
-  Connection between the Comment type and the ContentNode type
-  """
+  """Connection between the Comment type and the ContentNode type"""
   commentedOn: CommentToContentNodeConnectionEdge
 
   """
   Content of the comment. This field is equivalent to WP_Comment-&gt;comment_content and the value matching the &quot;comment_content&quot; column in SQL.
   """
   content(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
   """
@@ -1719,14 +1266,10 @@ type Comment implements Node & DatabaseIdentifier
   """
   dateGmt: String
 
-  """
-  The globally unique identifier for the comment object
-  """
+  """The globally unique identifier for the comment object"""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
   """
@@ -1734,13 +1277,9 @@ type Comment implements Node & DatabaseIdentifier
   """
   karma: Int
 
-  """
-  Connection between the Comment type and the Comment type
-  """
+  """Connection between the Comment type and the Comment type"""
   parent(
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: CommentToParentCommentConnectionWhereArgs
   ): CommentToParentCommentConnectionEdge
 
@@ -1749,23 +1288,15 @@ type Comment implements Node & DatabaseIdentifier
   """
   parentDatabaseId: Int
 
-  """
-  The globally unique identifier of the parent comment node.
-  """
+  """The globally unique identifier of the parent comment node."""
   parentId: ID
 
-  """
-  Connection between the Comment type and the Comment type
-  """
+  """Connection between the Comment type and the Comment type"""
   replies(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -1778,9 +1309,7 @@ type Comment implements Node & DatabaseIdentifier
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: CommentToCommentConnectionWhereArgs
   ): CommentToCommentConnection
 
@@ -1790,13 +1319,12 @@ type Comment implements Node & DatabaseIdentifier
   type: String
 }
 
-"""
-A Comment Author object
-"""
+"""A Comment Author object"""
 type CommentAuthor implements Node & Commenter
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "Commenter")
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.
   """
@@ -1811,65 +1339,45 @@ type CommentAuthor implements Node & Commenter
     """
     forceDefault: Boolean
 
-    """
-    The rating level of the avatar.
-    """
+    """The rating level of the avatar."""
     rating: AvatarRatingEnum
   ): Avatar
 
-  """
-  Identifies the primary key from the database.
-  """
+  """Identifies the primary key from the database."""
   databaseId: Int!
 
-  """
-  The email for the comment author
-  """
+  """The email for the comment author"""
   email: String
 
-  """
-  The globally unique identifier for the comment author object
-  """
+  """The globally unique identifier for the comment author object"""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  The name for the comment author.
-  """
+  """The name for the comment author."""
   name: String
 
-  """
-  The url the comment author.
-  """
+  """The url the comment author."""
   url: String
 }
 
-"""
-The author of a comment
-"""
-interface Commenter @join__type(graph: CMS) {
+"""The author of a comment"""
+interface Commenter
+  @join__type(graph: CMS)
+{
   """
   Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.
   """
   avatar: Avatar
 
-  """
-  Identifies the primary key from the database.
-  """
+  """Identifies the primary key from the database."""
   databaseId: Int!
 
-  """
-  The email address of the author of a comment.
-  """
+  """The email address of the author of a comment."""
   email: String
 
-  """
-  The globally unique identifier for the comment author.
-  """
+  """The globally unique identifier for the comment author."""
   id: ID!
 
   """
@@ -1877,89 +1385,57 @@ interface Commenter @join__type(graph: CMS) {
   """
   isRestricted: Boolean
 
-  """
-  The name of the author of a comment.
-  """
+  """The name of the author of a comment."""
   name: String
 
-  """
-  The url of the author of a comment.
-  """
+  """The url of the author of a comment."""
   url: String
 }
 
-"""
-Options for ordering the connection
-"""
-enum CommentsConnectionOrderbyEnum @join__type(graph: CMS) {
-  """
-  Order by browser user agent of the commenter.
-  """
+"""Options for ordering the connection"""
+enum CommentsConnectionOrderbyEnum
+  @join__type(graph: CMS)
+{
+  """Order by browser user agent of the commenter."""
   COMMENT_AGENT
 
-  """
-  Order by true/false approval of the comment.
-  """
+  """Order by true/false approval of the comment."""
   COMMENT_APPROVED
 
-  """
-  Order by name of the comment author.
-  """
+  """Order by name of the comment author."""
   COMMENT_AUTHOR
 
-  """
-  Order by e-mail of the comment author.
-  """
+  """Order by e-mail of the comment author."""
   COMMENT_AUTHOR_EMAIL
 
-  """
-  Order by IP address of the comment author.
-  """
+  """Order by IP address of the comment author."""
   COMMENT_AUTHOR_IP
 
-  """
-  Order by URL address of the comment author.
-  """
+  """Order by URL address of the comment author."""
   COMMENT_AUTHOR_URL
 
-  """
-  Order by the comment contents.
-  """
+  """Order by the comment contents."""
   COMMENT_CONTENT
 
-  """
-  Order by date/time timestamp of the comment.
-  """
+  """Order by date/time timestamp of the comment."""
   COMMENT_DATE
 
-  """
-  Order by GMT timezone date/time timestamp of the comment.
-  """
+  """Order by GMT timezone date/time timestamp of the comment."""
   COMMENT_DATE_GMT
 
-  """
-  Order by the globally unique identifier for the comment object
-  """
+  """Order by the globally unique identifier for the comment object"""
   COMMENT_ID
 
-  """
-  Order by the array list of comment IDs listed in the where clause.
-  """
+  """Order by the array list of comment IDs listed in the where clause."""
   COMMENT_IN
 
-  """
-  Order by the comment karma score.
-  """
+  """Order by the comment karma score."""
   COMMENT_KARMA
 
-  """
-  Order by the comment parent ID.
-  """
+  """Order by the comment parent ID."""
   COMMENT_PARENT
 
-  """
-  Order by the post object ID.
-  """
+  """Order by the post object ID."""
   COMMENT_POST_ID
 
   """
@@ -1967,74 +1443,52 @@ enum CommentsConnectionOrderbyEnum @join__type(graph: CMS) {
   """
   COMMENT_TYPE
 
-  """
-  Order by the user ID.
-  """
+  """Order by the user ID."""
   USER_ID
 }
 
-"""
-Connection between the Comment type and the Comment type
-"""
-type CommentToCommentConnection @join__type(graph: CMS) {
-  """
-  Edges for the CommentToCommentConnection connection
-  """
+"""Connection between the Comment type and the Comment type"""
+type CommentToCommentConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the CommentToCommentConnection connection"""
   edges: [CommentToCommentConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Comment]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type CommentToCommentConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type CommentToCommentConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Comment
 }
 
-"""
-Arguments for filtering the CommentToCommentConnection connection
-"""
-input CommentToCommentConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Comment author email address.
-  """
+"""Arguments for filtering the CommentToCommentConnection connection"""
+input CommentToCommentConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Comment author email address."""
   authorEmail: String
 
-  """
-  Array of author IDs to include comments for.
-  """
+  """Array of author IDs to include comments for."""
   authorIn: [ID]
 
-  """
-  Array of author IDs to exclude comments for.
-  """
+  """Array of author IDs to exclude comments for."""
   authorNotIn: [ID]
 
-  """
-  Comment author URL.
-  """
+  """Comment author URL."""
   authorUrl: String
 
-  """
-  Array of comment IDs to include.
-  """
+  """Array of comment IDs to include."""
   commentIn: [ID]
 
   """
@@ -2042,59 +1496,37 @@ input CommentToCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   commentNotIn: [ID]
 
-  """
-  Include comments of a given type.
-  """
+  """Include comments of a given type."""
   commentType: String
 
-  """
-  Include comments from a given array of comment types.
-  """
+  """Include comments from a given array of comment types."""
   commentTypeIn: [String]
 
-  """
-  Exclude comments from a given array of comment types.
-  """
+  """Exclude comments from a given array of comment types."""
   commentTypeNotIn: String
 
-  """
-  Content object author ID to limit results by.
-  """
+  """Content object author ID to limit results by."""
   contentAuthor: [ID]
 
-  """
-  Array of author IDs to retrieve comments for.
-  """
+  """Array of author IDs to retrieve comments for."""
   contentAuthorIn: [ID]
 
-  """
-  Array of author IDs *not* to retrieve comments for.
-  """
+  """Array of author IDs *not* to retrieve comments for."""
   contentAuthorNotIn: [ID]
 
-  """
-  Limit results to those affiliated with a given content object ID.
-  """
+  """Limit results to those affiliated with a given content object ID."""
   contentId: ID
 
-  """
-  Array of content object IDs to include affiliated comments for.
-  """
+  """Array of content object IDs to include affiliated comments for."""
   contentIdIn: [ID]
 
-  """
-  Array of content object IDs to exclude affiliated comments for.
-  """
+  """Array of content object IDs to exclude affiliated comments for."""
   contentIdNotIn: [ID]
 
-  """
-  Content object name to retrieve affiliated comments for.
-  """
+  """Content object name to retrieve affiliated comments for."""
   contentName: String
 
-  """
-  Content Object parent ID to retrieve affiliated comments for.
-  """
+  """Content Object parent ID to retrieve affiliated comments for."""
   contentParent: Int
 
   """
@@ -2112,109 +1544,77 @@ input CommentToCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   includeUnapproved: [ID]
 
-  """
-  Karma score to retrieve matching comments for.
-  """
+  """Karma score to retrieve matching comments for."""
   karma: Int
 
-  """
-  The cardinality of the order of the connection
-  """
+  """The cardinality of the order of the connection"""
   order: OrderEnum
 
-  """
-  Field to order the comments by.
-  """
+  """Field to order the comments by."""
   orderby: CommentsConnectionOrderbyEnum
 
-  """
-  Parent ID of comment to retrieve children of.
-  """
+  """Parent ID of comment to retrieve children of."""
   parent: Int
 
-  """
-  Array of parent IDs of comments to retrieve children for.
-  """
+  """Array of parent IDs of comments to retrieve children for."""
   parentIn: [ID]
 
-  """
-  Array of parent IDs of comments *not* to retrieve children for.
-  """
+  """Array of parent IDs of comments *not* to retrieve children for."""
   parentNotIn: [ID]
 
-  """
-  Search term(s) to retrieve matching comments for.
-  """
+  """Search term(s) to retrieve matching comments for."""
   search: String
 
-  """
-  Comment status to limit results by.
-  """
+  """Comment status to limit results by."""
   status: String
 
-  """
-  Include comments for a specific user ID.
-  """
+  """Include comments for a specific user ID."""
   userId: ID
 }
 
-"""
-Connection between the Comment type and the Commenter type
-"""
-type CommentToCommenterConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the Comment type and the Commenter type"""
+type CommentToCommenterConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Commenter
 }
 
-"""
-Connection between the Comment type and the ContentNode type
-"""
-type CommentToContentNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the Comment type and the ContentNode type"""
+type CommentToContentNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: ContentNode
 }
 
-"""
-Connection between the Comment type and the Comment type
-"""
-type CommentToParentCommentConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the Comment type and the Comment type"""
+type CommentToParentCommentConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Comment
 }
 
 """
 Arguments for filtering the CommentToParentCommentConnection connection
 """
-input CommentToParentCommentConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Comment author email address.
-  """
+input CommentToParentCommentConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Comment author email address."""
   authorEmail: String
 
-  """
-  Array of author IDs to include comments for.
-  """
+  """Array of author IDs to include comments for."""
   authorIn: [ID]
 
-  """
-  Array of author IDs to exclude comments for.
-  """
+  """Array of author IDs to exclude comments for."""
   authorNotIn: [ID]
 
-  """
-  Comment author URL.
-  """
+  """Comment author URL."""
   authorUrl: String
 
-  """
-  Array of comment IDs to include.
-  """
+  """Array of comment IDs to include."""
   commentIn: [ID]
 
   """
@@ -2222,59 +1622,37 @@ input CommentToParentCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   commentNotIn: [ID]
 
-  """
-  Include comments of a given type.
-  """
+  """Include comments of a given type."""
   commentType: String
 
-  """
-  Include comments from a given array of comment types.
-  """
+  """Include comments from a given array of comment types."""
   commentTypeIn: [String]
 
-  """
-  Exclude comments from a given array of comment types.
-  """
+  """Exclude comments from a given array of comment types."""
   commentTypeNotIn: String
 
-  """
-  Content object author ID to limit results by.
-  """
+  """Content object author ID to limit results by."""
   contentAuthor: [ID]
 
-  """
-  Array of author IDs to retrieve comments for.
-  """
+  """Array of author IDs to retrieve comments for."""
   contentAuthorIn: [ID]
 
-  """
-  Array of author IDs *not* to retrieve comments for.
-  """
+  """Array of author IDs *not* to retrieve comments for."""
   contentAuthorNotIn: [ID]
 
-  """
-  Limit results to those affiliated with a given content object ID.
-  """
+  """Limit results to those affiliated with a given content object ID."""
   contentId: ID
 
-  """
-  Array of content object IDs to include affiliated comments for.
-  """
+  """Array of content object IDs to include affiliated comments for."""
   contentIdIn: [ID]
 
-  """
-  Array of content object IDs to exclude affiliated comments for.
-  """
+  """Array of content object IDs to exclude affiliated comments for."""
   contentIdNotIn: [ID]
 
-  """
-  Content object name to retrieve affiliated comments for.
-  """
+  """Content object name to retrieve affiliated comments for."""
   contentName: String
 
-  """
-  Content Object parent ID to retrieve affiliated comments for.
-  """
+  """Content Object parent ID to retrieve affiliated comments for."""
   contentParent: Int
 
   """
@@ -2292,62 +1670,44 @@ input CommentToParentCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   includeUnapproved: [ID]
 
-  """
-  Karma score to retrieve matching comments for.
-  """
+  """Karma score to retrieve matching comments for."""
   karma: Int
 
-  """
-  The cardinality of the order of the connection
-  """
+  """The cardinality of the order of the connection"""
   order: OrderEnum
 
-  """
-  Field to order the comments by.
-  """
+  """Field to order the comments by."""
   orderby: CommentsConnectionOrderbyEnum
 
-  """
-  Parent ID of comment to retrieve children of.
-  """
+  """Parent ID of comment to retrieve children of."""
   parent: Int
 
-  """
-  Array of parent IDs of comments to retrieve children for.
-  """
+  """Array of parent IDs of comments to retrieve children for."""
   parentIn: [ID]
 
-  """
-  Array of parent IDs of comments *not* to retrieve children for.
-  """
+  """Array of parent IDs of comments *not* to retrieve children for."""
   parentNotIn: [ID]
 
-  """
-  Search term(s) to retrieve matching comments for.
-  """
+  """Search term(s) to retrieve matching comments for."""
   search: String
 
-  """
-  Comment status to limit results by.
-  """
+  """Comment status to limit results by."""
   status: String
 
-  """
-  Include comments for a specific user ID.
-  """
+  """Include comments for a specific user ID."""
   userId: ID
 }
 
-type Connection @join__type(graph: VENUES) {
+type Connection
+  @join__type(graph: VENUES)
+{
   sectionType: String
   name: String
   phone: String
   url: String
 }
 
-"""
-The contact type
-"""
+"""The contact type"""
 type Contact implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithFeaturedImage & NodeWithRevisions
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -2357,46 +1717,30 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   @join__implements(graph: CMS, interface: "NodeWithTitle")
   @join__implements(graph: CMS, interface: "NodeWithFeaturedImage")
   @join__implements(graph: CMS, interface: "NodeWithRevisions")
-  @join__type(graph: CMS) {
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  contactId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  @join__type(graph: CMS)
+{
+  """The id field matches the WP_Post-&gt;ID field."""
+  contactId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  Description
-  """
+  """Description"""
   description: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -2404,23 +1748,15 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -2438,14 +1774,10 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -2469,14 +1801,10 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   featuredImageDatabaseId: Int
 
-  """
-  Globally unique ID of the featured image assigned to the node
-  """
+  """Globally unique ID of the featured image assigned to the node"""
   featuredImageId: ID
 
-  """
-  First name
-  """
+  """First name"""
   firstName: String
 
   """
@@ -2484,59 +1812,37 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   guid: String
 
-  """
-  The globally unique identifier of the contact-cpt object.
-  """
+  """The globally unique identifier of the contact-cpt object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  True if the node is a revision of another node
-  """
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  Job Title
-  """
+  """Job Title"""
   jobTitle: String
 
-  """
-  Polylang language
-  """
+  """Polylang language"""
   language: Language
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  Last name
-  """
+  """Last name"""
   lastName: String
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -2549,19 +1855,13 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   modifiedGmt: String
 
-  """
-  Connection between the contact type and the contact type
-  """
+  """Connection between the contact type and the contact type"""
   preview: ContactToPreviewConnectionEdge
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -2569,18 +1869,12 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 
-  """
-  Connection between the contact type and the contact type
-  """
+  """Connection between the contact type and the contact type"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -2593,15 +1887,11 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: ContactToRevisionConnectionWhereArgs
   ): ContactToRevisionConnection
 
-  """
-  The SEO Framework data of the contact
-  """
+  """The SEO Framework data of the contact"""
   seo: SEO
 
   """
@@ -2609,28 +1899,18 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to a node of content
-  """
+  """The template assigned to a node of content"""
   template: ContentTemplate
 
-  """
-  Connection between the contact type and the TermNode type
-  """
+  """Connection between the contact type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -2643,9 +1923,7 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: ContactToTermNodeConnectionWhereArgs
   ): ContactToTermNodeConnection
 
@@ -2653,40 +1931,28 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): Contact
 
-  """
-  List all translated versions of this post
-  """
+  """List all translated versions of this post"""
   translations: [Contact]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum ContactIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum ContactIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
   """
@@ -2694,23 +1960,23 @@ enum ContactIdType @join__type(graph: CMS) {
   """
   SLUG
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-"""
-Contact details for a person, legal entity, venue or project
-"""
-type ContactInfo @join__type(graph: UNIFIED_SEARCH) {
+"""Contact details for a person, legal entity, venue or project"""
+type ContactInfo
+  @join__type(graph: UNIFIED_SEARCH)
+{
   contactUrl: String
   phoneNumbers: [PhoneNumber!]!
   emailAddresses: [String!]!
   postalAddresses: [Address!]!
 }
 
-enum ContactMedium @join__type(graph: UNIFIED_SEARCH) {
+enum ContactMedium
+  @join__type(graph: UNIFIED_SEARCH)
+{
   SMS
   EMAIL
   SMS_AND_EMAIL
@@ -2718,58 +1984,44 @@ enum ContactMedium @join__type(graph: UNIFIED_SEARCH) {
   ASIOINTI
 }
 
-"""
-Connection between the contact type and the contact type
-"""
-type ContactToPreviewConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the contact type and the contact type"""
+type ContactToPreviewConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Contact
 }
 
-"""
-Connection between the contact type and the contact type
-"""
-type ContactToRevisionConnection @join__type(graph: CMS) {
-  """
-  Edges for the contactToRevisionConnection connection
-  """
+"""Connection between the contact type and the contact type"""
+type ContactToRevisionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the contactToRevisionConnection connection"""
   edges: [ContactToRevisionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Contact]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ContactToRevisionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ContactToRevisionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Contact
 }
 
-"""
-Arguments for filtering the contactToRevisionConnection connection
-"""
-input ContactToRevisionConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the contactToRevisionConnection connection"""
+input ContactToRevisionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -2777,29 +2029,19 @@ input ContactToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -2807,91 +2049,63 @@ input ContactToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the contact type and the TermNode type
-"""
-type ContactToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the ContactToTermNodeConnection connection
-  """
+"""Connection between the contact type and the TermNode type"""
+type ContactToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the ContactToTermNodeConnection connection"""
   edges: [ContactToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ContactToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ContactToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the ContactToTermNodeConnection connection
-"""
-input ContactToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the ContactToTermNodeConnection connection"""
+input ContactToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -2932,19 +2146,13 @@ input ContactToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -2952,14 +2160,10 @@ input ContactToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -2967,9 +2171,7 @@ input ContactToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -2977,62 +2179,41 @@ input ContactToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Nodes used to manage content
-"""
+"""Nodes used to manage content"""
 interface ContentNode implements Node & UniformResourceIdentifiable
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "UniformResourceIdentifiable")
-  @join__type(graph: CMS) {
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  @join__type(graph: CMS)
+{
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The ID of the node in the database.
-  """
+  """The ID of the node in the database."""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -3040,23 +2221,15 @@ interface ContentNode implements Node & UniformResourceIdentifiable
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -3074,14 +2247,10 @@ interface ContentNode implements Node & UniformResourceIdentifiable
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -3100,39 +2269,25 @@ interface ContentNode implements Node & UniformResourceIdentifiable
   """
   guid: String
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -3145,14 +2300,10 @@ interface ContentNode implements Node & UniformResourceIdentifiable
   """
   modifiedGmt: String
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -3160,193 +2311,137 @@ interface ContentNode implements Node & UniformResourceIdentifiable
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to a node of content
-  """
+  """The template assigned to a node of content"""
   template: ContentTemplate
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum ContentNodeIdTypeEnum @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum ContentNodeIdTypeEnum
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-"""
-Connection between the ContentNode type and the ContentType type
-"""
-type ContentNodeToContentTypeConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the ContentNode type and the ContentType type"""
+type ContentNodeToContentTypeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: ContentType
 }
 
-"""
-Connection between the ContentNode type and the User type
-"""
-type ContentNodeToEditLastConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the ContentNode type and the User type"""
+type ContentNodeToEditLastConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: User
 }
 
-"""
-Connection between the ContentNode type and the User type
-"""
-type ContentNodeToEditLockConnectionEdge @join__type(graph: CMS) {
-  """
-  The timestamp for when the node was last edited
-  """
+"""Connection between the ContentNode type and the User type"""
+type ContentNodeToEditLockConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The timestamp for when the node was last edited"""
   lockTimestamp: String
 
-  """
-  The node of the connection, without the edges
-  """
+  """The node of the connection, without the edges"""
   node: User
 }
 
-"""
-Connection between the ContentNode type and the EnqueuedScript type
-"""
-type ContentNodeToEnqueuedScriptConnection @join__type(graph: CMS) {
-  """
-  Edges for the ContentNodeToEnqueuedScriptConnection connection
-  """
+"""Connection between the ContentNode type and the EnqueuedScript type"""
+type ContentNodeToEnqueuedScriptConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the ContentNodeToEnqueuedScriptConnection connection"""
   edges: [ContentNodeToEnqueuedScriptConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedScript]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ContentNodeToEnqueuedScriptConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ContentNodeToEnqueuedScriptConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedScript
 }
 
 """
 Connection between the ContentNode type and the EnqueuedStylesheet type
 """
-type ContentNodeToEnqueuedStylesheetConnection @join__type(graph: CMS) {
-  """
-  Edges for the ContentNodeToEnqueuedStylesheetConnection connection
-  """
+type ContentNodeToEnqueuedStylesheetConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the ContentNodeToEnqueuedStylesheetConnection connection"""
   edges: [ContentNodeToEnqueuedStylesheetConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedStylesheet]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ContentNodeToEnqueuedStylesheetConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ContentNodeToEnqueuedStylesheetConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedStylesheet
 }
 
-"""
-A union of Content Node Types that support revisions
-"""
-union ContentRevisionUnion @join__type(graph: CMS) =
-    Post
-  | Page
-  | Collection
-  | Contact
-  | LandingPage
-  | Release
-  | Translation
+"""A union of Content Node Types that support revisions"""
+union ContentRevisionUnion
+  @join__type(graph: CMS)
+ = Post | Page | Collection | Contact | LandingPage | Release | Translation
 
-"""
-The template assigned to a node of content
-"""
-interface ContentTemplate @join__type(graph: CMS) {
-  """
-  The name of the template
-  """
+"""The template assigned to a node of content"""
+interface ContentTemplate
+  @join__type(graph: CMS)
+{
+  """The name of the template"""
   templateName: String
 }
 
-"""
-An Post Type object
-"""
+"""An Post Type object"""
 type ContentType implements Node & UniformResourceIdentifiable
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "UniformResourceIdentifiable")
-  @join__type(graph: CMS) {
-  """
-  Whether this content type should can be exported.
-  """
+  @join__type(graph: CMS)
+{
+  """Whether this content type should can be exported."""
   canExport: Boolean
 
-  """
-  Connection between the ContentType type and the Taxonomy type
-  """
+  """Connection between the ContentType type and the Taxonomy type"""
   connectedTaxonomies(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -3360,18 +2455,12 @@ type ContentType implements Node & UniformResourceIdentifiable
     before: String
   ): ContentTypeToTaxonomyConnection
 
-  """
-  Connection between the ContentType type and the ContentNode type
-  """
+  """Connection between the ContentType type and the ContentNode type"""
   contentNodes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -3384,9 +2473,7 @@ type ContentType implements Node & UniformResourceIdentifiable
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: ContentTypeToContentNodeConnectionWhereArgs
   ): ContentTypeToContentNodeConnection
 
@@ -3395,9 +2482,7 @@ type ContentType implements Node & UniformResourceIdentifiable
   """
   deleteWithUser: Boolean
 
-  """
-  Description of the content type.
-  """
+  """Description of the content type."""
   description: String
 
   """
@@ -3405,14 +2490,10 @@ type ContentType implements Node & UniformResourceIdentifiable
   """
   excludeFromSearch: Boolean
 
-  """
-  The plural name of the content type within the GraphQL Schema.
-  """
+  """The plural name of the content type within the GraphQL Schema."""
   graphqlPluralName: String
 
-  """
-  The singular name of the content type within the GraphQL Schema.
-  """
+  """The singular name of the content type within the GraphQL Schema."""
   graphqlSingleName: String
 
   """
@@ -3420,54 +2501,34 @@ type ContentType implements Node & UniformResourceIdentifiable
   """
   hasArchive: Boolean
 
-  """
-  Whether the content type is hierarchical, for example pages.
-  """
+  """Whether the content type is hierarchical, for example pages."""
   hierarchical: Boolean
 
-  """
-  The globally unique identifier of the post-type object.
-  """
+  """The globally unique identifier of the post-type object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether this page is set to the static front page.
-  """
+  """Whether this page is set to the static front page."""
   isFrontPage: Boolean!
 
-  """
-  Whether this page is set to the blog posts page.
-  """
+  """Whether this page is set to the blog posts page."""
   isPostsPage: Boolean!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  Display name of the content type.
-  """
+  """Display name of the content type."""
   label: String
 
-  """
-  Details about the content type labels.
-  """
+  """Details about the content type labels."""
   labels: PostTypeLabelDetails
 
-  """
-  The name of the icon file to display as a menu icon.
-  """
+  """The name of the icon file to display as a menu icon."""
   menuIcon: String
 
   """
@@ -3495,19 +2556,13 @@ type ContentType implements Node & UniformResourceIdentifiable
   """
   restBase: String
 
-  """
-  The REST Controller class assigned to handling this content type.
-  """
+  """The REST Controller class assigned to handling this content type."""
   restControllerClass: String
 
-  """
-  Makes this content type available via the admin bar.
-  """
+  """Makes this content type available via the admin bar."""
   showInAdminBar: Boolean
 
-  """
-  Whether to add the content type to the GraphQL Schema.
-  """
+  """Whether to add the content type to the GraphQL Schema."""
   showInGraphql: Boolean
 
   """
@@ -3515,9 +2570,7 @@ type ContentType implements Node & UniformResourceIdentifiable
   """
   showInMenu: Boolean
 
-  """
-  Makes this content type available for selection in navigation menus.
-  """
+  """Makes this content type available for selection in navigation menus."""
   showInNavMenus: Boolean
 
   """
@@ -3530,149 +2583,111 @@ type ContentType implements Node & UniformResourceIdentifiable
   """
   showUi: Boolean
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-Allowed Content Types
-"""
-enum ContentTypeEnum @join__type(graph: CMS) {
-  """
-  The Type of Content object
-  """
+"""Allowed Content Types"""
+enum ContentTypeEnum
+  @join__type(graph: CMS)
+{
+  """The Type of Content object"""
   ATTACHMENT
 
-  """
-  The Type of Content object
-  """
+  """The Type of Content object"""
   COLLECTION_CPT
 
-  """
-  The Type of Content object
-  """
+  """The Type of Content object"""
   CONTACT_CPT
 
-  """
-  The Type of Content object
-  """
+  """The Type of Content object"""
   LANDING_PAGE_CPT
 
-  """
-  The Type of Content object
-  """
+  """The Type of Content object"""
   PAGE
 
-  """
-  The Type of Content object
-  """
+  """The Type of Content object"""
   POST
 
-  """
-  The Type of Content object
-  """
+  """The Type of Content object"""
   RELEASE_CPT
 
-  """
-  The Type of Content object
-  """
+  """The Type of Content object"""
   TRANSLATION_CPT
 }
 
 """
 The Type of Identifier used to fetch a single Content Type node. To be used along with the "id" field. Default is "ID".
 """
-enum ContentTypeIdTypeEnum @join__type(graph: CMS) {
-  """
-  The globally unique ID
-  """
+enum ContentTypeIdTypeEnum
+  @join__type(graph: CMS)
+{
+  """The globally unique ID"""
   ID
 
-  """
-  The name of the content type.
-  """
+  """The name of the content type."""
   NAME
 }
 
-"""
-Allowed Content Types of the Category taxonomy.
-"""
-enum ContentTypesOfCategoryEnum @join__type(graph: CMS) {
-  """
-  The Type of Content object
-  """
+"""Allowed Content Types of the Category taxonomy."""
+enum ContentTypesOfCategoryEnum
+  @join__type(graph: CMS)
+{
+  """The Type of Content object"""
   POST
 }
 
-"""
-Allowed Content Types of the PostFormat taxonomy.
-"""
-enum ContentTypesOfPostFormatEnum @join__type(graph: CMS) {
-  """
-  The Type of Content object
-  """
+"""Allowed Content Types of the PostFormat taxonomy."""
+enum ContentTypesOfPostFormatEnum
+  @join__type(graph: CMS)
+{
+  """The Type of Content object"""
   POST
 }
 
-"""
-Allowed Content Types of the Tag taxonomy.
-"""
-enum ContentTypesOfTagEnum @join__type(graph: CMS) {
-  """
-  The Type of Content object
-  """
+"""Allowed Content Types of the Tag taxonomy."""
+enum ContentTypesOfTagEnum
+  @join__type(graph: CMS)
+{
+  """The Type of Content object"""
   POST
 }
 
-"""
-Connection between the ContentType type and the ContentNode type
-"""
-type ContentTypeToContentNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the ContentTypeToContentNodeConnection connection
-  """
+"""Connection between the ContentType type and the ContentNode type"""
+type ContentTypeToContentNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the ContentTypeToContentNodeConnection connection"""
   edges: [ContentTypeToContentNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ContentTypeToContentNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ContentTypeToContentNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentNode
 }
 
 """
 Arguments for filtering the ContentTypeToContentNodeConnection connection
 """
-input ContentTypeToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+input ContentTypeToContentNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -3680,29 +2695,19 @@ input ContentTypeToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -3710,94 +2715,64 @@ input ContentTypeToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the ContentType type and the Taxonomy type
-"""
-type ContentTypeToTaxonomyConnection @join__type(graph: CMS) {
-  """
-  Edges for the ContentTypeToTaxonomyConnection connection
-  """
+"""Connection between the ContentType type and the Taxonomy type"""
+type ContentTypeToTaxonomyConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the ContentTypeToTaxonomyConnection connection"""
   edges: [ContentTypeToTaxonomyConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Taxonomy]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ContentTypeToTaxonomyConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ContentTypeToTaxonomyConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Taxonomy
 }
 
-"""
-Input for the createCategory mutation
-"""
-input CreateCategoryInput @join__type(graph: CMS) {
-  """
-  The slug that the category will be an alias of
-  """
+"""Input for the createCategory mutation"""
+input CreateCategoryInput
+  @join__type(graph: CMS)
+{
+  """The slug that the category will be an alias of"""
   aliasOf: String
 
   """
@@ -3805,20 +2780,14 @@ input CreateCategoryInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The description of the category object
-  """
+  """The description of the category object"""
   description: String
   language: LanguageCodeEnum
 
-  """
-  The name of the category object to mutate
-  """
+  """The name of the category object to mutate"""
   name: String!
 
-  """
-  The ID of the category that should be set as the parent
-  """
+  """The ID of the category that should be set as the parent"""
   parentId: ID
 
   """
@@ -3827,13 +2796,11 @@ input CreateCategoryInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-The payload for the createCategory mutation
-"""
-type CreateCategoryPayload @join__type(graph: CMS) {
-  """
-  The created category
-  """
+"""The payload for the createCategory mutation"""
+type CreateCategoryPayload
+  @join__type(graph: CMS)
+{
+  """The created category"""
   category: Category
 
   """
@@ -3842,10 +2809,10 @@ type CreateCategoryPayload @join__type(graph: CMS) {
   clientMutationId: String
 }
 
-"""
-Input for the createCollection mutation
-"""
-input CreateCollectionInput @join__type(graph: CMS) {
+"""Input for the createCollection mutation"""
+input CreateCollectionInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -3862,64 +2829,46 @@ input CreateCollectionInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the createCollection mutation
-"""
-type CreateCollectionPayload @join__type(graph: CMS) {
+"""The payload for the createCollection mutation"""
+type CreateCollectionPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   collection: Collection
 }
 
-"""
-Input for the createComment mutation
-"""
-input CreateCommentInput @join__type(graph: CMS) {
-  """
-  The approval status of the comment.
-  """
+"""Input for the createComment mutation"""
+input CreateCommentInput
+  @join__type(graph: CMS)
+{
+  """The approval status of the comment."""
   approved: String
 
-  """
-  The name of the comment's author.
-  """
+  """The name of the comment's author."""
   author: String
 
-  """
-  The email of the comment's author.
-  """
+  """The email of the comment's author."""
   authorEmail: String
 
-  """
-  The url of the comment's author.
-  """
+  """The url of the comment's author."""
   authorUrl: String
 
   """
@@ -3927,14 +2876,10 @@ input CreateCommentInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The ID of the post object the comment belongs to.
-  """
+  """The ID of the post object the comment belongs to."""
   commentOn: Int
 
-  """
-  Content of the comment.
-  """
+  """Content of the comment."""
   content: String
 
   """
@@ -3942,29 +2887,23 @@ input CreateCommentInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  Parent comment of current comment.
-  """
+  """Parent comment of current comment."""
   parent: ID
 
-  """
-  Type of comment.
-  """
+  """Type of comment."""
   type: String
 }
 
-"""
-The payload for the createComment mutation
-"""
-type CreateCommentPayload @join__type(graph: CMS) {
+"""The payload for the createComment mutation"""
+type CreateCommentPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The comment that was created
-  """
+  """The comment that was created"""
   comment: Comment
 
   """
@@ -3973,10 +2912,10 @@ type CreateCommentPayload @join__type(graph: CMS) {
   success: Boolean
 }
 
-"""
-Input for the createContact mutation
-"""
-input CreateContactInput @join__type(graph: CMS) {
+"""Input for the createContact mutation"""
+input CreateContactInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -3993,46 +2932,36 @@ input CreateContactInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the createContact mutation
-"""
-type CreateContactPayload @join__type(graph: CMS) {
+"""The payload for the createContact mutation"""
+type CreateContactPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   contact: Contact
 }
 
-"""
-Input for the createLandingPage mutation
-"""
-input CreateLandingPageInput @join__type(graph: CMS) {
+"""Input for the createLandingPage mutation"""
+input CreateLandingPageInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -4049,59 +2978,43 @@ input CreateLandingPageInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the createLandingPage mutation
-"""
-type CreateLandingPagePayload @join__type(graph: CMS) {
+"""The payload for the createLandingPage mutation"""
+type CreateLandingPagePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   landingPage: LandingPage
 }
 
-"""
-Input for the createMediaItem mutation
-"""
-input CreateMediaItemInput @join__type(graph: CMS) {
-  """
-  Alternative text to display when mediaItem is not displayed
-  """
+"""Input for the createMediaItem mutation"""
+input CreateMediaItemInput
+  @join__type(graph: CMS)
+{
+  """Alternative text to display when mediaItem is not displayed"""
   altText: String
 
-  """
-  The userId to assign as the author of the mediaItem
-  """
+  """The userId to assign as the author of the mediaItem"""
   authorId: ID
 
-  """
-  The caption for the mediaItem
-  """
+  """The caption for the mediaItem"""
   caption: String
 
   """
@@ -4109,85 +3022,59 @@ input CreateMediaItemInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The comment status for the mediaItem
-  """
+  """The comment status for the mediaItem"""
   commentStatus: String
 
-  """
-  The date of the mediaItem
-  """
+  """The date of the mediaItem"""
   date: String
 
-  """
-  The date (in GMT zone) of the mediaItem
-  """
+  """The date (in GMT zone) of the mediaItem"""
   dateGmt: String
 
-  """
-  Description of the mediaItem
-  """
+  """Description of the mediaItem"""
   description: String
 
-  """
-  The file name of the mediaItem
-  """
+  """The file name of the mediaItem"""
   filePath: String
 
-  """
-  The file type of the mediaItem
-  """
+  """The file type of the mediaItem"""
   fileType: MimeTypeEnum
   language: LanguageCodeEnum
 
-  """
-  The WordPress post ID or the graphQL postId of the parent object
-  """
+  """The WordPress post ID or the graphQL postId of the parent object"""
   parentId: ID
 
-  """
-  The ping status for the mediaItem
-  """
+  """The ping status for the mediaItem"""
   pingStatus: String
 
-  """
-  The slug of the mediaItem
-  """
+  """The slug of the mediaItem"""
   slug: String
 
-  """
-  The status of the mediaItem
-  """
+  """The status of the mediaItem"""
   status: MediaItemStatusEnum
 
-  """
-  The title of the mediaItem
-  """
+  """The title of the mediaItem"""
   title: String
 }
 
-"""
-The payload for the createMediaItem mutation
-"""
-type CreateMediaItemPayload @join__type(graph: CMS) {
+"""The payload for the createMediaItem mutation"""
+type CreateMediaItemPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The MediaItem object mutation type.
-  """
+  """The MediaItem object mutation type."""
   mediaItem: MediaItem
 }
 
-"""
-Input for the createPage mutation
-"""
-input CreatePageInput @join__type(graph: CMS) {
-  """
-  The userId to assign as the author of the object
-  """
+"""Input for the createPage mutation"""
+input CreatePageInput
+  @join__type(graph: CMS)
+{
+  """The userId to assign as the author of the object"""
   authorId: ID
 
   """
@@ -4195,9 +3082,7 @@ input CreatePageInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The content of the object
-  """
+  """The content of the object"""
   content: String
 
   """
@@ -4211,54 +3096,40 @@ input CreatePageInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The ID of the parent object
-  """
+  """The ID of the parent object"""
   parentId: ID
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the createPage mutation
-"""
-type CreatePagePayload @join__type(graph: CMS) {
+"""The payload for the createPage mutation"""
+type CreatePagePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   page: Page
 }
 
-"""
-Input for the createPostFormat mutation
-"""
-input CreatePostFormatInput @join__type(graph: CMS) {
-  """
-  The slug that the post_format will be an alias of
-  """
+"""Input for the createPostFormat mutation"""
+input CreatePostFormatInput
+  @join__type(graph: CMS)
+{
+  """The slug that the post_format will be an alias of"""
   aliasOf: String
 
   """
@@ -4266,14 +3137,10 @@ input CreatePostFormatInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The description of the post_format object
-  """
+  """The description of the post_format object"""
   description: String
 
-  """
-  The name of the post_format object to mutate
-  """
+  """The name of the post_format object to mutate"""
   name: String!
 
   """
@@ -4282,33 +3149,27 @@ input CreatePostFormatInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-The payload for the createPostFormat mutation
-"""
-type CreatePostFormatPayload @join__type(graph: CMS) {
+"""The payload for the createPostFormat mutation"""
+type CreatePostFormatPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The created post_format
-  """
+  """The created post_format"""
   postFormat: PostFormat
 }
 
-"""
-Input for the createPost mutation
-"""
-input CreatePostInput @join__type(graph: CMS) {
-  """
-  The userId to assign as the author of the object
-  """
+"""Input for the createPost mutation"""
+input CreatePostInput
+  @join__type(graph: CMS)
+{
+  """The userId to assign as the author of the object"""
   authorId: ID
 
-  """
-  Set connections between the post and categories
-  """
+  """Set connections between the post and categories"""
   categories: PostCategoriesInput
 
   """
@@ -4316,9 +3177,7 @@ input CreatePostInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The content of the object
-  """
+  """The content of the object"""
   content: String
 
   """
@@ -4332,64 +3191,48 @@ input CreatePostInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  Set connections between the post and postFormats
-  """
+  """Set connections between the post and postFormats"""
   postFormats: PostPostFormatsInput
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  Set connections between the post and tags
-  """
+  """Set connections between the post and tags"""
   tags: PostTagsInput
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the createPost mutation
-"""
-type CreatePostPayload @join__type(graph: CMS) {
+"""The payload for the createPost mutation"""
+type CreatePostPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   post: Post
 }
 
-"""
-Input for the createRelease mutation
-"""
-input CreateReleaseInput @join__type(graph: CMS) {
+"""Input for the createRelease mutation"""
+input CreateReleaseInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The content of the object
-  """
+  """The content of the object"""
   content: String
 
   """
@@ -4403,49 +3246,37 @@ input CreateReleaseInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the createRelease mutation
-"""
-type CreateReleasePayload @join__type(graph: CMS) {
+"""The payload for the createRelease mutation"""
+type CreateReleasePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   release: Release
 }
 
-"""
-Input for the createTag mutation
-"""
-input CreateTagInput @join__type(graph: CMS) {
-  """
-  The slug that the post_tag will be an alias of
-  """
+"""Input for the createTag mutation"""
+input CreateTagInput
+  @join__type(graph: CMS)
+{
+  """The slug that the post_tag will be an alias of"""
   aliasOf: String
 
   """
@@ -4453,15 +3284,11 @@ input CreateTagInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The description of the post_tag object
-  """
+  """The description of the post_tag object"""
   description: String
   language: LanguageCodeEnum
 
-  """
-  The name of the post_tag object to mutate
-  """
+  """The name of the post_tag object to mutate"""
   name: String!
 
   """
@@ -4470,25 +3297,23 @@ input CreateTagInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-The payload for the createTag mutation
-"""
-type CreateTagPayload @join__type(graph: CMS) {
+"""The payload for the createTag mutation"""
+type CreateTagPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The created post_tag
-  """
+  """The created post_tag"""
   tag: Tag
 }
 
-"""
-Input for the createTranslation mutation
-"""
-input CreateTranslationInput @join__type(graph: CMS) {
+"""Input for the createTranslation mutation"""
+input CreateTranslationInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -4504,49 +3329,37 @@ input CreateTranslationInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the createTranslation mutation
-"""
-type CreateTranslationPayload @join__type(graph: CMS) {
+"""The payload for the createTranslation mutation"""
+type CreateTranslationPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   translation: Translation
 }
 
-"""
-Input for the createUser mutation
-"""
-input CreateUserInput @join__type(graph: CMS) {
-  """
-  User's AOL IM account.
-  """
+"""Input for the createUser mutation"""
+input CreateUserInput
+  @join__type(graph: CMS)
+{
+  """User's AOL IM account."""
   aim: String
 
   """
@@ -4554,9 +3367,7 @@ input CreateUserInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  A string containing content about the user.
-  """
+  """A string containing content about the user."""
   description: String
 
   """
@@ -4564,29 +3375,19 @@ input CreateUserInput @join__type(graph: CMS) {
   """
   displayName: String
 
-  """
-  A string containing the user's email address.
-  """
+  """A string containing the user's email address."""
   email: String
 
-  """
-  The user's first name.
-  """
+  """	The user's first name."""
   firstName: String
 
-  """
-  User's Jabber account.
-  """
+  """User's Jabber account."""
   jabber: String
 
-  """
-  The user's last name.
-  """
+  """The user's last name."""
   lastName: String
 
-  """
-  User's locale.
-  """
+  """User's locale."""
   locale: String
 
   """
@@ -4594,19 +3395,13 @@ input CreateUserInput @join__type(graph: CMS) {
   """
   nicename: String
 
-  """
-  The user's nickname, defaults to the user's username.
-  """
+  """The user's nickname, defaults to the user's username."""
   nickname: String
 
-  """
-  A string that contains the plain text password for the user.
-  """
+  """A string that contains the plain text password for the user."""
   password: String
 
-  """
-  The date the user registered. Format is Y-m-d H:i:s.
-  """
+  """The date the user registered. Format is Y-m-d H:i:s."""
   registered: String
 
   """
@@ -4614,203 +3409,147 @@ input CreateUserInput @join__type(graph: CMS) {
   """
   richEditing: String
 
-  """
-  An array of roles to be assigned to the user.
-  """
+  """An array of roles to be assigned to the user."""
   roles: [String]
 
-  """
-  A string that contains the user's username for logging in.
-  """
+  """A string that contains the user's username for logging in."""
   username: String!
 
-  """
-  A string containing the user's URL for the user's web site.
-  """
+  """A string containing the user's URL for the user's web site."""
   websiteUrl: String
 
-  """
-  User's Yahoo IM account.
-  """
+  """User's Yahoo IM account."""
   yim: String
 }
 
-"""
-The payload for the createUser mutation
-"""
-type CreateUserPayload @join__type(graph: CMS) {
+"""The payload for the createUser mutation"""
+type CreateUserPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The User object mutation type.
-  """
+  """The User object mutation type."""
   user: User
 }
 
-"""
-Object that can be identified with a Database ID
-"""
-interface DatabaseIdentifier @join__type(graph: CMS) {
-  """
-  The unique identifier stored in the database
-  """
+"""Object that can be identified with a Database ID"""
+interface DatabaseIdentifier
+  @join__type(graph: CMS)
+{
+  """The unique identifier stored in the database"""
   databaseId: Int!
 }
 
-"""
-Date values
-"""
-input DateInput @join__type(graph: CMS) {
-  """
-  Day of the month (from 1 to 31)
-  """
+"""Date values"""
+input DateInput
+  @join__type(graph: CMS)
+{
+  """Day of the month (from 1 to 31)"""
   day: Int
 
-  """
-  Month number (from 1 to 12)
-  """
+  """Month number (from 1 to 12)"""
   month: Int
 
-  """
-  4 digit year (e.g. 2017)
-  """
+  """4 digit year (e.g. 2017)"""
   year: Int
 }
 
-"""
-Filter the connection based on input
-"""
-input DateQueryInput @join__type(graph: CMS) {
-  """
-  Nodes should be returned after this date
-  """
+"""Filter the connection based on input"""
+input DateQueryInput
+  @join__type(graph: CMS)
+{
+  """Nodes should be returned after this date"""
   after: DateInput
 
-  """
-  Nodes should be returned before this date
-  """
+  """Nodes should be returned before this date"""
   before: DateInput
 
-  """
-  Column to query against
-  """
+  """Column to query against"""
   column: PostObjectsConnectionDateColumnEnum
 
-  """
-  For after/before, whether exact value should be matched or not
-  """
+  """For after/before, whether exact value should be matched or not"""
   compare: String
 
-  """
-  Day of the month (from 1 to 31)
-  """
+  """Day of the month (from 1 to 31)"""
   day: Int
 
-  """
-  Hour (from 0 to 23)
-  """
+  """Hour (from 0 to 23)"""
   hour: Int
 
-  """
-  For after/before, whether exact value should be matched or not
-  """
+  """For after/before, whether exact value should be matched or not"""
   inclusive: Boolean
 
-  """
-  Minute (from 0 to 59)
-  """
+  """Minute (from 0 to 59)"""
   minute: Int
 
-  """
-  Month number (from 1 to 12)
-  """
+  """Month number (from 1 to 12)"""
   month: Int
 
-  """
-  OR or AND, how the sub-arrays should be compared
-  """
+  """OR or AND, how the sub-arrays should be compared"""
   relation: RelationEnum
 
-  """
-  Second (0 to 59)
-  """
+  """Second (0 to 59)"""
   second: Int
 
-  """
-  Week of the year (from 0 to 53)
-  """
+  """Week of the year (from 0 to 53)"""
   week: Int
 
-  """
-  4 digit year (e.g. 2017)
-  """
+  """4 digit year (e.g. 2017)"""
   year: Int
 }
 
-scalar DateTime @join__type(graph: UNIFIED_SEARCH)
+scalar DateTime
+  @join__type(graph: UNIFIED_SEARCH)
 
 """
 Default images of different post types. Returns url of image of queried post type. Values come from Sivuston Asetukset -&gt; Oletuskuvat.
 """
-type DefaultImages @join__type(graph: CMS) {
-  """
-  Attachment URL for article image
-  """
+type DefaultImages
+  @join__type(graph: CMS)
+{
+  """Attachment URL for article image"""
   article: String
 
-  """
-  Attachment URL for event image
-  """
+  """Attachment URL for event image"""
   event: String
 
-  """
-  Attachment URL for hero image
-  """
+  """Attachment URL for hero image"""
   hero: String
 
-  """
-  Attachment URL for page image
-  """
+  """Attachment URL for page image"""
   page: String
 }
 
-"""
-The template assigned to the node
-"""
+"""The template assigned to the node"""
 type DefaultTemplate implements ContentTemplate
   @join__implements(graph: CMS, interface: "ContentTemplate")
-  @join__type(graph: CMS) {
-  """
-  The name of the template
-  """
+  @join__type(graph: CMS)
+{
+  """The name of the template"""
   templateName: String
 }
 
-"""
-Input for the deleteCategory mutation
-"""
-input DeleteCategoryInput @join__type(graph: CMS) {
+"""Input for the deleteCategory mutation"""
+input DeleteCategoryInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the category to delete
-  """
+  """The ID of the category to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteCategory mutation
-"""
-type DeleteCategoryPayload @join__type(graph: CMS) {
-  """
-  The deteted term object
-  """
+"""The payload for the deleteCategory mutation"""
+type DeleteCategoryPayload
+  @join__type(graph: CMS)
+{
+  """The deteted term object"""
   category: Category
 
   """
@@ -4818,16 +3557,14 @@ type DeleteCategoryPayload @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 }
 
-"""
-Input for the deleteCollection mutation
-"""
-input DeleteCollectionInput @join__type(graph: CMS) {
+"""Input for the deleteCollection mutation"""
+input DeleteCollectionInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -4838,36 +3575,30 @@ input DeleteCollectionInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the collection to delete
-  """
+  """The ID of the collection to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteCollection mutation
-"""
-type DeleteCollectionPayload @join__type(graph: CMS) {
+"""The payload for the deleteCollection mutation"""
+type DeleteCollectionPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The object before it was deleted
-  """
+  """The object before it was deleted"""
   collection: Collection
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 }
 
-"""
-Input for the deleteComment mutation
-"""
-input DeleteCommentInput @join__type(graph: CMS) {
+"""Input for the deleteComment mutation"""
+input DeleteCommentInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -4878,36 +3609,30 @@ input DeleteCommentInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The deleted comment ID
-  """
+  """The deleted comment ID"""
   id: ID!
 }
 
-"""
-The payload for the deleteComment mutation
-"""
-type DeleteCommentPayload @join__type(graph: CMS) {
+"""The payload for the deleteComment mutation"""
+type DeleteCommentPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The deleted comment object
-  """
+  """The deleted comment object"""
   comment: Comment
 
-  """
-  The deleted comment ID
-  """
+  """The deleted comment ID"""
   deletedId: ID
 }
 
-"""
-Input for the deleteContact mutation
-"""
-input DeleteContactInput @join__type(graph: CMS) {
+"""Input for the deleteContact mutation"""
+input DeleteContactInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -4918,36 +3643,30 @@ input DeleteContactInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the contact to delete
-  """
+  """The ID of the contact to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteContact mutation
-"""
-type DeleteContactPayload @join__type(graph: CMS) {
+"""The payload for the deleteContact mutation"""
+type DeleteContactPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The object before it was deleted
-  """
+  """The object before it was deleted"""
   contact: Contact
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 }
 
-"""
-Input for the deleteLandingPage mutation
-"""
-input DeleteLandingPageInput @join__type(graph: CMS) {
+"""Input for the deleteLandingPage mutation"""
+input DeleteLandingPageInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -4958,36 +3677,30 @@ input DeleteLandingPageInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the landingPage to delete
-  """
+  """The ID of the landingPage to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteLandingPage mutation
-"""
-type DeleteLandingPagePayload @join__type(graph: CMS) {
+"""The payload for the deleteLandingPage mutation"""
+type DeleteLandingPagePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 
-  """
-  The object before it was deleted
-  """
+  """The object before it was deleted"""
   landingPage: LandingPage
 }
 
-"""
-Input for the deleteMediaItem mutation
-"""
-input DeleteMediaItemInput @join__type(graph: CMS) {
+"""Input for the deleteMediaItem mutation"""
+input DeleteMediaItemInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -4998,36 +3711,30 @@ input DeleteMediaItemInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the mediaItem to delete
-  """
+  """The ID of the mediaItem to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteMediaItem mutation
-"""
-type DeleteMediaItemPayload @join__type(graph: CMS) {
+"""The payload for the deleteMediaItem mutation"""
+type DeleteMediaItemPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted mediaItem
-  """
+  """The ID of the deleted mediaItem"""
   deletedId: ID
 
-  """
-  The mediaItem before it was deleted
-  """
+  """The mediaItem before it was deleted"""
   mediaItem: MediaItem
 }
 
-"""
-Input for the deletePage mutation
-"""
-input DeletePageInput @join__type(graph: CMS) {
+"""Input for the deletePage mutation"""
+input DeletePageInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -5038,71 +3745,59 @@ input DeletePageInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the page to delete
-  """
+  """The ID of the page to delete"""
   id: ID!
 }
 
-"""
-The payload for the deletePage mutation
-"""
-type DeletePagePayload @join__type(graph: CMS) {
+"""The payload for the deletePage mutation"""
+type DeletePagePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 
-  """
-  The object before it was deleted
-  """
+  """The object before it was deleted"""
   page: Page
 }
 
-"""
-Input for the deletePostFormat mutation
-"""
-input DeletePostFormatInput @join__type(graph: CMS) {
+"""Input for the deletePostFormat mutation"""
+input DeletePostFormatInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the postFormat to delete
-  """
+  """The ID of the postFormat to delete"""
   id: ID!
 }
 
-"""
-The payload for the deletePostFormat mutation
-"""
-type DeletePostFormatPayload @join__type(graph: CMS) {
+"""The payload for the deletePostFormat mutation"""
+type DeletePostFormatPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 
-  """
-  The deteted term object
-  """
+  """The deteted term object"""
   postFormat: PostFormat
 }
 
-"""
-Input for the deletePost mutation
-"""
-input DeletePostInput @join__type(graph: CMS) {
+"""Input for the deletePost mutation"""
+input DeletePostInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -5113,36 +3808,30 @@ input DeletePostInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the post to delete
-  """
+  """The ID of the post to delete"""
   id: ID!
 }
 
-"""
-The payload for the deletePost mutation
-"""
-type DeletePostPayload @join__type(graph: CMS) {
+"""The payload for the deletePost mutation"""
+type DeletePostPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 
-  """
-  The object before it was deleted
-  """
+  """The object before it was deleted"""
   post: Post
 }
 
-"""
-Input for the deleteRelease mutation
-"""
-input DeleteReleaseInput @join__type(graph: CMS) {
+"""Input for the deleteRelease mutation"""
+input DeleteReleaseInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -5153,71 +3842,59 @@ input DeleteReleaseInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the release to delete
-  """
+  """The ID of the release to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteRelease mutation
-"""
-type DeleteReleasePayload @join__type(graph: CMS) {
+"""The payload for the deleteRelease mutation"""
+type DeleteReleasePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 
-  """
-  The object before it was deleted
-  """
+  """The object before it was deleted"""
   release: Release
 }
 
-"""
-Input for the deleteTag mutation
-"""
-input DeleteTagInput @join__type(graph: CMS) {
+"""Input for the deleteTag mutation"""
+input DeleteTagInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the tag to delete
-  """
+  """The ID of the tag to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteTag mutation
-"""
-type DeleteTagPayload @join__type(graph: CMS) {
+"""The payload for the deleteTag mutation"""
+type DeleteTagPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 
-  """
-  The deteted term object
-  """
+  """The deteted term object"""
   tag: Tag
 }
 
-"""
-Input for the deleteTranslation mutation
-"""
-input DeleteTranslationInput @join__type(graph: CMS) {
+"""Input for the deleteTranslation mutation"""
+input DeleteTranslationInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -5228,69 +3905,55 @@ input DeleteTranslationInput @join__type(graph: CMS) {
   """
   forceDelete: Boolean
 
-  """
-  The ID of the translation to delete
-  """
+  """The ID of the translation to delete"""
   id: ID!
 }
 
-"""
-The payload for the deleteTranslation mutation
-"""
-type DeleteTranslationPayload @join__type(graph: CMS) {
+"""The payload for the deleteTranslation mutation"""
+type DeleteTranslationPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the deleted object
-  """
+  """The ID of the deleted object"""
   deletedId: ID
 
-  """
-  The object before it was deleted
-  """
+  """The object before it was deleted"""
   translation: Translation
 }
 
-"""
-Input for the deleteUser mutation
-"""
-input DeleteUserInput @join__type(graph: CMS) {
+"""Input for the deleteUser mutation"""
+input DeleteUserInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the user you want to delete
-  """
+  """The ID of the user you want to delete"""
   id: ID!
 
-  """
-  Reassign posts and links to new User ID.
-  """
+  """Reassign posts and links to new User ID."""
   reassignId: ID
 }
 
-"""
-The payload for the deleteUser mutation
-"""
-type DeleteUserPayload @join__type(graph: CMS) {
+"""The payload for the deleteUser mutation"""
+type DeleteUserPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the user that you just deleted
-  """
+  """The ID of the user that you just deleted"""
   deletedId: ID
 
-  """
-  The deleted user object
-  """
+  """The deleted user object"""
   user: User
 }
 
@@ -5298,19 +3961,19 @@ type DeleteUserPayload @join__type(graph: CMS) {
 Resources (media) that provide extra description of a resource,
 facility, event or venue, such as images, videos, info pages, etc.
 """
-type DescriptionResources @join__type(graph: UNIFIED_SEARCH) {
+type DescriptionResources
+  @join__type(graph: UNIFIED_SEARCH)
+{
   mediaResources: [MediaResource!]!
   infoUrls: [String!]!
   externalLinks: [String!]!
 }
 
-"""
-The discussion setting type
-"""
-type DiscussionSettings @join__type(graph: CMS) {
-  """
-  Salli uusien artikkelien kommentointi.
-  """
+"""The discussion setting type"""
+type DiscussionSettings
+  @join__type(graph: CMS)
+{
+  """Salli uusien artikkelien kommentointi."""
   defaultCommentStatus: String
 
   """
@@ -5319,153 +3982,111 @@ type DiscussionSettings @join__type(graph: CMS) {
   defaultPingStatus: String
 }
 
-type Division @join__type(graph: EVENTS) {
+type Division
+  @join__type(graph: EVENTS)
+{
   type: String!
   ocdId: String
   municipality: String
   name: LocalizedObject
 }
 
-"""
-Elasticsearch results
-"""
-type ElasticSearchResult @join__type(graph: UNIFIED_SEARCH) {
+"""Elasticsearch results"""
+type ElasticSearchResult
+  @join__type(graph: UNIFIED_SEARCH)
+{
   took: Int
   timed_out: Boolean
   _shards: Shards
   hits: Hits
 }
 
-"""
-Asset enqueued by the CMS
-"""
-interface EnqueuedAsset @join__type(graph: CMS) {
-  """
-  @todo
-  """
+"""Asset enqueued by the CMS"""
+interface EnqueuedAsset
+  @join__type(graph: CMS)
+{
+  """@todo"""
   args: Boolean
 
-  """
-  Dependencies needed to use this asset
-  """
+  """Dependencies needed to use this asset"""
   dependencies: [EnqueuedScript]
 
-  """
-  Extra information needed for the script
-  """
+  """Extra information needed for the script"""
   extra: String
 
-  """
-  The handle of the enqueued asset
-  """
+  """The handle of the enqueued asset"""
   handle: String
 
-  """
-  The ID of the enqueued asset
-  """
+  """The ID of the enqueued asset"""
   id: ID!
 
-  """
-  The source of the asset
-  """
+  """The source of the asset"""
   src: String
 
-  """
-  The version of the enqueued asset
-  """
+  """The version of the enqueued asset"""
   version: String
 }
 
-"""
-Script enqueued by the CMS
-"""
+"""Script enqueued by the CMS"""
 type EnqueuedScript implements Node & EnqueuedAsset
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "EnqueuedAsset")
-  @join__type(graph: CMS) {
-  """
-  @todo
-  """
+  @join__type(graph: CMS)
+{
+  """@todo"""
   args: Boolean
 
-  """
-  Dependencies needed to use this asset
-  """
+  """Dependencies needed to use this asset"""
   dependencies: [EnqueuedScript]
 
-  """
-  Extra information needed for the script
-  """
+  """Extra information needed for the script"""
   extra: String
 
-  """
-  The handle of the enqueued asset
-  """
+  """The handle of the enqueued asset"""
   handle: String
 
-  """
-  The ID of the enqueued asset
-  """
+  """The ID of the enqueued asset"""
   id: ID!
 
-  """
-  The source of the asset
-  """
+  """The source of the asset"""
   src: String
 
-  """
-  The version of the enqueued asset
-  """
+  """The version of the enqueued asset"""
   version: String
 }
 
-"""
-Stylesheet enqueued by the CMS
-"""
+"""Stylesheet enqueued by the CMS"""
 type EnqueuedStylesheet implements Node & EnqueuedAsset
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "EnqueuedAsset")
-  @join__type(graph: CMS) {
-  """
-  @todo
-  """
+  @join__type(graph: CMS)
+{
+  """@todo"""
   args: Boolean
 
-  """
-  Dependencies needed to use this asset
-  """
+  """Dependencies needed to use this asset"""
   dependencies: [EnqueuedScript]
 
-  """
-  Extra information needed for the script
-  """
+  """Extra information needed for the script"""
   extra: String
 
-  """
-  The handle of the enqueued asset
-  """
+  """The handle of the enqueued asset"""
   handle: String
 
-  """
-  The ID of the enqueued asset
-  """
+  """The ID of the enqueued asset"""
   id: ID!
 
-  """
-  The source of the asset
-  """
+  """The source of the asset"""
   src: String
 
-  """
-  The version of the enqueued asset
-  """
+  """The version of the enqueued asset"""
   version: String
 }
 
-"""
-Information about enrolled participant(s) in an event occurrence
-"""
-type Enrolment @join__type(graph: UNIFIED_SEARCH) {
+"""Information about enrolled participant(s) in an event occurrence"""
+type Enrolment
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   event: EventOccurrence
   enroller: Person
@@ -5479,10 +4100,10 @@ type Enrolment @join__type(graph: UNIFIED_SEARCH) {
   extraInformation: String
 }
 
-"""
-Rules about who can enroll to an event and how
-"""
-type EnrolmentPolicy @join__type(graph: UNIFIED_SEARCH) {
+"""Rules about who can enroll to an event and how"""
+type EnrolmentPolicy
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   type: [EnrolmentPolicyType!]!
   enrolmentTime: TimeDescription
@@ -5490,25 +4111,25 @@ type EnrolmentPolicy @join__type(graph: UNIFIED_SEARCH) {
   participantMinimumAge: Int!
   participantMaximumAge: Int!
 
-  """
-  minimum number of people who can enrol together (at the same time)
-  """
+  """minimum number of people who can enrol together (at the same time)"""
   minimumEnrolmentCount: Int
 
-  """
-  maximum number of people who can enrol together (at the same time)
-  """
+  """maximum number of people who can enrol together (at the same time)"""
   maximumEnrolmentCount: Int
 }
 
-enum EnrolmentPolicyType @join__type(graph: UNIFIED_SEARCH) {
+enum EnrolmentPolicyType
+  @join__type(graph: UNIFIED_SEARCH)
+{
   NO_ENROLMENT_NEEDED
   GROUPS
   GROUPS_WITH_SUPERVISORS
   INDIVIDUALS
 }
 
-enum EnrolmentStatus @join__type(graph: UNIFIED_SEARCH) {
+enum EnrolmentStatus
+  @join__type(graph: UNIFIED_SEARCH)
+{
   REQUESTED
   QUEUED
   CONFIRMED
@@ -5521,7 +4142,9 @@ Request for equipment - if someone needs equipment for a purpose such
 as organising a volunteering event (as is the case in park cleaning
 bees), a specification of what is being requested.
 """
-type EquipmentRequest @join__type(graph: UNIFIED_SEARCH) {
+type EquipmentRequest
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   requestedEquipment: String!
   estimatedAmount: Int
@@ -5538,7 +4161,9 @@ meetups, concerts, volunteering occasions (or bees), happenings.  This
 corresponds to Linked events/courses event, beta.kultus
 PalvelutarjotinEventNode, Kukkuu event.
 """
-type Event @join__type(graph: UNIFIED_SEARCH) {
+type Event
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   name: LanguageString
   description: LanguageString
@@ -5559,7 +4184,9 @@ type Event @join__type(graph: UNIFIED_SEARCH) {
   targetAudience: [KeywordString!]
 }
 
-type EventDetails @join__type(graph: EVENTS) {
+type EventDetails
+  @join__type(graph: EVENTS)
+{
   id: ID!
   typeId: EventTypeId
   location: Place
@@ -5600,17 +4227,19 @@ type EventDetails @join__type(graph: EVENTS) {
   remainingAttendeeCapacity: Int
 }
 
-type EventListResponse @join__type(graph: EVENTS) {
+type EventListResponse
+  @join__type(graph: EVENTS)
+{
   meta: Meta!
   data: [EventDetails!]!
 }
 
-type EventOccurrence @join__type(graph: UNIFIED_SEARCH) {
+type EventOccurrence
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
 
-  """
-  which event this is an occurrence of
-  """
+  """which event this is an occurrence of"""
   ofEvent: Event
   happensAt: TimeDescription
 
@@ -5627,13 +4256,13 @@ type EventOccurrence @join__type(graph: UNIFIED_SEARCH) {
   maximumAttendeeCount: Int
   currentlyAvailableParticipantCount: Int
 
-  """
-  for events where equipment is requested from the City of Helsinki
-  """
+  """for events where equipment is requested from the City of Helsinki"""
   cityEquipmentRequests: [EquipmentRequest!]
 }
 
-enum EventOccurrenceStatus @join__type(graph: UNIFIED_SEARCH) {
+enum EventOccurrenceStatus
+  @join__type(graph: UNIFIED_SEARCH)
+{
   UNPUBLISHED
   PUBLISHED
   CANCELLED
@@ -5641,31 +4270,25 @@ enum EventOccurrenceStatus @join__type(graph: UNIFIED_SEARCH) {
   POSTPONED
 }
 
-"""
-TODO: improve (a lot) over Linked events' offer type
-"""
-type EventPricing @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: improve (a lot) over Linked events' offer type"""
+type EventPricing
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   todo: String
 }
 
-"""
-Collection Module: EventSearch
-"""
-type EventSearch @join__type(graph: CMS) {
-  """
-  Amount of events listed before &quot;show more -button&quot;
-  """
+"""Collection Module: EventSearch"""
+type EventSearch
+  @join__type(graph: CMS)
+{
+  """Amount of events listed before &quot;show more -button&quot;"""
   initAmountOfEvents: Int
 
-  """
-  Module type
-  """
+  """Module type"""
   module: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [CollectionModulesUnionType]
 
   """
@@ -5675,44 +4298,30 @@ type EventSearch @join__type(graph: CMS) {
   """
   showAllLink: String
 
-  """
-  Module title
-  """
+  """Module title"""
   title: String
 
-  """
-  Search query
-  """
+  """Search query"""
   url: String
 }
 
-"""
-Collection Module: EventSearchCarousel
-"""
-type EventSearchCarousel @join__type(graph: CMS) {
-  """
-  Amount of cards in carousel
-  """
+"""Collection Module: EventSearchCarousel"""
+type EventSearchCarousel
+  @join__type(graph: CMS)
+{
+  """Amount of cards in carousel"""
   amountOfCards: Int
 
-  """
-  Events nearby
-  """
+  """Events nearby"""
   eventsNearby: Boolean
 
-  """
-  Module type
-  """
+  """Module type"""
   module: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [CollectionModulesUnionType]
 
-  """
-  Events order
-  """
+  """Events order"""
   orderNewestFirst: Boolean
 
   """
@@ -5722,177 +4331,130 @@ type EventSearchCarousel @join__type(graph: CMS) {
   """
   showAllLink: String
 
-  """
-  Module title
-  """
+  """Module title"""
   title: String
 
-  """
-  Search query
-  """
+  """Search query"""
   url: String
 }
 
-"""
-Collection Module: EventSelected
-"""
-type EventSelected @join__type(graph: CMS) {
-  """
-  List of event IDs
-  """
+"""Collection Module: EventSelected"""
+type EventSelected
+  @join__type(graph: CMS)
+{
+  """List of event IDs"""
   events: [String]
 
-  """
-  Amount of events listed before &quot;show more -button&quot;
-  """
+  """Amount of events listed before &quot;show more -button&quot;"""
   initAmountOfEvents: Int
 
-  """
-  Module type
-  """
+  """Module type"""
   module: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [CollectionModulesUnionType]
 
-  """
-  Show all -link
-  """
+  """Show all -link"""
   showAllLink: String
 
-  """
-  Module title
-  """
+  """Module title"""
   title: String
 }
 
-"""
-Collection Module: EventSelectedCarousel
-"""
-type EventSelectedCarousel @join__type(graph: CMS) {
-  """
-  Amount of cards in carousel
-  """
+"""Collection Module: EventSelectedCarousel"""
+type EventSelectedCarousel
+  @join__type(graph: CMS)
+{
+  """Amount of cards in carousel"""
   amountOfCards: Int
 
-  """
-  Amount of cards per row
-  """
+  """Amount of cards per row"""
   amountOfCardsPerRow: Int
 
-  """
-  List of event IDs
-  """
+  """List of event IDs"""
   events: [String]
 
-  """
-  Events nearby
-  """
+  """Events nearby"""
   eventsNearby: Boolean
 
-  """
-  Module type
-  """
+  """Module type"""
   module: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [CollectionModulesUnionType]
 
-  """
-  Show all -link
-  """
+  """Show all -link"""
   showAllLink: String
 
-  """
-  Module title
-  """
+  """Module title"""
   title: String
 }
 
-enum EventTypeId @join__type(graph: EVENTS) {
+enum EventTypeId
+  @join__type(graph: EVENTS)
+{
   General
   Course
 }
 
-type ExternalLink @join__type(graph: EVENTS) {
+type ExternalLink
+  @join__type(graph: EVENTS)
+{
   name: String
   link: String
   language: String
 }
 
-"""
-The general setting type
-"""
-type GeneralSettings @join__type(graph: CMS) {
-  """
-  Muoto kaikille päivämäärän merkkijonoille.
-  """
+"""The general setting type"""
+type GeneralSettings
+  @join__type(graph: CMS)
+{
+  """Muoto kaikille päivämäärän merkkijonoille."""
   dateFormat: String
 
-  """
-  Sivuston kuvaus.
-  """
+  """Sivuston kuvaus."""
   description: String
 
-  """
-  WordPressin kieli- ja maakoodi.
-  """
+  """WordPressin kieli- ja maakoodi."""
   language: String
 
-  """
-  Viikonpäivän numero josta viikko alkaa.
-  """
+  """Viikonpäivän numero josta viikko alkaa."""
   startOfWeek: Int
 
-  """
-  Muoto kaikille kellonajan merkkijonoille.
-  """
+  """Muoto kaikille kellonajan merkkijonoille."""
   timeFormat: String
 
-  """
-  Kaupunki samalla aikavyöhykkeellä kuin sinä.
-  """
+  """Kaupunki samalla aikavyöhykkeellä kuin sinä."""
   timezone: String
 
-  """
-  Sivuston otsikko.
-  """
+  """Sivuston otsikko."""
   title: String
 
-  """
-  Site URL.
-  """
+  """Site URL."""
   url: String
 }
 
-"""
-Coordinate Reference System (CRS) object.
-"""
-type GeoJSONCoordinateReferenceSystem @join__type(graph: UNIFIED_SEARCH) {
+"""Coordinate Reference System (CRS) object."""
+type GeoJSONCoordinateReferenceSystem
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONCRSType!
   properties: GeoJSONCRSProperties!
 }
 
-"""
-A (multidimensional) set of coordinates following x, y, z order.
-"""
-scalar GeoJSONCoordinates @join__type(graph: UNIFIED_SEARCH)
+"""A (multidimensional) set of coordinates following x, y, z order."""
+scalar GeoJSONCoordinates
+  @join__type(graph: UNIFIED_SEARCH)
 
-"""
-CRS object properties.
-"""
-union GeoJSONCRSProperties @join__type(graph: UNIFIED_SEARCH) =
-    GeoJSONNamedCRSProperties
-  | GeoJSONLinkedCRSProperties
+"""CRS object properties."""
+union GeoJSONCRSProperties
+  @join__type(graph: UNIFIED_SEARCH)
+ = GeoJSONNamedCRSProperties | GeoJSONLinkedCRSProperties
 
-"""
-Enumeration of all GeoJSON CRS object types.
-"""
-enum GeoJSONCRSType @join__type(graph: UNIFIED_SEARCH) {
+"""Enumeration of all GeoJSON CRS object types."""
+enum GeoJSONCRSType
+  @join__type(graph: UNIFIED_SEARCH)
+{
   name
   link
 }
@@ -5902,7 +4464,8 @@ An object that links a geometry to properties in order to provide context.
 """
 type GeoJSONFeature implements GeoJSONInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
@@ -5911,93 +4474,83 @@ type GeoJSONFeature implements GeoJSONInterface
   id: String
 }
 
-"""
-A set of multiple features.
-"""
+"""A set of multiple features."""
 type GeoJSONFeatureCollection implements GeoJSONInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
   features: [GeoJSONFeature!]!
 }
 
-"""
-A set of multiple geometries, possibly of various types.
-"""
+"""A set of multiple geometries, possibly of various types."""
 type GeoJSONGeometryCollection implements GeoJSONInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
   geometries: [GeoJSONGeometryInterface!]!
 }
 
-interface GeoJSONGeometryInterface @join__type(graph: UNIFIED_SEARCH) {
+interface GeoJSONGeometryInterface
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
   coordinates: GeoJSONCoordinates
 }
 
-interface GeoJSONInterface @join__type(graph: UNIFIED_SEARCH) {
+interface GeoJSONInterface
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
 }
 
-"""
-Object describing a single connected sequence of geographical points.
-"""
+"""Object describing a single connected sequence of geographical points."""
 type GeoJSONLineString implements GeoJSONInterface & GeoJSONGeometryInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__implements(
-    graph: UNIFIED_SEARCH
-    interface: "GeoJSONGeometryInterface"
-  )
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONGeometryInterface")
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Properties for link based CRS object.
-"""
-type GeoJSONLinkedCRSProperties @join__type(graph: UNIFIED_SEARCH) {
+"""Properties for link based CRS object."""
+type GeoJSONLinkedCRSProperties
+  @join__type(graph: UNIFIED_SEARCH)
+{
   href: String!
   type: String
 }
 
-"""
-Object describing multiple connected sequences of geographical points.
-"""
+"""Object describing multiple connected sequences of geographical points."""
 type GeoJSONMultiLineString implements GeoJSONInterface & GeoJSONGeometryInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__implements(
-    graph: UNIFIED_SEARCH
-    interface: "GeoJSONGeometryInterface"
-  )
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONGeometryInterface")
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Object describing multiple geographical points.
-"""
+"""Object describing multiple geographical points."""
 type GeoJSONMultiPoint implements GeoJSONInterface & GeoJSONGeometryInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__implements(
-    graph: UNIFIED_SEARCH
-    interface: "GeoJSONGeometryInterface"
-  )
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONGeometryInterface")
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
@@ -6009,34 +4562,28 @@ Object describing multiple shapes formed by sets of geographical points.
 """
 type GeoJSONMultiPolygon implements GeoJSONInterface & GeoJSONGeometryInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__implements(
-    graph: UNIFIED_SEARCH
-    interface: "GeoJSONGeometryInterface"
-  )
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONGeometryInterface")
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Properties for name based CRS object.
-"""
-type GeoJSONNamedCRSProperties @join__type(graph: UNIFIED_SEARCH) {
+"""Properties for name based CRS object."""
+type GeoJSONNamedCRSProperties
+  @join__type(graph: UNIFIED_SEARCH)
+{
   name: String!
 }
 
-"""
-Object describing a single geographical point.
-"""
+"""Object describing a single geographical point."""
 type GeoJSONPoint implements GeoJSONInterface & GeoJSONGeometryInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__implements(
-    graph: UNIFIED_SEARCH
-    interface: "GeoJSONGeometryInterface"
-  )
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONGeometryInterface")
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
@@ -6048,21 +4595,19 @@ Object describing a single shape formed by a set of geographical points.
 """
 type GeoJSONPolygon implements GeoJSONInterface & GeoJSONGeometryInterface
   @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONInterface")
-  @join__implements(
-    graph: UNIFIED_SEARCH
-    interface: "GeoJSONGeometryInterface"
-  )
-  @join__type(graph: UNIFIED_SEARCH) {
+  @join__implements(graph: UNIFIED_SEARCH, interface: "GeoJSONGeometryInterface")
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
   bbox: [Float]
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Enumeration of all GeoJSON object types.
-"""
-enum GeoJSONType @join__type(graph: UNIFIED_SEARCH) {
+"""Enumeration of all GeoJSON object types."""
+enum GeoJSONType
+  @join__type(graph: UNIFIED_SEARCH)
+{
   Point
   MultiPoint
   LineString
@@ -6074,22 +4619,18 @@ enum GeoJSONType @join__type(graph: UNIFIED_SEARCH) {
   FeatureCollection
 }
 
-"""
-Content node with hierarchical (parent/child) relationships
-"""
-interface HierarchicalContentNode @join__type(graph: CMS) {
+"""Content node with hierarchical (parent/child) relationships"""
+interface HierarchicalContentNode
+  @join__type(graph: CMS)
+{
   """
   Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
   """
   ancestors(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6102,9 +4643,7 @@ interface HierarchicalContentNode @join__type(graph: CMS) {
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeAncestorsConnection
 
@@ -6112,14 +4651,10 @@ interface HierarchicalContentNode @join__type(graph: CMS) {
   Connection between the HierarchicalContentNode type and the ContentNode type
   """
   children(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6132,25 +4667,17 @@ interface HierarchicalContentNode @join__type(graph: CMS) {
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeChildrenConnection
 
-  """
-  The parent of the node. The parent object can be of various types
-  """
+  """The parent of the node. The parent object can be of various types"""
   parent: HierarchicalContentNodeToParentContentNodeConnectionEdge
 
-  """
-  Database id of the parent node
-  """
+  """Database id of the parent node"""
   parentDatabaseId: Int
 
-  """
-  The globally unique identifier of the parent node.
-  """
+  """The globally unique identifier of the parent node."""
   parentId: ID
 }
 
@@ -6158,36 +4685,28 @@ interface HierarchicalContentNode @join__type(graph: CMS) {
 Connection between the HierarchicalContentNode type and the ContentNode type
 """
 type HierarchicalContentNodeToContentNodeAncestorsConnection
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   Edges for the HierarchicalContentNodeToContentNodeAncestorsConnection connection
   """
   edges: [HierarchicalContentNodeToContentNodeAncestorsConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
+"""An edge in a connection"""
 type HierarchicalContentNodeToContentNodeAncestorsConnectionEdge
-  @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentNode
 }
 
@@ -6195,15 +4714,12 @@ type HierarchicalContentNodeToContentNodeAncestorsConnectionEdge
 Arguments for filtering the HierarchicalContentNodeToContentNodeAncestorsConnection connection
 """
 input HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
-  @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -6211,29 +4727,19 @@ input HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -6241,49 +4747,31 @@ input HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
@@ -6291,36 +4779,28 @@ input HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
 Connection between the HierarchicalContentNode type and the ContentNode type
 """
 type HierarchicalContentNodeToContentNodeChildrenConnection
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   Edges for the HierarchicalContentNodeToContentNodeChildrenConnection connection
   """
   edges: [HierarchicalContentNodeToContentNodeChildrenConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
+"""An edge in a connection"""
 type HierarchicalContentNodeToContentNodeChildrenConnectionEdge
-  @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentNode
 }
 
@@ -6328,15 +4808,12 @@ type HierarchicalContentNodeToContentNodeChildrenConnectionEdge
 Arguments for filtering the HierarchicalContentNodeToContentNodeChildrenConnection connection
 """
 input HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
-  @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -6344,29 +4821,19 @@ input HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -6374,49 +4841,31 @@ input HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
@@ -6424,67 +4873,60 @@ input HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
 Connection between the HierarchicalContentNode type and the ContentNode type
 """
 type HierarchicalContentNodeToParentContentNodeConnectionEdge
-  @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: ContentNode
 }
 
-"""
-Term node with hierarchical (parent/child) relationships
-"""
-interface HierarchicalTermNode @join__type(graph: CMS) {
-  """
-  Database id of the parent node
-  """
+"""Term node with hierarchical (parent/child) relationships"""
+interface HierarchicalTermNode
+  @join__type(graph: CMS)
+{
+  """Database id of the parent node"""
   parentDatabaseId: Int
 
-  """
-  The globally unique identifier of the parent node.
-  """
+  """The globally unique identifier of the parent node."""
   parentId: ID
 }
 
-type Hits @join__type(graph: UNIFIED_SEARCH) {
+type Hits
+  @join__type(graph: UNIFIED_SEARCH)
+{
   max_score: Float
   total: HitTotal
   hits: [SingleHit]
 }
 
-type HitTotal @join__type(graph: UNIFIED_SEARCH) {
+type HitTotal
+  @join__type(graph: UNIFIED_SEARCH)
+{
   value: Int
   relation: String
 }
 
-enum IdentificationStrength @join__type(graph: UNIFIED_SEARCH) {
-  """
-  If this person is just a pseudoperson for contacting
-  """
+enum IdentificationStrength
+  @join__type(graph: UNIFIED_SEARCH)
+{
+  """If this person is just a pseudoperson for contacting"""
   NONIDENTIFIABLE
 
-  """
-  If the identity of this person is not known at all
-  """
+  """If the identity of this person is not known at all"""
   UNIDENTIFIED
 
-  """
-  If the person has authenticated with at least some method
-  """
+  """If the person has authenticated with at least some method"""
   AUTHENTICATED
 
-  """
-  If the person has done some identifiable action such as payment
-  """
+  """If the person has done some identifiable action such as payment"""
   INDIRECT
 
-  """
-  If the person has proved their legal identity
-  """
+  """If the person has proved their legal identity"""
   LEGALLY_CONNECTED
 }
 
-type Image @join__type(graph: EVENTS) {
+type Image
+  @join__type(graph: EVENTS)
+{
   id: ID
   license: String
   createdTime: String
@@ -6500,7 +4942,9 @@ type Image @join__type(graph: EVENTS) {
   internalType: String
 }
 
-type InLanguage @join__type(graph: EVENTS) {
+type InLanguage
+  @join__type(graph: EVENTS)
+{
   id: ID
   translationAvailable: Boolean
   name: LocalizedObject
@@ -6509,37 +4953,28 @@ type InLanguage @join__type(graph: EVENTS) {
   internalType: String
 }
 
-type InternalIdObject @join__type(graph: EVENTS) {
+type InternalIdObject
+  @join__type(graph: EVENTS)
+{
   internalId: String
 }
 
 scalar join__FieldSet
 
 enum join__Graph {
-  CMS
-    @join__graph(
-      name: "cms"
-      url: "https://tapahtumat.hkih.stage.geniem.io/graphql"
-    )
-  EVENTS
-    @join__graph(
-      name: "events"
-      url: "https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql"
-    )
-  UNIFIED_SEARCH
-    @join__graph(
-      name: "unified-search"
-      url: "https://unified-search.test.kuva.hel.ninja/search"
-    )
+  CMS @join__graph(name: "cms", url: "https://tapahtumat.hkih.stage.geniem.io/graphql")
+  EVENTS @join__graph(name: "events", url: "https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql")
+  UNIFIED_SEARCH @join__graph(name: "unified-search", url: "https://unified-search.test.kuva.hel.ninja/search")
   VENUES @join__graph(name: "venues", url: "http://localhost:3000/api/graphql")
 }
 
-"""
-Arbitrary JSON value
-"""
-scalar JSONObject @join__type(graph: UNIFIED_SEARCH)
+"""Arbitrary JSON value"""
+scalar JSONObject
+  @join__type(graph: UNIFIED_SEARCH)
 
-type Keyword @join__type(graph: EVENTS) {
+type Keyword
+  @join__type(graph: EVENTS)
+{
   id: ID
   altLabels: [String]
   createdTime: String
@@ -6557,7 +4992,9 @@ type Keyword @join__type(graph: EVENTS) {
   internalType: String
 }
 
-type KeywordListResponse @join__type(graph: EVENTS) {
+type KeywordListResponse
+  @join__type(graph: EVENTS)
+{
   meta: Meta!
   data: [Keyword!]!
 }
@@ -6566,13 +5003,13 @@ type KeywordListResponse @join__type(graph: EVENTS) {
 TODO: merge all free tags, categories, and keywords
 KEYWORDS ARE GIVEN FROM events-proxy (https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql)
 """
-type KeywordString @join__type(graph: UNIFIED_SEARCH) {
+type KeywordString
+  @join__type(graph: UNIFIED_SEARCH)
+{
   name: String!
 }
 
-"""
-The landingPage type
-"""
+"""The landingPage type"""
 type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithRevisions
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -6581,64 +5018,41 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   @join__implements(graph: CMS, interface: "NodeWithTemplate")
   @join__implements(graph: CMS, interface: "NodeWithTitle")
   @join__implements(graph: CMS, interface: "NodeWithRevisions")
-  @join__type(graph: CMS) {
-  """
-  Background Color
-  """
+  @join__type(graph: CMS)
+{
+  """Background Color"""
   backgroundColor: String
 
-  """
-  Box Color
-  """
+  """Box Color"""
   boxColor: String
 
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  Description
-  """
+  """Description"""
   description: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
-  """
-  Desktop Image
-  """
+  """Desktop Image"""
   desktopImage(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6651,9 +5065,7 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: LandingPageToMediaItemConnectionWhereArgs
   ): LandingPageToMediaItemConnection
 
@@ -6662,23 +5074,15 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6696,14 +5100,10 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6717,18 +5117,12 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     before: String
   ): ContentNodeToEnqueuedStylesheetConnection
 
-  """
-  Float Image
-  """
+  """Float Image"""
   floatImage(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6741,9 +5135,7 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: LandingPageToFloatImageConnectionWhereArgs
   ): LandingPageToFloatImageConnection
 
@@ -6752,74 +5144,45 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   guid: String
 
-  """
-  Link
-  """
+  """Link"""
   heroLink: [String]
 
-  """
-  The globally unique identifier of the landing-page-cpt object.
-  """
+  """The globally unique identifier of the landing-page-cpt object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  True if the node is a revision of another node
-  """
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  landingPageId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """The id field matches the WP_Post-&gt;ID field."""
+  landingPageId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Polylang language
-  """
+  """Polylang language"""
   language: Language
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
-  """
-  Mobile Image
-  """
+  """Mobile Image"""
   mobileImage(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6832,9 +5195,7 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: LandingPageToMobileImageConnectionWhereArgs
   ): LandingPageToMobileImageConnection
 
@@ -6848,24 +5209,16 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   modifiedGmt: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [CollectionModulesUnionType]
 
-  """
-  Connection between the landingPage type and the landingPage type
-  """
+  """Connection between the landingPage type and the landingPage type"""
   preview: LandingPageToPreviewConnectionEdge
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -6873,18 +5226,12 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 
-  """
-  Connection between the landingPage type and the landingPage type
-  """
+  """Connection between the landingPage type and the landingPage type"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6897,15 +5244,11 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: LandingPageToRevisionConnectionWhereArgs
   ): LandingPageToRevisionConnection
 
-  """
-  The SEO Framework data of the landingPage
-  """
+  """The SEO Framework data of the landingPage"""
   seo: SEO
 
   """
@@ -6913,28 +5256,18 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to the node
-  """
+  """The template assigned to the node"""
   template: ContentTemplate
 
-  """
-  Connection between the landingPage type and the TermNode type
-  """
+  """Connection between the landingPage type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -6947,9 +5280,7 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: LandingPageToTermNodeConnectionWhereArgs
   ): LandingPageToTermNodeConnection
 
@@ -6957,40 +5288,28 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): LandingPage
 
-  """
-  List all translated versions of this post
-  """
+  """List all translated versions of this post"""
   translations: [LandingPage]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum LandingPageIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum LandingPageIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
   """
@@ -6998,59 +5317,45 @@ enum LandingPageIdType @join__type(graph: CMS) {
   """
   SLUG
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-"""
-Connection between the landingPage type and the MediaItem type
-"""
-type LandingPageToFloatImageConnection @join__type(graph: CMS) {
-  """
-  Edges for the LandingPageToFloatImageConnection connection
-  """
+"""Connection between the landingPage type and the MediaItem type"""
+type LandingPageToFloatImageConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the LandingPageToFloatImageConnection connection"""
   edges: [LandingPageToFloatImageConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MediaItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type LandingPageToFloatImageConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type LandingPageToFloatImageConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MediaItem
 }
 
 """
 Arguments for filtering the LandingPageToFloatImageConnection connection
 """
-input LandingPageToFloatImageConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+input LandingPageToFloatImageConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -7058,29 +5363,19 @@ input LandingPageToFloatImageConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -7088,99 +5383,69 @@ input LandingPageToFloatImageConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the landingPage type and the MediaItem type
-"""
-type LandingPageToMediaItemConnection @join__type(graph: CMS) {
-  """
-  Edges for the LandingPageToMediaItemConnection connection
-  """
+"""Connection between the landingPage type and the MediaItem type"""
+type LandingPageToMediaItemConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the LandingPageToMediaItemConnection connection"""
   edges: [LandingPageToMediaItemConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MediaItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type LandingPageToMediaItemConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type LandingPageToMediaItemConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MediaItem
 }
 
 """
 Arguments for filtering the LandingPageToMediaItemConnection connection
 """
-input LandingPageToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+input LandingPageToMediaItemConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -7188,29 +5453,19 @@ input LandingPageToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -7218,99 +5473,69 @@ input LandingPageToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the landingPage type and the MediaItem type
-"""
-type LandingPageToMobileImageConnection @join__type(graph: CMS) {
-  """
-  Edges for the LandingPageToMobileImageConnection connection
-  """
+"""Connection between the landingPage type and the MediaItem type"""
+type LandingPageToMobileImageConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the LandingPageToMobileImageConnection connection"""
   edges: [LandingPageToMobileImageConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MediaItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type LandingPageToMobileImageConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type LandingPageToMobileImageConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MediaItem
 }
 
 """
 Arguments for filtering the LandingPageToMobileImageConnection connection
 """
-input LandingPageToMobileImageConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+input LandingPageToMobileImageConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -7318,29 +5543,19 @@ input LandingPageToMobileImageConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -7348,104 +5563,72 @@ input LandingPageToMobileImageConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the landingPage type and the landingPage type
-"""
-type LandingPageToPreviewConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the landingPage type and the landingPage type"""
+type LandingPageToPreviewConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: LandingPage
 }
 
-"""
-Connection between the landingPage type and the landingPage type
-"""
-type LandingPageToRevisionConnection @join__type(graph: CMS) {
-  """
-  Edges for the landingPageToRevisionConnection connection
-  """
+"""Connection between the landingPage type and the landingPage type"""
+type LandingPageToRevisionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the landingPageToRevisionConnection connection"""
   edges: [LandingPageToRevisionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [LandingPage]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type LandingPageToRevisionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type LandingPageToRevisionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: LandingPage
 }
 
-"""
-Arguments for filtering the landingPageToRevisionConnection connection
-"""
-input LandingPageToRevisionConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the landingPageToRevisionConnection connection"""
+input LandingPageToRevisionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -7453,29 +5636,19 @@ input LandingPageToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -7483,91 +5656,63 @@ input LandingPageToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the landingPage type and the TermNode type
-"""
-type LandingPageToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the LandingPageToTermNodeConnection connection
-  """
+"""Connection between the landingPage type and the TermNode type"""
+type LandingPageToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the LandingPageToTermNodeConnection connection"""
   edges: [LandingPageToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type LandingPageToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type LandingPageToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the LandingPageToTermNodeConnection connection
-"""
-input LandingPageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the LandingPageToTermNodeConnection connection"""
+input LandingPageToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -7608,19 +5753,13 @@ input LandingPageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -7628,14 +5767,10 @@ input LandingPageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -7643,9 +5778,7 @@ input LandingPageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -7653,49 +5786,33 @@ input LandingPageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Language (Polylang)
-"""
-type Language @join__type(graph: CMS) {
-  """
-  Language code (Polylang)
-  """
+"""Language (Polylang)"""
+type Language
+  @join__type(graph: CMS)
+{
+  """Language code (Polylang)"""
   code: LanguageCodeEnum
 
-  """
-  Language ID (Polylang)
-  """
+  """Language ID (Polylang)"""
   id: ID!
 
-  """
-  Language locale (Polylang)
-  """
+  """Language locale (Polylang)"""
   locale: String
 
-  """
-  Human readable language name (Polylang)
-  """
+  """Human readable language name (Polylang)"""
   name: String
 
   """
@@ -7704,15 +5821,13 @@ type Language @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-Enum of all available language codes
-"""
-enum LanguageCodeEnum @join__type(graph: CMS) {
+"""Enum of all available language codes"""
+enum LanguageCodeEnum
+  @join__type(graph: CMS)
+{
   EN
 
-  """
-  The default locale of the site
-  """
+  """The default locale of the site"""
   FI
   SV
 }
@@ -7720,311 +5835,217 @@ enum LanguageCodeEnum @join__type(graph: CMS) {
 """
 Filter item by specific language, default language or list all languages
 """
-enum LanguageCodeFilterEnum @join__type(graph: CMS) {
+enum LanguageCodeFilterEnum
+  @join__type(graph: CMS)
+{
   ALL
   DEFAULT
   EN
 
-  """
-  The default locale of the site
-  """
+  """The default locale of the site"""
   FI
   SV
 }
 
-"""
-TODO: convert all String's to LanguageString's if linguistic content
-"""
-type LanguageString @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: convert all String's to LanguageString's if linguistic content"""
+type LanguageString
+  @join__type(graph: UNIFIED_SEARCH)
+{
   fi: String
   sv: String
   en: String
 }
 
-"""
-Layout: LayoutArticleHighlights
-"""
-type LayoutArticleHighlights @join__type(graph: CMS) {
-  """
-  Anchor
-  """
+"""Layout: LayoutArticleHighlights"""
+type LayoutArticleHighlights
+  @join__type(graph: CMS)
+{
+  """Anchor"""
   anchor: String
 
-  """
-  Articles
-  """
+  """Articles"""
   articles: [Post]
 
-  """
-  Background Color
-  """
+  """Background Color"""
   backgroundColor: String
 
-  """
-  Category
-  """
+  """Category"""
   category: Int
 
-  """
-  Amount of articles to list
-  """
+  """Amount of articles to list"""
   limit: Int
 
-  """
-  Show more link
-  """
+  """Show more link"""
   showMore: [String]
 
-  """
-  Tag
-  """
+  """Tag"""
   tag: Int
 
-  """
-  Title
-  """
+  """Title"""
   title: String
 }
 
-"""
-Layout: LayoutArticles
-"""
-type LayoutArticles @join__type(graph: CMS) {
-  """
-  Anchor
-  """
+"""Layout: LayoutArticles"""
+type LayoutArticles
+  @join__type(graph: CMS)
+{
+  """Anchor"""
   anchor: String
 
-  """
-  Articles
-  """
+  """Articles"""
   articles: [Post]
 
-  """
-  Background Color
-  """
+  """Background Color"""
   backgroundColor: String
 
-  """
-  Category
-  """
+  """Category"""
   category: Int
 
-  """
-  Tag
-  """
+  """Tag"""
   limit: Int
 
-  """
-  Show all -link
-  """
+  """Show all -link"""
   showAllLink: String
 
-  """
-  Tag
-  """
+  """Tag"""
   tag: Int
 
-  """
-  Title
-  """
+  """Title"""
   title: String
 }
 
-"""
-Layout: LayoutArticlesCarousel
-"""
-type LayoutArticlesCarousel @join__type(graph: CMS) {
-  """
-  Anchor
-  """
+"""Layout: LayoutArticlesCarousel"""
+type LayoutArticlesCarousel
+  @join__type(graph: CMS)
+{
+  """Anchor"""
   anchor: String
 
-  """
-  Articles
-  """
+  """Articles"""
   articles: [Post]
 
-  """
-  Background Color
-  """
+  """Background Color"""
   backgroundColor: String
 
-  """
-  Category
-  """
+  """Category"""
   category: Int
 
-  """
-  Amount of articles to list
-  """
+  """Amount of articles to list"""
   limit: Int
 
-  """
-  Show all -link
-  """
+  """Show all -link"""
   showAllLink: String
 
-  """
-  Show more link
-  """
+  """Show more link"""
   showMore: [String]
 
-  """
-  Tag
-  """
+  """Tag"""
   tag: Int
 
-  """
-  Title
-  """
+  """Title"""
   title: String
 }
 
-"""
-Layout: LayoutCollection
-"""
-type LayoutCollection @join__type(graph: CMS) {
-  """
-  Collection
-  """
+"""Layout: LayoutCollection"""
+type LayoutCollection
+  @join__type(graph: CMS)
+{
+  """Collection"""
   collection: Collection
 }
 
-"""
-Layout: LayoutContact
-"""
-type LayoutContact @join__type(graph: CMS) {
-  """
-  Contacts
-  """
+"""Layout: LayoutContact"""
+type LayoutContact
+  @join__type(graph: CMS)
+{
+  """Contacts"""
   contacts: [Contact]
 
-  """
-  Description
-  """
+  """Description"""
   description: String
 
-  """
-  Title
-  """
+  """Title"""
   title: String
 }
 
-"""
-Layout: LayoutLinkList
-"""
-type LayoutLinkList @join__type(graph: CMS) {
-  """
-  Anchor
-  """
+"""Layout: LayoutLinkList"""
+type LayoutLinkList
+  @join__type(graph: CMS)
+{
+  """Anchor"""
   anchor: String
 
-  """
-  Background Color
-  """
+  """Background Color"""
   backgroundColor: String
 
-  """
-  Title
-  """
+  """Title"""
   description: String
 
-  """
-  Links
-  """
+  """Links"""
   links: [Link]
 
-  """
-  Title
-  """
+  """Title"""
   title: String
 }
 
-"""
-Layout: LayoutPages
-"""
-type LayoutPages @join__type(graph: CMS) {
-  """
-  Anchor
-  """
+"""Layout: LayoutPages"""
+type LayoutPages
+  @join__type(graph: CMS)
+{
+  """Anchor"""
   anchor: String
 
-  """
-  Background Color
-  """
+  """Background Color"""
   backgroundColor: String
 
-  """
-  Description
-  """
+  """Description"""
   description: String
 
-  """
-  Pages
-  """
+  """Pages"""
   pages: [Page]
 
-  """
-  Show all -link
-  """
+  """Show all -link"""
   showAllLink: String
 
-  """
-  Title
-  """
+  """Title"""
   title: String
 }
 
-"""
-Layout: LayoutPagesCarousel
-"""
-type LayoutPagesCarousel @join__type(graph: CMS) {
-  """
-  Anchor
-  """
+"""Layout: LayoutPagesCarousel"""
+type LayoutPagesCarousel
+  @join__type(graph: CMS)
+{
+  """Anchor"""
   anchor: String
 
-  """
-  Background Color
-  """
+  """Background Color"""
   backgroundColor: String
 
-  """
-  Description
-  """
+  """Description"""
   description: String
 
-  """
-  Pages
-  """
+  """Pages"""
   pages: [Page]
 
-  """
-  Title
-  """
+  """Title"""
   title: String
 }
 
-union LegalEntity @join__type(graph: UNIFIED_SEARCH) = Person | Organisation
+union LegalEntity
+  @join__type(graph: UNIFIED_SEARCH)
+ = Person | Organisation
 
-"""
-Link field
-"""
-type Link @join__type(graph: CMS) {
-  """
-  The target of the link
-  """
+"""Link field"""
+type Link
+  @join__type(graph: CMS)
+{
+  """The target of the link"""
   target: String
 
-  """
-  The title of the link
-  """
+  """The title of the link"""
   title: String
 
-  """
-  The url of the link
-  """
+  """The url of the link"""
   url: String
 }
 
@@ -8042,10 +6063,10 @@ enum link__Purpose {
   EXECUTION
 }
 
-type LinkedeventsPlace @join__type(graph: UNIFIED_SEARCH) {
-  """
-  Raw Linkedevents Place fields
-  """
+type LinkedeventsPlace
+  @join__type(graph: UNIFIED_SEARCH)
+{
+  """Raw Linkedevents Place fields"""
   origin: String
   id: String
   data_source: String
@@ -8078,46 +6099,58 @@ type LinkedeventsPlace @join__type(graph: UNIFIED_SEARCH) {
   _at_type: String
 }
 
-type LinkedeventsPlaceDivision @join__type(graph: UNIFIED_SEARCH) {
+type LinkedeventsPlaceDivision
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: String
   ocd_id: String
   municipality: String
   name: LinkedeventsPlaceLocalityString
 }
 
-type LinkedeventsPlaceLocalityString @join__type(graph: UNIFIED_SEARCH) {
+type LinkedeventsPlaceLocalityString
+  @join__type(graph: UNIFIED_SEARCH)
+{
   fi: String
   sv: String
   en: String
 }
 
-type LinkedeventsPlacePosition @join__type(graph: UNIFIED_SEARCH) {
+type LinkedeventsPlacePosition
+  @join__type(graph: UNIFIED_SEARCH)
+{
   type: String
   coordinates: [Float]
 }
 
-type LocalizedCmsImage @join__type(graph: EVENTS) {
+type LocalizedCmsImage
+  @join__type(graph: EVENTS)
+{
   en: CmsImage
   fi: CmsImage
   sv: CmsImage
 }
 
-type LocalizedCmsKeywords @join__type(graph: EVENTS) {
+type LocalizedCmsKeywords
+  @join__type(graph: EVENTS)
+{
   en: [String]
   fi: [String]
   sv: [String]
 }
 
-type LocalizedObject @join__type(graph: EVENTS) {
+type LocalizedObject
+  @join__type(graph: EVENTS)
+{
   fi: String
   sv: String
   en: String
 }
 
-"""
-Free-form location, not necessarily at a know venue.
-"""
-type LocationDescription @join__type(graph: UNIFIED_SEARCH) {
+"""Free-form location, not necessarily at a know venue."""
+type LocationDescription
+  @join__type(graph: UNIFIED_SEARCH)
+{
   url: LanguageString
   geoLocation: GeoJSONFeature
   address: Address
@@ -8126,69 +6159,68 @@ type LocationDescription @join__type(graph: UNIFIED_SEARCH) {
   venue: UnifiedSearchVenue
 }
 
-type LocationImage @join__type(graph: UNIFIED_SEARCH) {
+type LocationImage
+  @join__type(graph: UNIFIED_SEARCH)
+{
   url: String
   caption: LanguageString
 }
 
-"""
-Collection Module: LocationsSelected
-"""
-type LocationsSelected @join__type(graph: CMS) {
-  """
-  List of location IDs
-  """
+"""Collection Module: LocationsSelected"""
+type LocationsSelected
+  @join__type(graph: CMS)
+{
+  """List of location IDs"""
   locations: [Int]
 
-  """
-  Module type
-  """
+  """Module type"""
   module: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [CollectionModulesUnionType]
 
-  """
-  Module title
-  """
+  """Module title"""
   title: String
 }
 
-"""
-File details for a Media Item
-"""
-type MediaDetails @join__type(graph: CMS) {
-  """
-  The filename of the mediaItem
-  """
+"""Collection Module: LocationsSelectedCarousel"""
+type LocationsSelectedCarousel
+  @join__type(graph: CMS)
+{
+  """List of location IDs"""
+  locations: [Int]
+
+  """Module type"""
+  module: String
+
+  """List of modules"""
+  modules: [CollectionModulesUnionType]
+
+  """Module title"""
+  title: String
+}
+
+"""File details for a Media Item"""
+type MediaDetails
+  @join__type(graph: CMS)
+{
+  """The filename of the mediaItem"""
   file: String
 
-  """
-  The height of the mediaItem
-  """
+  """The height of the mediaItem"""
   height: Int
 
-  """
-  Meta information associated with the mediaItem
-  """
+  """Meta information associated with the mediaItem"""
   meta: MediaItemMeta
 
-  """
-  The available sizes of the mediaItem
-  """
+  """The available sizes of the mediaItem"""
   sizes: [MediaSize]
 
-  """
-  The width of the mediaItem
-  """
+  """The width of the mediaItem"""
   width: Int
 }
 
-"""
-The mediaItem type
-"""
+"""The mediaItem type"""
 type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithAuthor & HierarchicalContentNode
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -8198,24 +6230,19 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   @join__implements(graph: CMS, interface: "NodeWithTitle")
   @join__implements(graph: CMS, interface: "NodeWithAuthor")
   @join__implements(graph: CMS, interface: "HierarchicalContentNode")
-  @join__type(graph: CMS) {
-  """
-  Alternative text to display when resource is not displayed
-  """
+  @join__type(graph: CMS)
+{
+  """Alternative text to display when resource is not displayed"""
   altText: String
 
   """
   Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
   """
   ancestors(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -8228,34 +6255,22 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeAncestorsConnection
 
-  """
-  Connection between the NodeWithAuthor type and the User type
-  """
+  """Connection between the NodeWithAuthor type and the User type"""
   author: NodeWithAuthorToUserConnectionEdge
 
-  """
-  The database identifier of the author of the node
-  """
+  """The database identifier of the author of the node"""
   authorDatabaseId: Int
 
-  """
-  The globally unique identifier of the author of the node
-  """
+  """The globally unique identifier of the author of the node"""
   authorId: ID
 
-  """
-  The caption for the resource
-  """
+  """The caption for the resource"""
   caption(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
@@ -8263,14 +6278,10 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   Connection between the HierarchicalContentNode type and the ContentNode type
   """
   children(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -8283,50 +6294,32 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeChildrenConnection
 
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  Description of the image (stored as post_content)
-  """
+  """Description of the image (stored as post_content)"""
   description(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -8334,23 +6327,15 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -8368,14 +6353,10 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -8389,13 +6370,9 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     before: String
   ): ContentNodeToEnqueuedStylesheetConnection
 
-  """
-  The filesize in bytes of the resource
-  """
+  """The filesize in bytes of the resource"""
   fileSize(
-    """
-    Size of the MediaItem to return
-    """
+    """Size of the MediaItem to return"""
     size: MediaItemSizeEnum
   ): Int
 
@@ -8404,70 +6381,43 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   """
   guid: String
 
-  """
-  The globally unique identifier of the attachment object.
-  """
+  """The globally unique identifier of the attachment object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  Polylang language
-  """
+  """Polylang language"""
   language: Language
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
-  """
-  Details about the mediaItem
-  """
+  """Details about the mediaItem"""
   mediaDetails: MediaDetails
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  mediaItemId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """The id field matches the WP_Post-&gt;ID field."""
+  mediaItemId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Url of the mediaItem
-  """
+  """Url of the mediaItem"""
   mediaItemUrl: String
 
-  """
-  Type of resource
-  """
+  """Type of resource"""
   mediaType: String
 
-  """
-  The mime type of the mediaItem
-  """
+  """The mime type of the mediaItem"""
   mimeType: String
 
   """
@@ -8480,48 +6430,30 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   """
   modifiedGmt: String
 
-  """
-  The parent of the node. The parent object can be of various types
-  """
+  """The parent of the node. The parent object can be of various types"""
   parent: HierarchicalContentNodeToParentContentNodeConnectionEdge
 
-  """
-  Database id of the parent node
-  """
+  """Database id of the parent node"""
   parentDatabaseId: Int
 
-  """
-  The globally unique identifier of the parent node.
-  """
+  """The globally unique identifier of the parent node."""
   parentId: ID
 
-  """
-  Valokuvaajan tiedot
-  """
+  """Valokuvaajan tiedot"""
   photographerName: String
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
-  """
-  The SEO Framework data of the mediaItem
-  """
+  """The SEO Framework data of the mediaItem"""
   seo: SEO
 
-  """
-  The sizes attribute value for an image.
-  """
+  """The sizes attribute value for an image."""
   sizes(
-    """
-    Size of the MediaItem to calculate sizes with
-    """
+    """Size of the MediaItem to calculate sizes with"""
     size: MediaItemSizeEnum
   ): String
 
@@ -8530,13 +6462,9 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   """
   slug: String
 
-  """
-  Url of the mediaItem
-  """
+  """Url of the mediaItem"""
   sourceUrl(
-    """
-    Size of the MediaItem to return
-    """
+    """Size of the MediaItem to return"""
     size: MediaItemSizeEnum
   ): String
 
@@ -8544,34 +6472,22 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   The srcset attribute specifies the URL of the image to use in different situations. It is a comma separated string of urls and their widths.
   """
   srcSet(
-    """
-    Size of the MediaItem to calculate srcSet with
-    """
+    """Size of the MediaItem to calculate srcSet with"""
     size: MediaItemSizeEnum
   ): String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to the node
-  """
+  """The template assigned to the node"""
   template: ContentTemplate
 
-  """
-  Connection between the mediaItem type and the TermNode type
-  """
+  """Connection between the mediaItem type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -8584,9 +6500,7 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: MediaItemToTermNodeConnectionWhereArgs
   ): MediaItemToTermNodeConnection
 
@@ -8594,40 +6508,28 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): MediaItem
 
-  """
-  List all translated versions of this post
-  """
+  """List all translated versions of this post"""
   translations: [MediaItem]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum MediaItemIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum MediaItemIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
   """
@@ -8635,54 +6537,36 @@ enum MediaItemIdType @join__type(graph: CMS) {
   """
   SLUG
 
-  """
-  Identify a media item by its source url
-  """
+  """Identify a media item by its source url"""
   SOURCE_URL
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-"""
-Meta connected to a MediaItem
-"""
-type MediaItemMeta @join__type(graph: CMS) {
-  """
-  Aperture measurement of the media item.
-  """
+"""Meta connected to a MediaItem"""
+type MediaItemMeta
+  @join__type(graph: CMS)
+{
+  """Aperture measurement of the media item."""
   aperture: Float
 
-  """
-  Information about the camera used to create the media item.
-  """
+  """Information about the camera used to create the media item."""
   camera: String
 
-  """
-  The text string description associated with the media item.
-  """
+  """The text string description associated with the media item."""
   caption: String
 
-  """
-  Copyright information associated with the media item.
-  """
+  """Copyright information associated with the media item."""
   copyright: String
 
-  """
-  The date/time when the media was created.
-  """
+  """The date/time when the media was created."""
   createdTimestamp: Int
 
-  """
-  The original creator of the media item.
-  """
+  """The original creator of the media item."""
   credit: String
 
-  """
-  The focal length value of the media item.
-  """
+  """The focal length value of the media item."""
   focalLength: Float
 
   """
@@ -8690,126 +6574,88 @@ type MediaItemMeta @join__type(graph: CMS) {
   """
   iso: Int
 
-  """
-  List of keywords used to describe or identfy the media item.
-  """
+  """List of keywords used to describe or identfy the media item."""
   keywords: [String]
 
-  """
-  The vertical or horizontal aspect of the media item.
-  """
+  """The vertical or horizontal aspect of the media item."""
   orientation: String
 
-  """
-  The shutter speed information of the media item.
-  """
+  """The shutter speed information of the media item."""
   shutterSpeed: Float
 
-  """
-  A useful title for the media item.
-  """
+  """A useful title for the media item."""
   title: String
 }
 
-"""
-The size of the media item object.
-"""
-enum MediaItemSizeEnum @join__type(graph: CMS) {
-  """
-  MediaItem with the large size
-  """
+"""The size of the media item object."""
+enum MediaItemSizeEnum
+  @join__type(graph: CMS)
+{
+  """MediaItem with the large size"""
   LARGE
 
-  """
-  MediaItem with the medium size
-  """
+  """MediaItem with the medium size"""
   MEDIUM
 
-  """
-  MediaItem with the medium_large size
-  """
+  """MediaItem with the medium_large size"""
   MEDIUM_LARGE
 
-  """
-  MediaItem with the thumbnail size
-  """
+  """MediaItem with the thumbnail size"""
   THUMBNAIL
 
-  """
-  MediaItem with the 1536x1536 size
-  """
+  """MediaItem with the 1536x1536 size"""
   _1536X1536
 
-  """
-  MediaItem with the 2048x2048 size
-  """
+  """MediaItem with the 2048x2048 size"""
   _2048X2048
 }
 
-"""
-The status of the media item object.
-"""
-enum MediaItemStatusEnum @join__type(graph: CMS) {
-  """
-  Objects with the auto-draft status
-  """
+"""The status of the media item object."""
+enum MediaItemStatusEnum
+  @join__type(graph: CMS)
+{
+  """Objects with the auto-draft status"""
   AUTO_DRAFT
 
-  """
-  Objects with the inherit status
-  """
+  """Objects with the inherit status"""
   INHERIT
 
-  """
-  Objects with the private status
-  """
+  """Objects with the private status"""
   PRIVATE
 
-  """
-  Objects with the trash status
-  """
+  """Objects with the trash status"""
   TRASH
 }
 
-"""
-Connection between the mediaItem type and the TermNode type
-"""
-type MediaItemToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the MediaItemToTermNodeConnection connection
-  """
+"""Connection between the mediaItem type and the TermNode type"""
+type MediaItemToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the MediaItemToTermNodeConnection connection"""
   edges: [MediaItemToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type MediaItemToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type MediaItemToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the MediaItemToTermNodeConnection connection
-"""
-input MediaItemToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the MediaItemToTermNodeConnection connection"""
+input MediaItemToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -8850,19 +6696,13 @@ input MediaItemToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -8870,14 +6710,10 @@ input MediaItemToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -8885,9 +6721,7 @@ input MediaItemToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -8895,72 +6729,50 @@ input MediaItemToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-TODO: take this from Linked events Image type.
-"""
-type MediaResource @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: take this from Linked events Image type."""
+type MediaResource
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   todo: String
 }
 
-"""
-Details of an available size for a media item
-"""
-type MediaSize @join__type(graph: CMS) {
-  """
-  The filename of the referenced size
-  """
+"""Details of an available size for a media item"""
+type MediaSize
+  @join__type(graph: CMS)
+{
+  """The filename of the referenced size"""
   file: String
 
-  """
-  The filesize of the resource
-  """
+  """The filesize of the resource"""
   fileSize: Int
 
-  """
-  The height of the referenced size
-  """
+  """The height of the referenced size"""
   height: String
 
-  """
-  The mime type of the referenced size
-  """
+  """The mime type of the referenced size"""
   mimeType: String
 
-  """
-  The referenced size name
-  """
+  """The referenced size name"""
   name: String
 
-  """
-  The url of the referenced size
-  """
+  """The url of the referenced size"""
   sourceUrl: String
 
-  """
-  The width of the referenced size
-  """
+  """The width of the referenced size"""
   width: String
 }
 
@@ -8970,49 +6782,32 @@ Menus are the containers for navigation items. Menus can be assigned to menu loc
 type Menu implements Node & DatabaseIdentifier
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
-  @join__type(graph: CMS) {
-  """
-  The number of items in the menu
-  """
+  @join__type(graph: CMS)
+{
+  """The number of items in the menu"""
   count: Int
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  The globally unique identifier of the nav menu object.
-  """
+  """The globally unique identifier of the nav menu object."""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  The locations a menu is assigned to
-  """
+  """The locations a menu is assigned to"""
   locations: [MenuLocationEnum]
 
-  """
-  WP ID of the nav menu.
-  """
+  """WP ID of the nav menu."""
   menuId: Int @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Connection between the Menu type and the MenuItem type
-  """
+  """Connection between the Menu type and the MenuItem type"""
   menuItems(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -9025,20 +6820,14 @@ type Menu implements Node & DatabaseIdentifier
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: MenuToMenuItemConnectionWhereArgs
   ): MenuToMenuItemConnection
 
-  """
-  Display name of the menu. Equivalent to WP_Term-&gt;name.
-  """
+  """Display name of the menu. Equivalent to WP_Term-&gt;name."""
   name: String
 
-  """
-  The url friendly name of the menu. Equivalent to WP_Term-&gt;slug
-  """
+  """The url friendly name of the menu. Equivalent to WP_Term-&gt;slug"""
   slug: String
 }
 
@@ -9048,19 +6837,14 @@ Navigation menu items are the individual items assigned to a menu. These are ren
 type MenuItem implements Node & DatabaseIdentifier
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
-  @join__type(graph: CMS) {
-  """
-  Connection between the MenuItem type and the MenuItem type
-  """
+  @join__type(graph: CMS)
+{
+  """Connection between the MenuItem type and the MenuItem type"""
   childItems(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -9073,87 +6857,53 @@ type MenuItem implements Node & DatabaseIdentifier
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: MenuItemToMenuItemConnectionWhereArgs
   ): MenuItemToMenuItemConnection
 
-  """
-  Connection from MenuItem to it&#039;s connected node
-  """
+  """Connection from MenuItem to it&#039;s connected node"""
   connectedNode: MenuItemToMenuItemLinkableConnectionEdge
 
-  """
-  The object connected to this menu item.
-  """
-  connectedObject: MenuItemObjectUnion
-    @deprecated(reason: "Deprecated in favor of the connectedNode field")
+  """The object connected to this menu item."""
+  connectedObject: MenuItemObjectUnion @deprecated(reason: "Deprecated in favor of the connectedNode field")
 
-  """
-  Class attribute for the menu item link
-  """
+  """Class attribute for the menu item link"""
   cssClasses: [String]
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Description of the menu item.
-  """
+  """Description of the menu item."""
   description: String
 
-  """
-  The globally unique identifier of the nav menu item object.
-  """
+  """The globally unique identifier of the nav menu item object."""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Label or title of the menu item.
-  """
+  """Label or title of the menu item."""
   label: String
 
-  """
-  Link relationship (XFN) of the menu item.
-  """
+  """Link relationship (XFN) of the menu item."""
   linkRelationship: String
 
-  """
-  The locations the menu item&#039;s Menu is assigned to
-  """
+  """The locations the menu item&#039;s Menu is assigned to"""
   locations: [MenuLocationEnum]
 
-  """
-  The Menu a MenuItem is part of
-  """
+  """The Menu a MenuItem is part of"""
   menu: MenuItemToMenuConnectionEdge
 
-  """
-  WP ID of the menu item.
-  """
-  menuItemId: Int
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """WP ID of the menu item."""
+  menuItemId: Int @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Menu item order
-  """
+  """Menu item order"""
   order: Int
 
-  """
-  The database id of the parent menu item or null if it is the root
-  """
+  """The database id of the parent menu item or null if it is the root"""
   parentDatabaseId: Int
 
-  """
-  The globally unique identifier of the parent nav menu item object.
-  """
+  """The globally unique identifier of the parent nav menu item object."""
   parentId: ID
 
   """
@@ -9161,335 +6911,239 @@ type MenuItem implements Node & DatabaseIdentifier
   """
   path: String
 
-  """
-  Target attribute for the menu item link.
-  """
+  """Target attribute for the menu item link."""
   target: String
 
-  """
-  Title attribute for the menu item link
-  """
+  """Title attribute for the menu item link"""
   title: String
 
-  """
-  URL or destination of the menu item.
-  """
+  """URL or destination of the menu item."""
   url: String
 }
 
-"""
-Nodes that can be linked to as Menu Items
-"""
-interface MenuItemLinkable @join__type(graph: CMS) {
-  """
-  The unique resource identifier path
-  """
+"""Nodes that can be linked to as Menu Items"""
+interface MenuItemLinkable
+  @join__type(graph: CMS)
+{
+  """The unique resource identifier path"""
   databaseId: Int!
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
 """
 The Type of Identifier used to fetch a single node. Default is "ID". To be used along with the "id" field.
 """
-enum MenuItemNodeIdTypeEnum @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+enum MenuItemNodeIdTypeEnum
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 }
 
-"""
-Deprecated in favor of MenuItemLinkeable Interface
-"""
-union MenuItemObjectUnion @join__type(graph: CMS) = Post | Page | Category | Tag
+"""Deprecated in favor of MenuItemLinkeable Interface"""
+union MenuItemObjectUnion
+  @join__type(graph: CMS)
+ = Post | Page | Category | Tag
 
-"""
-Connection between the MenuItem type and the Menu type
-"""
-type MenuItemToMenuConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the MenuItem type and the Menu type"""
+type MenuItemToMenuConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Menu
 }
 
-"""
-Connection between the MenuItem type and the MenuItem type
-"""
-type MenuItemToMenuItemConnection @join__type(graph: CMS) {
-  """
-  Edges for the MenuItemToMenuItemConnection connection
-  """
+"""Connection between the MenuItem type and the MenuItem type"""
+type MenuItemToMenuItemConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the MenuItemToMenuItemConnection connection"""
   edges: [MenuItemToMenuItemConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MenuItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type MenuItemToMenuItemConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type MenuItemToMenuItemConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MenuItem
 }
 
-"""
-Arguments for filtering the MenuItemToMenuItemConnection connection
-"""
-input MenuItemToMenuItemConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The ID of the object
-  """
+"""Arguments for filtering the MenuItemToMenuItemConnection connection"""
+input MenuItemToMenuItemConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The ID of the object"""
   id: Int
 
-  """
-  The menu location for the menu being queried
-  """
+  """The menu location for the menu being queried"""
   location: MenuLocationEnum
 
-  """
-  The database ID of the parent menu object
-  """
+  """The database ID of the parent menu object"""
   parentDatabaseId: Int
 
-  """
-  The ID of the parent menu object
-  """
+  """The ID of the parent menu object"""
   parentId: ID
 }
 
-"""
-Connection between the MenuItem type and the MenuItemLinkable type
-"""
-type MenuItemToMenuItemLinkableConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the MenuItem type and the MenuItemLinkable type"""
+type MenuItemToMenuItemLinkableConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: MenuItemLinkable
 }
 
-"""
-Registered menu locations
-"""
-enum MenuLocationEnum @join__type(graph: CMS) {
-  """
-  Put the menu in the primary location
-  """
+"""Registered menu locations"""
+enum MenuLocationEnum
+  @join__type(graph: CMS)
+{
+  """Put the menu in the primary location"""
   PRIMARY
 
-  """
-  Put the menu in the primary___en location
-  """
+  """Put the menu in the primary___en location"""
   PRIMARY___EN
 
-  """
-  Put the menu in the primary___sv location
-  """
+  """Put the menu in the primary___sv location"""
   PRIMARY___SV
 
-  """
-  Put the menu in the secondary location
-  """
+  """Put the menu in the secondary location"""
   SECONDARY
 
-  """
-  Put the menu in the secondary___en location
-  """
+  """Put the menu in the secondary___en location"""
   SECONDARY___EN
 
-  """
-  Put the menu in the secondary___sv location
-  """
+  """Put the menu in the secondary___sv location"""
   SECONDARY___SV
 
-  """
-  Put the menu in the tertiary location
-  """
+  """Put the menu in the tertiary location"""
   TERTIARY
 
-  """
-  Put the menu in the tertiary___en location
-  """
+  """Put the menu in the tertiary___en location"""
   TERTIARY___EN
 
-  """
-  Put the menu in the tertiary___sv location
-  """
+  """Put the menu in the tertiary___sv location"""
   TERTIARY___SV
 }
 
 """
 The Type of Identifier used to fetch a single node. Default is "ID". To be used along with the "id" field.
 """
-enum MenuNodeIdTypeEnum @join__type(graph: CMS) {
-  """
-  Identify a menu node by the Database ID.
-  """
+enum MenuNodeIdTypeEnum
+  @join__type(graph: CMS)
+{
+  """Identify a menu node by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a menu node by the (hashed) Global ID.
-  """
+  """Identify a menu node by the (hashed) Global ID."""
   ID
 
-  """
-  Identify a menu node by it's name
-  """
+  """Identify a menu node by it's name"""
   NAME
 }
 
-"""
-Connection between the Menu type and the MenuItem type
-"""
-type MenuToMenuItemConnection @join__type(graph: CMS) {
-  """
-  Edges for the MenuToMenuItemConnection connection
-  """
+"""Connection between the Menu type and the MenuItem type"""
+type MenuToMenuItemConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the MenuToMenuItemConnection connection"""
   edges: [MenuToMenuItemConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MenuItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type MenuToMenuItemConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type MenuToMenuItemConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MenuItem
 }
 
-"""
-Arguments for filtering the MenuToMenuItemConnection connection
-"""
-input MenuToMenuItemConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The ID of the object
-  """
+"""Arguments for filtering the MenuToMenuItemConnection connection"""
+input MenuToMenuItemConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The ID of the object"""
   id: Int
 
-  """
-  The menu location for the menu being queried
-  """
+  """The menu location for the menu being queried"""
   location: MenuLocationEnum
 
-  """
-  The database ID of the parent menu object
-  """
+  """The database ID of the parent menu object"""
   parentDatabaseId: Int
 
-  """
-  The ID of the parent menu object
-  """
+  """The ID of the parent menu object"""
   parentId: ID
 }
 
-type Meta @join__type(graph: EVENTS) {
+type Meta
+  @join__type(graph: EVENTS)
+{
   count: Int!
   next: String
   previous: String
 }
 
-"""
-The MimeType of the object
-"""
-enum MimeTypeEnum @join__type(graph: CMS) {
-  """
-  MimeType application/msword
-  """
+"""The MimeType of the object"""
+enum MimeTypeEnum
+  @join__type(graph: CMS)
+{
+  """MimeType application/msword"""
   APPLICATION_MSWORD
 
-  """
-  MimeType application/pdf
-  """
+  """MimeType application/pdf"""
   APPLICATION_PDF
 
-  """
-  MimeType application/vnd.apple.keynote
-  """
+  """MimeType application/vnd.apple.keynote"""
   APPLICATION_VND_APPLE_KEYNOTE
 
-  """
-  MimeType application/vnd.ms-excel
-  """
+  """MimeType application/vnd.ms-excel"""
   APPLICATION_VND_MS_EXCEL
 
-  """
-  MimeType application/vnd.ms-excel.sheet.binary.macroEnabled.12
-  """
+  """MimeType application/vnd.ms-excel.sheet.binary.macroEnabled.12"""
   APPLICATION_VND_MS_EXCEL_SHEET_BINARY_MACROENABLED_12
 
-  """
-  MimeType application/vnd.ms-excel.sheet.macroEnabled.12
-  """
+  """MimeType application/vnd.ms-excel.sheet.macroEnabled.12"""
   APPLICATION_VND_MS_EXCEL_SHEET_MACROENABLED_12
 
-  """
-  MimeType application/vnd.ms-powerpoint
-  """
+  """MimeType application/vnd.ms-powerpoint"""
   APPLICATION_VND_MS_POWERPOINT
 
-  """
-  MimeType application/vnd.ms-powerpoint.presentation.macroEnabled.12
-  """
+  """MimeType application/vnd.ms-powerpoint.presentation.macroEnabled.12"""
   APPLICATION_VND_MS_POWERPOINT_PRESENTATION_MACROENABLED_12
 
-  """
-  MimeType application/vnd.ms-powerpoint.slideshow.macroEnabled.12
-  """
+  """MimeType application/vnd.ms-powerpoint.slideshow.macroEnabled.12"""
   APPLICATION_VND_MS_POWERPOINT_SLIDESHOW_MACROENABLED_12
 
-  """
-  MimeType application/vnd.ms-word.document.macroEnabled.12
-  """
+  """MimeType application/vnd.ms-word.document.macroEnabled.12"""
   APPLICATION_VND_MS_WORD_DOCUMENT_MACROENABLED_12
 
-  """
-  MimeType application/vnd.oasis.opendocument.text
-  """
+  """MimeType application/vnd.oasis.opendocument.text"""
   APPLICATION_VND_OASIS_OPENDOCUMENT_TEXT
 
   """
@@ -9512,656 +7166,422 @@ enum MimeTypeEnum @join__type(graph: CMS) {
   """
   APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT
 
-  """
-  MimeType audio/flac
-  """
+  """MimeType audio/flac"""
   AUDIO_FLAC
 
-  """
-  MimeType audio/midi
-  """
+  """MimeType audio/midi"""
   AUDIO_MIDI
 
-  """
-  MimeType audio/mpeg
-  """
+  """MimeType audio/mpeg"""
   AUDIO_MPEG
 
-  """
-  MimeType audio/ogg
-  """
+  """MimeType audio/ogg"""
   AUDIO_OGG
 
-  """
-  MimeType audio/wav
-  """
+  """MimeType audio/wav"""
   AUDIO_WAV
 
-  """
-  MimeType image/gif
-  """
+  """MimeType image/gif"""
   IMAGE_GIF
 
-  """
-  MimeType image/jpeg
-  """
+  """MimeType image/jpeg"""
   IMAGE_JPEG
 
-  """
-  MimeType image/png
-  """
+  """MimeType image/png"""
   IMAGE_PNG
 
-  """
-  MimeType video/3gpp
-  """
+  """MimeType video/3gpp"""
   VIDEO_3GPP
 
-  """
-  MimeType video/3gpp2
-  """
+  """MimeType video/3gpp2"""
   VIDEO_3GPP2
 
-  """
-  MimeType video/avi
-  """
+  """MimeType video/avi"""
   VIDEO_AVI
 
-  """
-  MimeType video/mp4
-  """
+  """MimeType video/mp4"""
   VIDEO_MP4
 
-  """
-  MimeType video/mpeg
-  """
+  """MimeType video/mpeg"""
   VIDEO_MPEG
 
-  """
-  MimeType video/ogg
-  """
+  """MimeType video/ogg"""
   VIDEO_OGG
 
-  """
-  MimeType video/quicktime
-  """
+  """MimeType video/quicktime"""
   VIDEO_QUICKTIME
 
-  """
-  MimeType video/webm
-  """
+  """MimeType video/webm"""
   VIDEO_WEBM
 
-  """
-  MimeType video/x-flv
-  """
+  """MimeType video/x-flv"""
   VIDEO_X_FLV
 }
 
-"""
-The root mutation
-"""
-type Mutation @join__type(graph: CMS) @join__type(graph: EVENTS) {
-  """
-  The payload for the createCategory mutation
-  """
+"""The root mutation"""
+type Mutation
+  @join__type(graph: CMS)
+  @join__type(graph: EVENTS)
+{
+  """The payload for the createCategory mutation"""
   createCategory(
-    """
-    Input for the createCategory mutation
-    """
+    """Input for the createCategory mutation"""
     input: CreateCategoryInput!
   ): CreateCategoryPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createCollection mutation
-  """
+  """The payload for the createCollection mutation"""
   createCollection(
-    """
-    Input for the createCollection mutation
-    """
+    """Input for the createCollection mutation"""
     input: CreateCollectionInput!
   ): CreateCollectionPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createComment mutation
-  """
+  """The payload for the createComment mutation"""
   createComment(
-    """
-    Input for the createComment mutation
-    """
+    """Input for the createComment mutation"""
     input: CreateCommentInput!
   ): CreateCommentPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createContact mutation
-  """
+  """The payload for the createContact mutation"""
   createContact(
-    """
-    Input for the createContact mutation
-    """
+    """Input for the createContact mutation"""
     input: CreateContactInput!
   ): CreateContactPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createLandingPage mutation
-  """
+  """The payload for the createLandingPage mutation"""
   createLandingPage(
-    """
-    Input for the createLandingPage mutation
-    """
+    """Input for the createLandingPage mutation"""
     input: CreateLandingPageInput!
   ): CreateLandingPagePayload @join__field(graph: CMS)
 
-  """
-  The payload for the createMediaItem mutation
-  """
+  """The payload for the createMediaItem mutation"""
   createMediaItem(
-    """
-    Input for the createMediaItem mutation
-    """
+    """Input for the createMediaItem mutation"""
     input: CreateMediaItemInput!
   ): CreateMediaItemPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createPage mutation
-  """
+  """The payload for the createPage mutation"""
   createPage(
-    """
-    Input for the createPage mutation
-    """
+    """Input for the createPage mutation"""
     input: CreatePageInput!
   ): CreatePagePayload @join__field(graph: CMS)
 
-  """
-  The payload for the createPost mutation
-  """
+  """The payload for the createPost mutation"""
   createPost(
-    """
-    Input for the createPost mutation
-    """
+    """Input for the createPost mutation"""
     input: CreatePostInput!
   ): CreatePostPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createPostFormat mutation
-  """
+  """The payload for the createPostFormat mutation"""
   createPostFormat(
-    """
-    Input for the createPostFormat mutation
-    """
+    """Input for the createPostFormat mutation"""
     input: CreatePostFormatInput!
   ): CreatePostFormatPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createRelease mutation
-  """
+  """The payload for the createRelease mutation"""
   createRelease(
-    """
-    Input for the createRelease mutation
-    """
+    """Input for the createRelease mutation"""
     input: CreateReleaseInput!
   ): CreateReleasePayload @join__field(graph: CMS)
 
-  """
-  The payload for the createTag mutation
-  """
+  """The payload for the createTag mutation"""
   createTag(
-    """
-    Input for the createTag mutation
-    """
+    """Input for the createTag mutation"""
     input: CreateTagInput!
   ): CreateTagPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createTranslation mutation
-  """
+  """The payload for the createTranslation mutation"""
   createTranslation(
-    """
-    Input for the createTranslation mutation
-    """
+    """Input for the createTranslation mutation"""
     input: CreateTranslationInput!
   ): CreateTranslationPayload @join__field(graph: CMS)
 
-  """
-  The payload for the createUser mutation
-  """
+  """The payload for the createUser mutation"""
   createUser(
-    """
-    Input for the createUser mutation
-    """
+    """Input for the createUser mutation"""
     input: CreateUserInput!
   ): CreateUserPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteCategory mutation
-  """
+  """The payload for the deleteCategory mutation"""
   deleteCategory(
-    """
-    Input for the deleteCategory mutation
-    """
+    """Input for the deleteCategory mutation"""
     input: DeleteCategoryInput!
   ): DeleteCategoryPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteCollection mutation
-  """
+  """The payload for the deleteCollection mutation"""
   deleteCollection(
-    """
-    Input for the deleteCollection mutation
-    """
+    """Input for the deleteCollection mutation"""
     input: DeleteCollectionInput!
   ): DeleteCollectionPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteComment mutation
-  """
+  """The payload for the deleteComment mutation"""
   deleteComment(
-    """
-    Input for the deleteComment mutation
-    """
+    """Input for the deleteComment mutation"""
     input: DeleteCommentInput!
   ): DeleteCommentPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteContact mutation
-  """
+  """The payload for the deleteContact mutation"""
   deleteContact(
-    """
-    Input for the deleteContact mutation
-    """
+    """Input for the deleteContact mutation"""
     input: DeleteContactInput!
   ): DeleteContactPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteLandingPage mutation
-  """
+  """The payload for the deleteLandingPage mutation"""
   deleteLandingPage(
-    """
-    Input for the deleteLandingPage mutation
-    """
+    """Input for the deleteLandingPage mutation"""
     input: DeleteLandingPageInput!
   ): DeleteLandingPagePayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteMediaItem mutation
-  """
+  """The payload for the deleteMediaItem mutation"""
   deleteMediaItem(
-    """
-    Input for the deleteMediaItem mutation
-    """
+    """Input for the deleteMediaItem mutation"""
     input: DeleteMediaItemInput!
   ): DeleteMediaItemPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deletePage mutation
-  """
+  """The payload for the deletePage mutation"""
   deletePage(
-    """
-    Input for the deletePage mutation
-    """
+    """Input for the deletePage mutation"""
     input: DeletePageInput!
   ): DeletePagePayload @join__field(graph: CMS)
 
-  """
-  The payload for the deletePost mutation
-  """
+  """The payload for the deletePost mutation"""
   deletePost(
-    """
-    Input for the deletePost mutation
-    """
+    """Input for the deletePost mutation"""
     input: DeletePostInput!
   ): DeletePostPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deletePostFormat mutation
-  """
+  """The payload for the deletePostFormat mutation"""
   deletePostFormat(
-    """
-    Input for the deletePostFormat mutation
-    """
+    """Input for the deletePostFormat mutation"""
     input: DeletePostFormatInput!
   ): DeletePostFormatPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteRelease mutation
-  """
+  """The payload for the deleteRelease mutation"""
   deleteRelease(
-    """
-    Input for the deleteRelease mutation
-    """
+    """Input for the deleteRelease mutation"""
     input: DeleteReleaseInput!
   ): DeleteReleasePayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteTag mutation
-  """
+  """The payload for the deleteTag mutation"""
   deleteTag(
-    """
-    Input for the deleteTag mutation
-    """
+    """Input for the deleteTag mutation"""
     input: DeleteTagInput!
   ): DeleteTagPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteTranslation mutation
-  """
+  """The payload for the deleteTranslation mutation"""
   deleteTranslation(
-    """
-    Input for the deleteTranslation mutation
-    """
+    """Input for the deleteTranslation mutation"""
     input: DeleteTranslationInput!
   ): DeleteTranslationPayload @join__field(graph: CMS)
 
-  """
-  The payload for the deleteUser mutation
-  """
+  """The payload for the deleteUser mutation"""
   deleteUser(
-    """
-    Input for the deleteUser mutation
-    """
+    """Input for the deleteUser mutation"""
     input: DeleteUserInput!
   ): DeleteUserPayload @join__field(graph: CMS)
 
-  """
-  Increase the count.
-  """
+  """Increase the count."""
   increaseCount(
-    """
-    The count to increase
-    """
+    """The count to increase"""
     count: Int
   ): Int @join__field(graph: CMS)
 
-  """
-  The payload for the registerUser mutation
-  """
+  """The payload for the registerUser mutation"""
   registerUser(
-    """
-    Input for the registerUser mutation
-    """
+    """Input for the registerUser mutation"""
     input: RegisterUserInput!
   ): RegisterUserPayload @join__field(graph: CMS)
 
-  """
-  The payload for the resetUserPassword mutation
-  """
+  """The payload for the resetUserPassword mutation"""
   resetUserPassword(
-    """
-    Input for the resetUserPassword mutation
-    """
+    """Input for the resetUserPassword mutation"""
     input: ResetUserPasswordInput!
   ): ResetUserPasswordPayload @join__field(graph: CMS)
 
-  """
-  The payload for the restoreComment mutation
-  """
+  """The payload for the restoreComment mutation"""
   restoreComment(
-    """
-    Input for the restoreComment mutation
-    """
+    """Input for the restoreComment mutation"""
     input: RestoreCommentInput!
   ): RestoreCommentPayload @join__field(graph: CMS)
 
-  """
-  The payload for the sendPasswordResetEmail mutation
-  """
+  """The payload for the sendPasswordResetEmail mutation"""
   sendPasswordResetEmail(
-    """
-    Input for the sendPasswordResetEmail mutation
-    """
+    """Input for the sendPasswordResetEmail mutation"""
     input: SendPasswordResetEmailInput!
   ): SendPasswordResetEmailPayload @join__field(graph: CMS)
 
-  """
-  The payload for the UpdateCategory mutation
-  """
+  """The payload for the UpdateCategory mutation"""
   updateCategory(
-    """
-    Input for the UpdateCategory mutation
-    """
+    """Input for the UpdateCategory mutation"""
     input: UpdateCategoryInput!
   ): UpdateCategoryPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateCollection mutation
-  """
+  """The payload for the updateCollection mutation"""
   updateCollection(
-    """
-    Input for the updateCollection mutation
-    """
+    """Input for the updateCollection mutation"""
     input: UpdateCollectionInput!
   ): UpdateCollectionPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateComment mutation
-  """
+  """The payload for the updateComment mutation"""
   updateComment(
-    """
-    Input for the updateComment mutation
-    """
+    """Input for the updateComment mutation"""
     input: UpdateCommentInput!
   ): UpdateCommentPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateContact mutation
-  """
+  """The payload for the updateContact mutation"""
   updateContact(
-    """
-    Input for the updateContact mutation
-    """
+    """Input for the updateContact mutation"""
     input: UpdateContactInput!
   ): UpdateContactPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateLandingPage mutation
-  """
+  """The payload for the updateLandingPage mutation"""
   updateLandingPage(
-    """
-    Input for the updateLandingPage mutation
-    """
+    """Input for the updateLandingPage mutation"""
     input: UpdateLandingPageInput!
   ): UpdateLandingPagePayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateMediaItem mutation
-  """
+  """The payload for the updateMediaItem mutation"""
   updateMediaItem(
-    """
-    Input for the updateMediaItem mutation
-    """
+    """Input for the updateMediaItem mutation"""
     input: UpdateMediaItemInput!
   ): UpdateMediaItemPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updatePage mutation
-  """
+  """The payload for the updatePage mutation"""
   updatePage(
-    """
-    Input for the updatePage mutation
-    """
+    """Input for the updatePage mutation"""
     input: UpdatePageInput!
   ): UpdatePagePayload @join__field(graph: CMS)
 
-  """
-  The payload for the updatePost mutation
-  """
+  """The payload for the updatePost mutation"""
   updatePost(
-    """
-    Input for the updatePost mutation
-    """
+    """Input for the updatePost mutation"""
     input: UpdatePostInput!
   ): UpdatePostPayload @join__field(graph: CMS)
 
-  """
-  The payload for the UpdatePostFormat mutation
-  """
+  """The payload for the UpdatePostFormat mutation"""
   updatePostFormat(
-    """
-    Input for the UpdatePostFormat mutation
-    """
+    """Input for the UpdatePostFormat mutation"""
     input: UpdatePostFormatInput!
   ): UpdatePostFormatPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateRelease mutation
-  """
+  """The payload for the updateRelease mutation"""
   updateRelease(
-    """
-    Input for the updateRelease mutation
-    """
+    """Input for the updateRelease mutation"""
     input: UpdateReleaseInput!
   ): UpdateReleasePayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateSettings mutation
-  """
+  """The payload for the updateSettings mutation"""
   updateSettings(
-    """
-    Input for the updateSettings mutation
-    """
+    """Input for the updateSettings mutation"""
     input: UpdateSettingsInput!
   ): UpdateSettingsPayload @join__field(graph: CMS)
 
-  """
-  The payload for the UpdateTag mutation
-  """
+  """The payload for the UpdateTag mutation"""
   updateTag(
-    """
-    Input for the UpdateTag mutation
-    """
+    """Input for the UpdateTag mutation"""
     input: UpdateTagInput!
   ): UpdateTagPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateTranslation mutation
-  """
+  """The payload for the updateTranslation mutation"""
   updateTranslation(
-    """
-    Input for the updateTranslation mutation
-    """
+    """Input for the updateTranslation mutation"""
     input: UpdateTranslationInput!
   ): UpdateTranslationPayload @join__field(graph: CMS)
 
-  """
-  The payload for the updateUser mutation
-  """
+  """The payload for the updateUser mutation"""
   updateUser(
-    """
-    Input for the updateUser mutation
-    """
+    """Input for the updateUser mutation"""
     input: UpdateUserInput!
   ): UpdateUserPayload @join__field(graph: CMS)
   _empty: String @join__field(graph: EVENTS)
 }
 
-type Neighborhood @join__type(graph: EVENTS) {
+type Neighborhood
+  @join__type(graph: EVENTS)
+{
   id: ID!
   name: LocalizedObject!
 }
 
-type NeighborhoodListResponse @join__type(graph: EVENTS) {
+type NeighborhoodListResponse
+  @join__type(graph: EVENTS)
+{
   meta: Meta!
   data: [Neighborhood!]!
 }
 
-"""
-An object with an ID
-"""
-interface Node @join__type(graph: CMS) {
-  """
-  The globally unique ID for the object
-  """
+"""An object with an ID"""
+interface Node
+  @join__type(graph: CMS)
+{
+  """The globally unique ID for the object"""
   id: ID!
 }
 
-type NodeMeta @join__type(graph: UNIFIED_SEARCH) {
+type NodeMeta
+  @join__type(graph: UNIFIED_SEARCH)
+{
   id: ID!
   createdAt: DateTime
   updatedAt: DateTime
 }
 
-"""
-A node that can have an author assigned to it
-"""
-interface NodeWithAuthor @join__type(graph: CMS) {
-  """
-  Connection between the NodeWithAuthor type and the User type
-  """
+"""A node that can have an author assigned to it"""
+interface NodeWithAuthor
+  @join__type(graph: CMS)
+{
+  """Connection between the NodeWithAuthor type and the User type"""
   author: NodeWithAuthorToUserConnectionEdge
 
-  """
-  The database identifier of the author of the node
-  """
+  """The database identifier of the author of the node"""
   authorDatabaseId: Int
 
-  """
-  The globally unique identifier of the author of the node
-  """
+  """The globally unique identifier of the author of the node"""
   authorId: ID
 }
 
-"""
-Connection between the NodeWithAuthor type and the User type
-"""
-type NodeWithAuthorToUserConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the NodeWithAuthor type and the User type"""
+type NodeWithAuthorToUserConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: User
 }
 
-"""
-A node that supports the content editor
-"""
-interface NodeWithContentEditor @join__type(graph: CMS) {
-  """
-  The content of the post.
-  """
+"""A node that supports the content editor"""
+interface NodeWithContentEditor
+  @join__type(graph: CMS)
+{
+  """The content of the post."""
   content(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 }
 
-"""
-A node that can have a featured image set
-"""
+"""A node that can have a featured image set"""
 interface NodeWithFeaturedImage implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
   @join__implements(graph: CMS, interface: "UniformResourceIdentifiable")
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
-  @join__type(graph: CMS) {
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  @join__type(graph: CMS)
+{
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -10169,23 +7589,15 @@ interface NodeWithFeaturedImage implements Node & ContentNode & UniformResourceI
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10203,14 +7615,10 @@ interface NodeWithFeaturedImage implements Node & ContentNode & UniformResourceI
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10234,9 +7642,7 @@ interface NodeWithFeaturedImage implements Node & ContentNode & UniformResourceI
   """
   featuredImageDatabaseId: Int
 
-  """
-  Globally unique ID of the featured image assigned to the node
-  """
+  """Globally unique ID of the featured image assigned to the node"""
   featuredImageId: ID
 
   """
@@ -10244,39 +7650,25 @@ interface NodeWithFeaturedImage implements Node & ContentNode & UniformResourceI
   """
   guid: String
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -10289,14 +7681,10 @@ interface NodeWithFeaturedImage implements Node & ContentNode & UniformResourceI
   """
   modifiedGmt: String
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -10304,49 +7692,41 @@ interface NodeWithFeaturedImage implements Node & ContentNode & UniformResourceI
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to a node of content
-  """
+  """The template assigned to a node of content"""
   template: ContentTemplate
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
 """
 Connection between the NodeWithFeaturedImage type and the MediaItem type
 """
-type NodeWithFeaturedImageToMediaItemConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+type NodeWithFeaturedImageToMediaItemConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: MediaItem
 }
 
-"""
-A node that can have page attributes
-"""
-interface NodeWithPageAttributes @join__type(graph: CMS) {
+"""A node that can have page attributes"""
+interface NodeWithPageAttributes
+  @join__type(graph: CMS)
+{
   """
   A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
   """
   menuOrder: Int
 }
 
-"""
-A node that can have revisions
-"""
-interface NodeWithRevisions @join__type(graph: CMS) {
-  """
-  True if the node is a revision of another node
-  """
+"""A node that can have revisions"""
+interface NodeWithRevisions
+  @join__type(graph: CMS)
+{
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
   """
@@ -10355,94 +7735,80 @@ interface NodeWithRevisions @join__type(graph: CMS) {
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 }
 
-"""
-Connection between the NodeWithRevisions type and the ContentNode type
-"""
-type NodeWithRevisionsToContentNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the NodeWithRevisions type and the ContentNode type"""
+type NodeWithRevisionsToContentNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: ContentNode
 }
 
-"""
-A node that can have a template associated with it
-"""
-interface NodeWithTemplate @join__type(graph: CMS) {
-  """
-  The template assigned to the node
-  """
+"""A node that can have a template associated with it"""
+interface NodeWithTemplate
+  @join__type(graph: CMS)
+{
+  """The template assigned to the node"""
   template: ContentTemplate
 }
 
-"""
-A node that NodeWith a title
-"""
-interface NodeWithTitle @join__type(graph: CMS) {
+"""A node that NodeWith a title"""
+interface NodeWithTitle
+  @join__type(graph: CMS)
+{
   """
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 }
 
-"""
-Describe what a CustomType is
-"""
-type Notification @join__type(graph: CMS) {
-  """
-  Notification content
-  """
+"""Describe what a CustomType is"""
+type Notification
+  @join__type(graph: CMS)
+{
+  """Notification content"""
   content: String
 
-  """
-  Notification end date
-  """
+  """Notification end date"""
   endDate: String
 
-  """
-  Notification level
-  """
+  """Notification level"""
   level: String
 
-  """
-  Notification link text
-  """
+  """Notification link text"""
   linkText: String
 
-  """
-  Notification link url
-  """
+  """Notification link url"""
   linkUrl: String
 
-  """
-  Notification start date
-  """
+  """Notification start date"""
   startDate: String
 
-  """
-  Notification title
-  """
+  """Notification title"""
   title: String
 }
 
-type Offer @join__type(graph: EVENTS) {
+type Offer
+  @join__type(graph: EVENTS)
+{
   isFree: Boolean
   description: LocalizedObject
   price: LocalizedObject
   infoUrl: LocalizedObject
 }
 
-type Ontology @join__type(graph: VENUES) {
+type Ontology
+  @join__type(graph: VENUES)
+{
   id: Int
   label: String
 }
 
-type OntologyTree @join__type(graph: UNIFIED_SEARCH) {
+type OntologyTree
+  @join__type(graph: UNIFIED_SEARCH)
+{
   id: ID
   parentId: ID
   name: LanguageString
@@ -10451,7 +7817,9 @@ type OntologyTree @join__type(graph: UNIFIED_SEARCH) {
   level: Int
 }
 
-type Ontologyword @join__type(graph: UNIFIED_SEARCH) {
+type Ontologyword
+  @join__type(graph: UNIFIED_SEARCH)
+{
   id: Int
   ontologyword_fi: String
   ontologyword_sv: String
@@ -10462,29 +7830,39 @@ type Ontologyword @join__type(graph: UNIFIED_SEARCH) {
   unit_ids: [Int]
 }
 
-type OntologyWord @join__type(graph: UNIFIED_SEARCH) {
+type OntologyWord
+  @join__type(graph: UNIFIED_SEARCH)
+{
   id: ID
   label: LanguageString
 }
 
-type OpeningHour @join__type(graph: VENUES) {
+type OpeningHour
+  @join__type(graph: VENUES)
+{
   date: String!
   times: [Time!]!
 }
 
-type OpeningHours @join__type(graph: UNIFIED_SEARCH) {
+type OpeningHours
+  @join__type(graph: UNIFIED_SEARCH)
+{
   url: String
   is_open_now_url: String
   today: [OpeningHoursTimes]
   data: [OpeningHoursDay]
 }
 
-type OpeningHoursDay @join__type(graph: UNIFIED_SEARCH) {
+type OpeningHoursDay
+  @join__type(graph: UNIFIED_SEARCH)
+{
   date: String
   times: [OpeningHoursTimes]
 }
 
-type OpeningHoursTimes @join__type(graph: UNIFIED_SEARCH) {
+type OpeningHoursTimes
+  @join__type(graph: UNIFIED_SEARCH)
+{
   startTime: String
   endTime: String
   endTimeOnNextDay: Boolean
@@ -10492,40 +7870,42 @@ type OpeningHoursTimes @join__type(graph: UNIFIED_SEARCH) {
   fullDay: Boolean
 }
 
-input OrderByDistance @join__type(graph: UNIFIED_SEARCH) {
+input OrderByDistance
+  @join__type(graph: UNIFIED_SEARCH)
+{
   latitude: Float!
   longitude: Float!
   order: SortOrder = ASCENDING
 }
 
-input OrderByName @join__type(graph: UNIFIED_SEARCH) {
+input OrderByName
+  @join__type(graph: UNIFIED_SEARCH)
+{
   order: SortOrder = ASCENDING
 }
 
-"""
-The cardinality of the connection order
-"""
-enum OrderEnum @join__type(graph: CMS) {
-  """
-  Sort the query result set in an ascending order
-  """
+"""The cardinality of the connection order"""
+enum OrderEnum
+  @join__type(graph: CMS)
+{
+  """Sort the query result set in an ascending order"""
   ASC
 
-  """
-  Sort the query result set in a descending order
-  """
+  """Sort the query result set in a descending order"""
   DESC
 }
 
-"""
-TODO: merge beta.kultus organisation, etc
-"""
-type Organisation @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: merge beta.kultus organisation, etc"""
+type Organisation
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   contactDetails: ContactInfo
 }
 
-type OrganizationDetails @join__type(graph: EVENTS) {
+type OrganizationDetails
+  @join__type(graph: EVENTS)
+{
   id: ID
   dataSource: String
   classification: String
@@ -10544,9 +7924,7 @@ type OrganizationDetails @join__type(graph: EVENTS) {
   internalType: String
 }
 
-"""
-The page type
-"""
+"""The page type"""
 type Page implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithContentEditor & NodeWithAuthor & NodeWithFeaturedImage & NodeWithRevisions & NodeWithPageAttributes & HierarchicalContentNode & MenuItemLinkable
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -10561,19 +7939,16 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   @join__implements(graph: CMS, interface: "NodeWithPageAttributes")
   @join__implements(graph: CMS, interface: "HierarchicalContentNode")
   @join__implements(graph: CMS, interface: "MenuItemLinkable")
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
   """
   ancestors(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10586,39 +7961,27 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeAncestorsConnection
 
-  """
-  Connection between the NodeWithAuthor type and the User type
-  """
+  """Connection between the NodeWithAuthor type and the User type"""
   author: NodeWithAuthorToUserConnectionEdge
 
-  """
-  The database identifier of the author of the node
-  """
+  """The database identifier of the author of the node"""
   authorDatabaseId: Int
 
-  """
-  The globally unique identifier of the author of the node
-  """
+  """The globally unique identifier of the author of the node"""
   authorId: ID
 
   """
   Connection between the HierarchicalContentNode type and the ContentNode type
   """
   children(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10631,50 +7994,32 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeChildrenConnection
 
-  """
-  The content of the post.
-  """
+  """The content of the post."""
   content(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -10682,23 +8027,15 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10716,14 +8053,10 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10737,9 +8070,7 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     before: String
   ): ContentNodeToEnqueuedStylesheetConnection
 
-  """
-  Vanhentumisaika
-  """
+  """Vanhentumisaika"""
   expirationTime: String
 
   """
@@ -10752,9 +8083,7 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   featuredImageDatabaseId: Int
 
-  """
-  Globally unique ID of the featured image assigned to the node
-  """
+  """Globally unique ID of the featured image assigned to the node"""
   featuredImageId: ID
 
   """
@@ -10762,69 +8091,43 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   guid: String
 
-  """
-  The globally unique identifier of the page object.
-  """
+  """The globally unique identifier of the page object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether this page is set to the static front page.
-  """
+  """Whether this page is set to the static front page."""
   isFrontPage: Boolean!
 
-  """
-  Whether this page is set to the blog posts page.
-  """
+  """Whether this page is set to the blog posts page."""
   isPostsPage: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether this page is set to the privacy page.
-  """
+  """Whether this page is set to the privacy page."""
   isPrivacyPage: Boolean!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  True if the node is a revision of another node
-  """
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  Polylang language
-  """
+  """Polylang language"""
   language: Language
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  Ingressi
-  """
+  """Ingressi"""
   lead: String
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -10842,45 +8145,28 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   modifiedGmt: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [PageModulesUnionType]
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  pageId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """The id field matches the WP_Post-&gt;ID field."""
+  pageId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  The parent of the node. The parent object can be of various types
-  """
+  """The parent of the node. The parent object can be of various types"""
   parent: HierarchicalContentNodeToParentContentNodeConnectionEdge
 
-  """
-  Database id of the parent node
-  """
+  """Database id of the parent node"""
   parentDatabaseId: Int
 
-  """
-  The globally unique identifier of the parent node.
-  """
+  """The globally unique identifier of the parent node."""
   parentId: ID
 
-  """
-  Connection between the page type and the page type
-  """
+  """Connection between the page type and the page type"""
   preview: PageToPreviewConnectionEdge
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -10888,18 +8174,12 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 
-  """
-  Connection between the page type and the page type
-  """
+  """Connection between the page type and the page type"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10912,25 +8192,17 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PageToRevisionConnectionWhereArgs
   ): PageToRevisionConnection
 
-  """
-  The SEO Framework data of the page
-  """
+  """The SEO Framework data of the page"""
   seo: SEO
 
-  """
-  Näytä alisivut
-  """
+  """Näytä alisivut"""
   showChildPages: Boolean
 
-  """
-  List of modules
-  """
+  """List of modules"""
   sidebar: [PageSidebarUnionType]
 
   """
@@ -10938,28 +8210,18 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to a node of content
-  """
+  """The template assigned to a node of content"""
   template: ContentTemplate
 
-  """
-  Connection between the page type and the TermNode type
-  """
+  """Connection between the page type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -10972,9 +8234,7 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PageToTermNodeConnectionWhereArgs
   ): PageToTermNodeConnection
 
@@ -10982,129 +8242,88 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): Page
 
-  """
-  List all translated versions of this post
-  """
+  """List all translated versions of this post"""
   translations: [Page]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum PageIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum PageIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-union PageModulesUnionType @join__type(graph: CMS) =
-    EventSearch
-  | EventSelected
-  | EventSearchCarousel
-  | EventSelectedCarousel
-  | LocationsSelected
-  | LayoutCollection
-  | LayoutContact
-  | LayoutArticles
-  | LayoutArticlesCarousel
-  | LayoutArticleHighlights
-  | LayoutPages
-  | LayoutPagesCarousel
+union PageModulesUnionType
+  @join__type(graph: CMS)
+ = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel
 
-union PageSidebarUnionType @join__type(graph: CMS) =
-    LayoutLinkList
-  | LayoutArticles
-  | LayoutPages
+union PageSidebarUnionType
+  @join__type(graph: CMS)
+ = LayoutLinkList | LayoutArticles | LayoutPages
 
-"""
-Connection between the page type and the page type
-"""
-type PageToPreviewConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the page type and the page type"""
+type PageToPreviewConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Page
 }
 
-"""
-Connection between the page type and the page type
-"""
-type PageToRevisionConnection @join__type(graph: CMS) {
-  """
-  Edges for the pageToRevisionConnection connection
-  """
+"""Connection between the page type and the page type"""
+type PageToRevisionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the pageToRevisionConnection connection"""
   edges: [PageToRevisionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Page]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PageToRevisionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PageToRevisionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Page
 }
 
-"""
-Arguments for filtering the pageToRevisionConnection connection
-"""
-input PageToRevisionConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the pageToRevisionConnection connection"""
+input PageToRevisionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -11112,9 +8331,7 @@ input PageToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -11122,29 +8339,19 @@ input PageToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -11152,91 +8359,63 @@ input PageToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the page type and the TermNode type
-"""
-type PageToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the PageToTermNodeConnection connection
-  """
+"""Connection between the page type and the TermNode type"""
+type PageToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the PageToTermNodeConnection connection"""
   edges: [PageToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PageToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PageToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the PageToTermNodeConnection connection
-"""
-input PageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the PageToTermNodeConnection connection"""
+input PageToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -11277,19 +8456,13 @@ input PageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -11297,14 +8470,10 @@ input PageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -11312,9 +8481,7 @@ input PageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -11322,31 +8489,23 @@ input PageToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-type PalvelukarttaUnit @join__type(graph: UNIFIED_SEARCH) {
-  """
-  Raw palvelukartta Unit fields
-  """
+type PalvelukarttaUnit
+  @join__type(graph: UNIFIED_SEARCH)
+{
+  """Raw palvelukartta Unit fields"""
   origin: String
   id: Int
   org_id: String
@@ -11395,10 +8554,10 @@ type PalvelukarttaUnit @join__type(graph: UNIFIED_SEARCH) {
   ontologyword_ids_enriched: [Ontologyword]
 }
 
-"""
-TODO: take from Profile
-"""
-type Person @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: take from Profile"""
+type Person
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   name: String
   identificationStrength: IdentificationStrength
@@ -11407,12 +8566,16 @@ type Person @join__type(graph: UNIFIED_SEARCH) {
   preferredMedium: ContactMedium
 }
 
-type PhoneNumber @join__type(graph: UNIFIED_SEARCH) {
+type PhoneNumber
+  @join__type(graph: UNIFIED_SEARCH)
+{
   countryCode: String!
   restNumber: String!
 }
 
-type Place @join__type(graph: EVENTS) {
+type Place
+  @join__type(graph: EVENTS)
+{
   id: ID
   divisions: [Division!]
   hasUpcomingEvents: Boolean
@@ -11444,55 +8607,44 @@ type Place @join__type(graph: EVENTS) {
   internalType: String
 }
 
-type PlaceListResponse @join__type(graph: EVENTS) {
+type PlaceListResponse
+  @join__type(graph: EVENTS)
+{
   meta: Meta!
   data: [Place!]!
 }
 
-type PlacePosition @join__type(graph: EVENTS) {
+type PlacePosition
+  @join__type(graph: EVENTS)
+{
   type: String!
   coordinates: [Float!]!
 }
 
-"""
-An plugin object
-"""
+"""An plugin object"""
 type Plugin implements Node
   @join__implements(graph: CMS, interface: "Node")
-  @join__type(graph: CMS) {
-  """
-  Name of the plugin author(s), may also be a company name.
-  """
+  @join__type(graph: CMS)
+{
+  """Name of the plugin author(s), may also be a company name."""
   author: String
 
-  """
-  URI for the related author(s)/company website.
-  """
+  """URI for the related author(s)/company website."""
   authorUri: String
 
-  """
-  Description of the plugin.
-  """
+  """Description of the plugin."""
   description: String
 
-  """
-  The globally unique identifier of the plugin object.
-  """
+  """The globally unique identifier of the plugin object."""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Display name of the plugin.
-  """
+  """Display name of the plugin."""
   name: String
 
-  """
-  Plugin path.
-  """
+  """Plugin path."""
   path: String
 
   """
@@ -11500,39 +8652,27 @@ type Plugin implements Node
   """
   pluginUri: String
 
-  """
-  Current version of the plugin.
-  """
+  """Current version of the plugin."""
   version: String
 }
 
-"""
-The status of the WordPress plugin.
-"""
-enum PluginStatusEnum @join__type(graph: CMS) {
-  """
-  The plugin is currently active.
-  """
+"""The status of the WordPress plugin."""
+enum PluginStatusEnum
+  @join__type(graph: CMS)
+{
+  """The plugin is currently active."""
   ACTIVE
 
-  """
-  The plugin is a drop-in plugin.
-  """
+  """The plugin is a drop-in plugin."""
   DROP_IN
 
-  """
-  The plugin is currently inactive.
-  """
+  """The plugin is currently inactive."""
   INACTIVE
 
-  """
-  The plugin is a must-use plugin.
-  """
+  """The plugin is a must-use plugin."""
   MUST_USE
 
-  """
-  The plugin is activated on the multisite network.
-  """
+  """The plugin is activated on the multisite network."""
   NETWORK_ACTIVATED
 
   """
@@ -11540,30 +8680,24 @@ enum PluginStatusEnum @join__type(graph: CMS) {
   """
   NETWORK_INACTIVE
 
-  """
-  The plugin is technically active but was paused while loading.
-  """
+  """The plugin is technically active but was paused while loading."""
   PAUSED
 
-  """
-  The plugin was active recently.
-  """
+  """The plugin was active recently."""
   RECENTLY_ACTIVE
 
-  """
-  The plugin has an upgrade available.
-  """
+  """The plugin has an upgrade available."""
   UPGRADE
 }
 
-type Point @join__type(graph: VENUES) {
+type Point
+  @join__type(graph: VENUES)
+{
   type: String
   coordinates: [Float!]!
 }
 
-"""
-The post type
-"""
+"""The post type"""
 type Post implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithContentEditor & NodeWithAuthor & NodeWithFeaturedImage & NodeWithRevisions & MenuItemLinkable
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -11576,34 +8710,23 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   @join__implements(graph: CMS, interface: "NodeWithFeaturedImage")
   @join__implements(graph: CMS, interface: "NodeWithRevisions")
   @join__implements(graph: CMS, interface: "MenuItemLinkable")
-  @join__type(graph: CMS) {
-  """
-  Connection between the NodeWithAuthor type and the User type
-  """
+  @join__type(graph: CMS)
+{
+  """Connection between the NodeWithAuthor type and the User type"""
   author: NodeWithAuthorToUserConnectionEdge
 
-  """
-  The database identifier of the author of the node
-  """
+  """The database identifier of the author of the node"""
   authorDatabaseId: Int
 
-  """
-  The globally unique identifier of the author of the node
-  """
+  """The globally unique identifier of the author of the node"""
   authorId: ID
 
-  """
-  Connection between the post type and the category type
-  """
+  """Connection between the post type and the category type"""
   categories(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -11616,50 +8739,32 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PostToCategoryConnectionWhereArgs
   ): PostToCategoryConnection
 
-  """
-  The content of the post.
-  """
+  """The content of the post."""
   content(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -11667,23 +8772,15 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -11701,14 +8798,10 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -11722,9 +8815,7 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     before: String
   ): ContentNodeToEnqueuedStylesheetConnection
 
-  """
-  Vanhentumisaika
-  """
+  """Vanhentumisaika"""
   expirationTime: String
 
   """
@@ -11737,9 +8828,7 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   featuredImageDatabaseId: Int
 
-  """
-  Globally unique ID of the featured image assigned to the node
-  """
+  """Globally unique ID of the featured image assigned to the node"""
   featuredImageId: ID
 
   """
@@ -11747,64 +8836,40 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   guid: String
 
-  """
-  Hide Published Date
-  """
+  """Hide Published Date"""
   hidePublishedDate: Boolean
 
-  """
-  The globally unique identifier of the post object.
-  """
+  """The globally unique identifier of the post object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  True if the node is a revision of another node
-  """
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
-  """
-  Whether this page is sticky
-  """
+  """Whether this page is sticky"""
   isSticky: Boolean!
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  Polylang language
-  """
+  """Polylang language"""
   language: Language
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  Ingressi
-  """
+  """Ingressi"""
   lead: String
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -11817,23 +8882,15 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   modifiedGmt: String
 
-  """
-  List of modules
-  """
+  """List of modules"""
   modules: [PostModulesUnionType]
 
-  """
-  Connection between the post type and the postFormat type
-  """
+  """Connection between the post type and the postFormat type"""
   postFormats(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -11846,31 +8903,20 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PostToPostFormatConnectionWhereArgs
   ): PostToPostFormatConnection
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  postId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """The id field matches the WP_Post-&gt;ID field."""
+  postId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Connection between the post type and the post type
-  """
+  """Connection between the post type and the post type"""
   preview: PostToPreviewConnectionEdge
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -11878,18 +8924,12 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 
-  """
-  Connection between the post type and the post type
-  """
+  """Connection between the post type and the post type"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -11902,20 +8942,14 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PostToRevisionConnectionWhereArgs
   ): PostToRevisionConnection
 
-  """
-  The SEO Framework data of the post
-  """
+  """The SEO Framework data of the post"""
   seo: SEO
 
-  """
-  List of modules
-  """
+  """List of modules"""
   sidebar: [PostSidebarUnionType]
 
   """
@@ -11923,23 +8957,15 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  Connection between the post type and the tag type
-  """
+  """Connection between the post type and the tag type"""
   tags(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -11952,29 +8978,19 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PostToTagConnectionWhereArgs
   ): PostToTagConnection
 
-  """
-  The template assigned to a node of content
-  """
+  """The template assigned to a node of content"""
   template: ContentTemplate
 
-  """
-  Connection between the post type and the TermNode type
-  """
+  """Connection between the post type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -11987,9 +9003,7 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PostToTermNodeConnectionWhereArgs
   ): PostToTermNodeConnection
 
@@ -11997,47 +9011,39 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): Post
 
-  """
-  List all translated versions of this post
-  """
+  """List all translated versions of this post"""
   translations: [Post]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-Set relationships between the post to categories
-"""
-input PostCategoriesInput @join__type(graph: CMS) {
+"""Set relationships between the post to categories"""
+input PostCategoriesInput
+  @join__type(graph: CMS)
+{
   """
   If true, this will append the category to existing related categories. If false, this will replace existing relationships. Default true.
   """
   append: Boolean
 
-  """
-  The input list of items to set.
-  """
+  """The input list of items to set."""
   nodes: [PostCategoriesNodeInput]
 }
 
 """
 List of categories to connect the post to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.
 """
-input PostCategoriesNodeInput @join__type(graph: CMS) {
+input PostCategoriesNodeInput
+  @join__type(graph: CMS)
+{
   """
   The description of the category. This field is used to set a description of the category if a new one is created during the mutation.
   """
@@ -12059,27 +9065,20 @@ input PostCategoriesNodeInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-The postFormat type
-"""
+"""The postFormat type"""
 type PostFormat implements Node & TermNode & UniformResourceIdentifiable & DatabaseIdentifier
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "TermNode")
   @join__implements(graph: CMS, interface: "UniformResourceIdentifiable")
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
-  @join__type(graph: CMS) {
-  """
-  Connection between the postFormat type and the ContentNode type
-  """
+  @join__type(graph: CMS)
+{
+  """Connection between the postFormat type and the ContentNode type"""
   contentNodes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -12092,39 +9091,25 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PostFormatToContentNodeConnectionWhereArgs
   ): PostFormatToContentNodeConnection
 
-  """
-  The number of objects connected to the object
-  """
+  """The number of objects connected to the object"""
   count: Int
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  The description of the object
-  """
+  """The description of the object"""
   description: String
 
-  """
-  Connection between the TermNode type and the EnqueuedScript type
-  """
+  """Connection between the TermNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -12138,18 +9123,12 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     before: String
   ): TermNodeToEnqueuedScriptConnection
 
-  """
-  Connection between the TermNode type and the EnqueuedStylesheet type
-  """
+  """Connection between the TermNode type and the EnqueuedStylesheet type"""
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -12163,53 +9142,33 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     before: String
   ): TermNodeToEnqueuedStylesheetConnection
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  The link to the term
-  """
+  """The link to the term"""
   link: String
 
-  """
-  The human friendly name of the object.
-  """
+  """The human friendly name of the object."""
   name: String
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
+  """The id field matches the WP_Post-&gt;ID field."""
   postFormatId: Int @deprecated(reason: "Deprecated in favor of databaseId")
 
-  """
-  Connection between the postFormat type and the post type
-  """
+  """Connection between the postFormat type and the post type"""
   posts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -12222,120 +9181,84 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: PostFormatToPostConnectionWhereArgs
   ): PostFormatToPostConnection
 
-  """
-  An alphanumeric identifier for the object unique to its type.
-  """
+  """An alphanumeric identifier for the object unique to its type."""
   slug: String
 
-  """
-  Connection between the postFormat type and the Taxonomy type
-  """
+  """Connection between the postFormat type and the Taxonomy type"""
   taxonomy: PostFormatToTaxonomyConnectionEdge
 
-  """
-  The name of the taxonomy that the object is associated with
-  """
+  """The name of the taxonomy that the object is associated with"""
   taxonomyName: String
 
-  """
-  The ID of the term group that this term object belongs to
-  """
+  """The ID of the term group that this term object belongs to"""
   termGroupId: Int
 
-  """
-  The taxonomy ID that the object is associated with
-  """
+  """The taxonomy ID that the object is associated with"""
   termTaxonomyId: Int
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum PostFormatIdType @join__type(graph: CMS) {
-  """
-  The Database ID for the node
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum PostFormatIdType
+  @join__type(graph: CMS)
+{
+  """The Database ID for the node"""
   DATABASE_ID
 
-  """
-  The hashed Global ID
-  """
+  """The hashed Global ID"""
   ID
 
-  """
-  The name of the node
-  """
+  """The name of the node"""
   NAME
 
-  """
-  Url friendly name of the node
-  """
+  """Url friendly name of the node"""
   SLUG
 
-  """
-  The URI for the node
-  """
+  """The URI for the node"""
   URI
 }
 
-"""
-Connection between the postFormat type and the ContentNode type
-"""
-type PostFormatToContentNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the PostFormatToContentNodeConnection connection
-  """
+"""Connection between the postFormat type and the ContentNode type"""
+type PostFormatToContentNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the PostFormatToContentNodeConnection connection"""
   edges: [PostFormatToContentNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PostFormatToContentNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PostFormatToContentNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentNode
 }
 
 """
 Arguments for filtering the PostFormatToContentNodeConnection connection
 """
-input PostFormatToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+input PostFormatToContentNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypesOfPostFormatEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -12343,29 +9266,19 @@ input PostFormatToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -12373,104 +9286,72 @@ input PostFormatToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the postFormat type and the post type
-"""
-type PostFormatToPostConnection @join__type(graph: CMS) {
-  """
-  Edges for the PostFormatToPostConnection connection
-  """
+"""Connection between the postFormat type and the post type"""
+type PostFormatToPostConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the PostFormatToPostConnection connection"""
   edges: [PostFormatToPostConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Post]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PostFormatToPostConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PostFormatToPostConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Post
 }
 
-"""
-Arguments for filtering the PostFormatToPostConnection connection
-"""
-input PostFormatToPostConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the PostFormatToPostConnection connection"""
+input PostFormatToPostConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -12478,9 +9359,7 @@ input PostFormatToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Category ID
-  """
+  """Category ID"""
   categoryId: Int
 
   """
@@ -12488,9 +9367,7 @@ input PostFormatToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryIn: [ID]
 
-  """
-  Use Category Slug
-  """
+  """Use Category Slug"""
   categoryName: String
 
   """
@@ -12498,9 +9375,7 @@ input PostFormatToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -12508,29 +9383,19 @@ input PostFormatToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -12538,104 +9403,68 @@ input PostFormatToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Tag Slug
-  """
+  """Tag Slug"""
   tag: String
 
-  """
-  Use Tag ID
-  """
+  """Use Tag ID"""
   tagId: String
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagIn: [ID]
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagNotIn: [ID]
 
-  """
-  Array of tag slugs, used to display objects from one tag OR another
-  """
+  """Array of tag slugs, used to display objects from one tag OR another"""
   tagSlugAnd: [String]
 
-  """
-  Array of tag slugs, used to exclude objects in specified tags
-  """
+  """Array of tag slugs, used to exclude objects in specified tags"""
   tagSlugIn: [String]
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the postFormat type and the Taxonomy type
-"""
-type PostFormatToTaxonomyConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the postFormat type and the Taxonomy type"""
+type PostFormatToTaxonomyConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Taxonomy
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum PostIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum PostIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
   """
@@ -12643,145 +9472,101 @@ enum PostIdType @join__type(graph: CMS) {
   """
   SLUG
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-union PostModulesUnionType @join__type(graph: CMS) =
-    EventSearch
-  | EventSelected
-  | EventSearchCarousel
-  | EventSelectedCarousel
-  | LocationsSelected
-  | LayoutCollection
-  | LayoutContact
-  | LayoutArticles
-  | LayoutArticlesCarousel
-  | LayoutArticleHighlights
-  | LayoutPages
-  | LayoutPagesCarousel
+union PostModulesUnionType
+  @join__type(graph: CMS)
+ = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel
 
-"""
-The format of post field data.
-"""
-enum PostObjectFieldFormatEnum @join__type(graph: CMS) {
-  """
-  Provide the field value directly from database
-  """
+"""The format of post field data."""
+enum PostObjectFieldFormatEnum
+  @join__type(graph: CMS)
+{
+  """Provide the field value directly from database"""
   RAW
 
-  """
-  Apply the default WordPress rendering
-  """
+  """Apply the default WordPress rendering"""
   RENDERED
 }
 
-"""
-The column to use when filtering by date
-"""
-enum PostObjectsConnectionDateColumnEnum @join__type(graph: CMS) {
-  """
-  The date the comment was created in local time.
-  """
+"""The column to use when filtering by date"""
+enum PostObjectsConnectionDateColumnEnum
+  @join__type(graph: CMS)
+{
+  """The date the comment was created in local time."""
   DATE
 
-  """
-  The most recent modification date of the comment.
-  """
+  """The most recent modification date of the comment."""
   MODIFIED
 }
 
-"""
-Field to order the connection by
-"""
-enum PostObjectsConnectionOrderbyEnum @join__type(graph: CMS) {
-  """
-  Order by author
-  """
+"""Field to order the connection by"""
+enum PostObjectsConnectionOrderbyEnum
+  @join__type(graph: CMS)
+{
+  """Order by author"""
   AUTHOR
 
-  """
-  Order by the number of comments it has acquired
-  """
+  """Order by the number of comments it has acquired"""
   COMMENT_COUNT
 
-  """
-  Order by publish date
-  """
+  """Order by publish date"""
   DATE
 
-  """
-  Preserve the ID order given in the IN array
-  """
+  """Preserve the ID order given in the IN array"""
   IN
 
-  """
-  Order by the menu order value
-  """
+  """Order by the menu order value"""
   MENU_ORDER
 
-  """
-  Order by last modified date
-  """
+  """Order by last modified date"""
   MODIFIED
 
-  """
-  Preserve slug order given in the NAME_IN array
-  """
+  """Preserve slug order given in the NAME_IN array"""
   NAME_IN
 
-  """
-  Order by parent ID
-  """
+  """Order by parent ID"""
   PARENT
 
-  """
-  Order by slug
-  """
+  """Order by slug"""
   SLUG
 
-  """
-  Order by title
-  """
+  """Order by title"""
   TITLE
 }
 
-"""
-Options for ordering the connection
-"""
-input PostObjectsConnectionOrderbyInput @join__type(graph: CMS) {
-  """
-  The field to order the connection by
-  """
+"""Options for ordering the connection"""
+input PostObjectsConnectionOrderbyInput
+  @join__type(graph: CMS)
+{
+  """The field to order the connection by"""
   field: PostObjectsConnectionOrderbyEnum!
 
-  """
-  Possible directions in which to order a list of items
-  """
+  """Possible directions in which to order a list of items"""
   order: OrderEnum!
 }
 
-"""
-Set relationships between the post to postFormats
-"""
-input PostPostFormatsInput @join__type(graph: CMS) {
+"""Set relationships between the post to postFormats"""
+input PostPostFormatsInput
+  @join__type(graph: CMS)
+{
   """
   If true, this will append the postFormat to existing related postFormats. If false, this will replace existing relationships. Default true.
   """
   append: Boolean
 
-  """
-  The input list of items to set.
-  """
+  """The input list of items to set."""
   nodes: [PostPostFormatsNodeInput]
 }
 
 """
 List of postFormats to connect the post to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.
 """
-input PostPostFormatsNodeInput @join__type(graph: CMS) {
+input PostPostFormatsNodeInput
+  @join__type(graph: CMS)
+{
   """
   The description of the postFormat. This field is used to set a description of the postFormat if a new one is created during the mutation.
   """
@@ -12803,115 +9588,82 @@ input PostPostFormatsNodeInput @join__type(graph: CMS) {
   slug: String
 }
 
-union PostSidebarUnionType @join__type(graph: CMS) =
-    LayoutLinkList
-  | LayoutArticles
-  | LayoutPages
+union PostSidebarUnionType
+  @join__type(graph: CMS)
+ = LayoutLinkList | LayoutArticles | LayoutPages
 
-"""
-The status of the object.
-"""
-enum PostStatusEnum @join__type(graph: CMS) {
-  """
-  Objects with the acf-disabled status
-  """
+"""The status of the object."""
+enum PostStatusEnum
+  @join__type(graph: CMS)
+{
+  """Objects with the acf-disabled status"""
   ACF_DISABLED
 
-  """
-  Objects with the auto-draft status
-  """
+  """Objects with the auto-draft status"""
   AUTO_DRAFT
 
-  """
-  Objects with the dp-rewrite-republish status
-  """
+  """Objects with the dp-rewrite-republish status"""
   DP_REWRITE_REPUBLISH
 
-  """
-  Objects with the draft status
-  """
+  """Objects with the draft status"""
   DRAFT
 
-  """
-  Objects with the future status
-  """
+  """Objects with the future status"""
   FUTURE
 
-  """
-  Objects with the inherit status
-  """
+  """Objects with the inherit status"""
   INHERIT
 
-  """
-  Objects with the pending status
-  """
+  """Objects with the pending status"""
   PENDING
 
-  """
-  Objects with the private status
-  """
+  """Objects with the private status"""
   PRIVATE
 
-  """
-  Objects with the publish status
-  """
+  """Objects with the publish status"""
   PUBLISH
 
-  """
-  Objects with the request-completed status
-  """
+  """Objects with the request-completed status"""
   REQUEST_COMPLETED
 
-  """
-  Objects with the request-confirmed status
-  """
+  """Objects with the request-confirmed status"""
   REQUEST_CONFIRMED
 
-  """
-  Objects with the request-failed status
-  """
+  """Objects with the request-failed status"""
   REQUEST_FAILED
 
-  """
-  Objects with the request-pending status
-  """
+  """Objects with the request-pending status"""
   REQUEST_PENDING
 
-  """
-  Objects with the trash status
-  """
+  """Objects with the trash status"""
   TRASH
 
-  """
-  Objects with the wp_stream_disabled status
-  """
+  """Objects with the wp_stream_disabled status"""
   WP_STREAM_DISABLED
 
-  """
-  Objects with the wp_stream_enabled status
-  """
+  """Objects with the wp_stream_enabled status"""
   WP_STREAM_ENABLED
 }
 
-"""
-Set relationships between the post to tags
-"""
-input PostTagsInput @join__type(graph: CMS) {
+"""Set relationships between the post to tags"""
+input PostTagsInput
+  @join__type(graph: CMS)
+{
   """
   If true, this will append the tag to existing related tags. If false, this will replace existing relationships. Default true.
   """
   append: Boolean
 
-  """
-  The input list of items to set.
-  """
+  """The input list of items to set."""
   nodes: [PostTagsNodeInput]
 }
 
 """
 List of tags to connect the post to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists.
 """
-input PostTagsNodeInput @join__type(graph: CMS) {
+input PostTagsNodeInput
+  @join__type(graph: CMS)
+{
   """
   The description of the tag. This field is used to set a description of the tag if a new one is created during the mutation.
   """
@@ -12933,45 +9685,35 @@ input PostTagsNodeInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-Connection between the post type and the category type
-"""
-type PostToCategoryConnection @join__type(graph: CMS) {
-  """
-  Edges for the PostToCategoryConnection connection
-  """
+"""Connection between the post type and the category type"""
+type PostToCategoryConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the PostToCategoryConnection connection"""
   edges: [PostToCategoryConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Category]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PostToCategoryConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PostToCategoryConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Category
 }
 
-"""
-Arguments for filtering the PostToCategoryConnection connection
-"""
-input PostToCategoryConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the PostToCategoryConnection connection"""
+input PostToCategoryConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -13012,19 +9754,13 @@ input PostToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -13032,14 +9768,10 @@ input PostToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -13047,9 +9779,7 @@ input PostToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -13057,61 +9787,45 @@ input PostToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the post type and the postFormat type
-"""
-type PostToPostFormatConnection @join__type(graph: CMS) {
-  """
-  Edges for the PostToPostFormatConnection connection
-  """
+"""Connection between the post type and the postFormat type"""
+type PostToPostFormatConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the PostToPostFormatConnection connection"""
   edges: [PostToPostFormatConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [PostFormat]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PostToPostFormatConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PostToPostFormatConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: PostFormat
 }
 
-"""
-Arguments for filtering the PostToPostFormatConnection connection
-"""
-input PostToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the PostToPostFormatConnection connection"""
+input PostToPostFormatConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -13152,19 +9866,13 @@ input PostToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -13172,14 +9880,10 @@ input PostToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -13187,9 +9891,7 @@ input PostToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -13197,84 +9899,62 @@ input PostToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the post type and the post type
-"""
-type PostToPreviewConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the post type and the post type"""
+type PostToPreviewConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Post
 }
 
-"""
-Connection between the post type and the post type
-"""
-type PostToRevisionConnection @join__type(graph: CMS) {
-  """
-  Edges for the postToRevisionConnection connection
-  """
+"""Connection between the post type and the post type"""
+type PostToRevisionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the postToRevisionConnection connection"""
   edges: [PostToRevisionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Post]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PostToRevisionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PostToRevisionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Post
 }
 
-"""
-Arguments for filtering the postToRevisionConnection connection
-"""
-input PostToRevisionConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the postToRevisionConnection connection"""
+input PostToRevisionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -13282,9 +9962,7 @@ input PostToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Category ID
-  """
+  """Category ID"""
   categoryId: Int
 
   """
@@ -13292,9 +9970,7 @@ input PostToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryIn: [ID]
 
-  """
-  Use Category Slug
-  """
+  """Use Category Slug"""
   categoryName: String
 
   """
@@ -13302,9 +9978,7 @@ input PostToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -13312,29 +9986,19 @@ input PostToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -13342,121 +10006,81 @@ input PostToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Tag Slug
-  """
+  """Tag Slug"""
   tag: String
 
-  """
-  Use Tag ID
-  """
+  """Use Tag ID"""
   tagId: String
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagIn: [ID]
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagNotIn: [ID]
 
-  """
-  Array of tag slugs, used to display objects from one tag OR another
-  """
+  """Array of tag slugs, used to display objects from one tag OR another"""
   tagSlugAnd: [String]
 
-  """
-  Array of tag slugs, used to exclude objects in specified tags
-  """
+  """Array of tag slugs, used to exclude objects in specified tags"""
   tagSlugIn: [String]
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the post type and the tag type
-"""
-type PostToTagConnection @join__type(graph: CMS) {
-  """
-  Edges for the PostToTagConnection connection
-  """
+"""Connection between the post type and the tag type"""
+type PostToTagConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the PostToTagConnection connection"""
   edges: [PostToTagConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Tag]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PostToTagConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PostToTagConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Tag
 }
 
-"""
-Arguments for filtering the PostToTagConnection connection
-"""
-input PostToTagConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the PostToTagConnection connection"""
+input PostToTagConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -13497,19 +10121,13 @@ input PostToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -13517,14 +10135,10 @@ input PostToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -13532,9 +10146,7 @@ input PostToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -13542,61 +10154,45 @@ input PostToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the post type and the TermNode type
-"""
-type PostToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the PostToTermNodeConnection connection
-  """
+"""Connection between the post type and the TermNode type"""
+type PostToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the PostToTermNodeConnection connection"""
   edges: [PostToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type PostToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type PostToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the PostToTermNodeConnection connection
-"""
-input PostToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the PostToTermNodeConnection connection"""
+input PostToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -13637,19 +10233,13 @@ input PostToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -13657,14 +10247,10 @@ input PostToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -13672,9 +10258,7 @@ input PostToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -13682,182 +10266,115 @@ input PostToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Details for labels of the PostType
-"""
-type PostTypeLabelDetails @join__type(graph: CMS) {
-  """
-  Default is ‘Add New’ for both hierarchical and non-hierarchical types.
-  """
+"""Details for labels of the PostType"""
+type PostTypeLabelDetails
+  @join__type(graph: CMS)
+{
+  """Default is ‘Add New’ for both hierarchical and non-hierarchical types."""
   addNew: String
 
-  """
-  Label for adding a new singular item.
-  """
+  """Label for adding a new singular item."""
   addNewItem: String
 
-  """
-  Label to signify all items in a submenu link.
-  """
+  """Label to signify all items in a submenu link."""
   allItems: String
 
-  """
-  Label for archives in nav menus
-  """
+  """Label for archives in nav menus"""
   archives: String
 
-  """
-  Label for the attributes meta box.
-  """
+  """Label for the attributes meta box."""
   attributes: String
 
-  """
-  Label for editing a singular item.
-  """
+  """Label for editing a singular item."""
   editItem: String
 
-  """
-  Label for the Featured Image meta box title.
-  """
+  """Label for the Featured Image meta box title."""
   featuredImage: String
 
-  """
-  Label for the table views hidden heading.
-  """
+  """Label for the table views hidden heading."""
   filterItemsList: String
 
-  """
-  Label for the media frame button.
-  """
+  """Label for the media frame button."""
   insertIntoItem: String
 
-  """
-  Label for the table hidden heading.
-  """
+  """Label for the table hidden heading."""
   itemsList: String
 
-  """
-  Label for the table pagination hidden heading.
-  """
+  """Label for the table pagination hidden heading."""
   itemsListNavigation: String
 
-  """
-  Label for the menu name.
-  """
+  """Label for the menu name."""
   menuName: String
 
-  """
-  General name for the post type, usually plural.
-  """
+  """General name for the post type, usually plural."""
   name: String
 
-  """
-  Label for the new item page title.
-  """
+  """Label for the new item page title."""
   newItem: String
 
-  """
-  Label used when no items are found.
-  """
+  """Label used when no items are found."""
   notFound: String
 
-  """
-  Label used when no items are in the trash.
-  """
+  """Label used when no items are in the trash."""
   notFoundInTrash: String
 
-  """
-  Label used to prefix parents of hierarchical items.
-  """
+  """Label used to prefix parents of hierarchical items."""
   parentItemColon: String
 
-  """
-  Label for removing the featured image.
-  """
+  """Label for removing the featured image."""
   removeFeaturedImage: String
 
-  """
-  Label for searching plural items.
-  """
+  """Label for searching plural items."""
   searchItems: String
 
-  """
-  Label for setting the featured image.
-  """
+  """Label for setting the featured image."""
   setFeaturedImage: String
 
-  """
-  Name for one object of this post type.
-  """
+  """Name for one object of this post type."""
   singularName: String
 
-  """
-  Label for the media frame filter.
-  """
+  """Label for the media frame filter."""
   uploadedToThisItem: String
 
-  """
-  Label in the media frame for using a featured image.
-  """
+  """Label in the media frame for using a featured image."""
   useFeaturedImage: String
 
-  """
-  Label for viewing a singular item.
-  """
+  """Label for viewing a singular item."""
   viewItem: String
 
-  """
-  Label for viewing post type archives.
-  """
+  """Label for viewing post type archives."""
   viewItems: String
 }
 
-"""
-The root entry point into the Graph
-"""
+"""The root entry point into the Graph"""
 type Query
   @join__type(graph: CMS)
   @join__type(graph: EVENTS)
   @join__type(graph: UNIFIED_SEARCH)
-  @join__type(graph: VENUES) {
-  """
-  Entry point to get all settings for the site
-  """
+  @join__type(graph: VENUES)
+{
+  """Entry point to get all settings for the site"""
   allSettings: Settings @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the category type
-  """
+  """Connection between the RootQuery type and the category type"""
   categories(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -13870,88 +10387,54 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToCategoryConnectionWhereArgs
   ): RootQueryToCategoryConnection @join__field(graph: CMS)
 
-  """
-  A 0bject
-  """
+  """A 0bject"""
   category(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: CategoryIdType
   ): Category @join__field(graph: CMS)
 
-  """
-  An object of the collection Type. Collections
-  """
+  """An object of the collection Type. Collections"""
   collection(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: CollectionIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): Collection @join__field(graph: CMS)
 
-  """
-  A collection object
-  """
+  """A collection object"""
   collectionBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the collection by its database ID
-    """
+    """Get the collection by its database ID"""
     collectionId: Int
 
-    """
-    Get the collection by its uri
-    """
+    """Get the collection by its uri"""
     uri: String
 
     """
     Get the collection by its slug (only available for non-hierarchical types)
     """
     slug: String
-  ): Collection
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Collection @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  Connection between the RootQuery type and the collection type
-  """
+  """Connection between the RootQuery type and the collection type"""
   collections(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -13964,34 +10447,22 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToCollectionConnectionWhereArgs
   ): RootQueryToCollectionConnection @join__field(graph: CMS)
 
-  """
-  Returns a Comment
-  """
+  """Returns a Comment"""
   comment(
-    """
-    Unique identifier for the comment node.
-    """
+    """Unique identifier for the comment node."""
     id: ID!
   ): Comment @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the Comment type
-  """
+  """Connection between the RootQuery type and the Comment type"""
   comments(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14004,73 +10475,45 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToCommentConnectionWhereArgs
   ): RootQueryToCommentConnection @join__field(graph: CMS)
 
-  """
-  An object of the contact Type. Contacts
-  """
+  """An object of the contact Type. Contacts"""
   contact(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: ContactIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): Contact @join__field(graph: CMS)
 
-  """
-  A contact object
-  """
+  """A contact object"""
   contactBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the contact by its database ID
-    """
+    """Get the contact by its database ID"""
     contactId: Int
 
-    """
-    Get the contact by its uri
-    """
+    """Get the contact by its uri"""
     uri: String
 
     """
     Get the contact by its slug (only available for non-hierarchical types)
     """
     slug: String
-  ): Contact
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Contact @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  Connection between the RootQuery type and the contact type
-  """
+  """Connection between the RootQuery type and the contact type"""
   contacts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14083,19 +10526,13 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToContactConnectionWhereArgs
   ): RootQueryToContactConnection @join__field(graph: CMS)
 
-  """
-  A node used to manage content
-  """
+  """A node used to manage content"""
   contentNode(
-    """
-    Unique identifier for the content node.
-    """
+    """Unique identifier for the content node."""
     id: ID!
 
     """
@@ -14108,24 +10545,16 @@ type Query
     """
     contentType: ContentTypeEnum
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): ContentNode @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the ContentNode type
-  """
+  """Connection between the RootQuery type and the ContentNode type"""
   contentNodes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14138,19 +10567,13 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToContentNodeConnectionWhereArgs
   ): RootQueryToContentNodeConnection @join__field(graph: CMS)
 
-  """
-  Fetch a Content Type node by unique Identifier
-  """
+  """Fetch a Content Type node by unique Identifier"""
   contentType(
-    """
-    Unique Identifier for the Content Type node.
-    """
+    """Unique Identifier for the Content Type node."""
     id: ID!
 
     """
@@ -14159,18 +10582,12 @@ type Query
     idType: ContentTypeIdTypeEnum
   ): ContentType @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the ContentType type
-  """
+  """Connection between the RootQuery type and the ContentType type"""
   contentTypes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14184,87 +10601,53 @@ type Query
     before: String
   ): RootQueryToContentTypeConnection @join__field(graph: CMS)
 
-  """
-  Default Images
-  """
+  """Default Images"""
   defaultImages(language: String!): DefaultImages @join__field(graph: CMS)
 
-  """
-  Get language list
-  """
+  """Get language list"""
   defaultLanguage: Language @join__field(graph: CMS)
 
-  """
-  Fields of the &#039;DiscussionSettings&#039; settings group
-  """
+  """Fields of the &#039;DiscussionSettings&#039; settings group"""
   discussionSettings: DiscussionSettings @join__field(graph: CMS)
 
-  """
-  Fields of the &#039;GeneralSettings&#039; settings group
-  """
+  """Fields of the &#039;GeneralSettings&#039; settings group"""
   generalSettings: GeneralSettings @join__field(graph: CMS)
 
-  """
-  An object of the landingPage Type. Landing Pages
-  """
+  """An object of the landingPage Type. Landing Pages"""
   landingPage(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: LandingPageIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): LandingPage @join__field(graph: CMS)
 
-  """
-  A landingPage object
-  """
+  """A landingPage object"""
   landingPageBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the landingPage by its database ID
-    """
+    """Get the landingPage by its database ID"""
     landingPageId: Int
 
-    """
-    Get the landingPage by its uri
-    """
+    """Get the landingPage by its uri"""
     uri: String
 
     """
     Get the landingPage by its slug (only available for non-hierarchical types)
     """
     slug: String
-  ): LandingPage
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): LandingPage @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  Connection between the RootQuery type and the landingPage type
-  """
+  """Connection between the RootQuery type and the landingPage type"""
   landingPages(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14277,78 +10660,48 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToLandingPageConnectionWhereArgs
   ): RootQueryToLandingPageConnection @join__field(graph: CMS)
 
-  """
-  List available languages
-  """
+  """List available languages"""
   languages: [Language] @join__field(graph: CMS)
 
-  """
-  An object of the mediaItem Type.
-  """
+  """An object of the mediaItem Type. """
   mediaItem(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: MediaItemIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): MediaItem @join__field(graph: CMS)
 
-  """
-  A mediaItem object
-  """
+  """A mediaItem object"""
   mediaItemBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the mediaItem by its database ID
-    """
+    """Get the mediaItem by its database ID"""
     mediaItemId: Int
 
-    """
-    Get the mediaItem by its uri
-    """
+    """Get the mediaItem by its uri"""
     uri: String
 
     """
     Get the mediaItem by its slug (only available for non-hierarchical types)
     """
     slug: String
-  ): MediaItem
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): MediaItem @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  Connection between the RootQuery type and the mediaItem type
-  """
+  """Connection between the RootQuery type and the mediaItem type"""
   mediaItems(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14361,34 +10714,22 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToMediaItemConnectionWhereArgs
   ): RootQueryToMediaItemConnection @join__field(graph: CMS)
 
-  """
-  A WordPress navigation menu
-  """
+  """A WordPress navigation menu"""
   menu(
-    """
-    The globally unique identifier of the menu.
-    """
+    """The globally unique identifier of the menu."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch a menu by. Default is Global ID
-    """
+    """Type of unique identifier to fetch a menu by. Default is Global ID"""
     idType: MenuNodeIdTypeEnum
   ): Menu @join__field(graph: CMS)
 
-  """
-  A WordPress navigation menu item
-  """
+  """A WordPress navigation menu item"""
   menuItem(
-    """
-    The globally unique identifier of the menu item.
-    """
+    """The globally unique identifier of the menu item."""
     id: ID!
 
     """
@@ -14397,18 +10738,12 @@ type Query
     idType: MenuItemNodeIdTypeEnum
   ): MenuItem @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the MenuItem type
-  """
+  """Connection between the RootQuery type and the MenuItem type"""
   menuItems(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14421,24 +10756,16 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToMenuItemConnectionWhereArgs
   ): RootQueryToMenuItemConnection @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the Menu type
-  """
+  """Connection between the RootQuery type and the Menu type"""
   menus(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14451,25 +10778,17 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToMenuConnectionWhereArgs
   ): RootQueryToMenuConnection @join__field(graph: CMS)
 
-  """
-  Fetches an object given its ID
-  """
+  """Fetches an object given its ID"""
   node(
-    """
-    The unique identifier of the node
-    """
+    """The unique identifier of the node"""
     id: ID
   ): Node @join__field(graph: CMS)
 
-  """
-  Fetches an object given its Unique Resource Identifier
-  """
+  """Fetches an object given its Unique Resource Identifier"""
   nodeByUri(
     """
     Unique Resource Identifier in the form of a path or permalink for a node. Ex: "/hello-world"
@@ -14477,72 +10796,42 @@ type Query
     uri: String!
   ): UniformResourceIdentifiable @join__field(graph: CMS)
 
-  """
-  """
+  """"""
   notification(language: String!): Notification @join__field(graph: CMS)
 
-  """
-  An object of the page Type.
-  """
+  """An object of the page Type. """
   page(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: PageIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): Page @join__field(graph: CMS)
 
-  """
-  A page object
-  """
+  """A page object"""
   pageBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the page by its database ID
-    """
+    """Get the page by its database ID"""
     pageId: Int
 
-    """
-    Get the page by its uri
-    """
+    """Get the page by its uri"""
     uri: String
-  ): Page
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Page @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  Returns ID of page that uses the given template
-  """
-  pageByTemplate(language: String, template: TemplateEnum): Page
-    @join__field(graph: CMS)
+  """Returns ID of page that uses the given template"""
+  pageByTemplate(language: String, template: TemplateEnum): Page @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the page type
-  """
+  """Connection between the RootQuery type and the page type"""
   pages(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14555,34 +10844,22 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToPageConnectionWhereArgs
   ): RootQueryToPageConnection @join__field(graph: CMS)
 
-  """
-  A WordPress plugin
-  """
+  """A WordPress plugin"""
   plugin(
-    """
-    The globally unique identifier of the plugin.
-    """
+    """The globally unique identifier of the plugin."""
     id: ID!
   ): Plugin @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the Plugin type
-  """
+  """Connection between the RootQuery type and the Plugin type"""
   plugins(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14595,88 +10872,52 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToPluginConnectionWhereArgs
   ): RootQueryToPluginConnection @join__field(graph: CMS)
 
-  """
-  An object of the post Type.
-  """
+  """An object of the post Type. """
   post(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: PostIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): Post @join__field(graph: CMS)
 
-  """
-  A post object
-  """
+  """A post object"""
   postBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the post by its database ID
-    """
+    """Get the post by its database ID"""
     postId: Int
 
-    """
-    Get the post by its uri
-    """
+    """Get the post by its uri"""
     uri: String
 
-    """
-    Get the post by its slug (only available for non-hierarchical types)
-    """
+    """Get the post by its slug (only available for non-hierarchical types)"""
     slug: String
-  ): Post
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Post @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  A 0bject
-  """
+  """A 0bject"""
   postFormat(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: PostFormatIdType
   ): PostFormat @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the postFormat type
-  """
+  """Connection between the RootQuery type and the postFormat type"""
   postFormats(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14689,24 +10930,16 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToPostFormatConnectionWhereArgs
   ): RootQueryToPostFormatConnection @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the post type
-  """
+  """Connection between the RootQuery type and the post type"""
   posts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14719,29 +10952,19 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToPostConnectionWhereArgs
   ): RootQueryToPostConnection @join__field(graph: CMS)
 
-  """
-  Fields of the &#039;ReadingSettings&#039; settings group
-  """
+  """Fields of the &#039;ReadingSettings&#039; settings group"""
   readingSettings: ReadingSettings @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the EnqueuedScript type
-  """
+  """Connection between the RootQuery type and the EnqueuedScript type"""
   registeredScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14755,18 +10978,12 @@ type Query
     before: String
   ): RootQueryToEnqueuedScriptConnection @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the EnqueuedStylesheet type
-  """
+  """Connection between the RootQuery type and the EnqueuedStylesheet type"""
   registeredStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14780,67 +10997,41 @@ type Query
     before: String
   ): RootQueryToEnqueuedStylesheetConnection @join__field(graph: CMS)
 
-  """
-  An object of the release Type. Releases
-  """
+  """An object of the release Type. Releases"""
   release(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: ReleaseIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): Release @join__field(graph: CMS)
 
-  """
-  A release object
-  """
+  """A release object"""
   releaseBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the release by its database ID
-    """
+    """Get the release by its database ID"""
     releaseId: Int
 
-    """
-    Get the release by its uri
-    """
+    """Get the release by its uri"""
     uri: String
 
     """
     Get the release by its slug (only available for non-hierarchical types)
     """
     slug: String
-  ): Release
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Release @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  Connection between the RootQuery type and the release type
-  """
+  """Connection between the RootQuery type and the release type"""
   releases(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14853,9 +11044,7 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToReleaseConnectionWhereArgs
   ): RootQueryToReleaseConnection @join__field(graph: CMS)
 
@@ -14863,14 +11052,10 @@ type Query
   Connection between the RootQuery type and the ContentRevisionUnion type
   """
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14883,49 +11068,31 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToContentRevisionUnionConnectionWhereArgs
   ): RootQueryToContentRevisionUnionConnection @join__field(graph: CMS)
 
-  """
-  The SEO Framework settings
-  """
+  """The SEO Framework settings"""
   seoSettings: SeoSettings @join__field(graph: CMS)
 
-  """
-  Site Settings
-  """
+  """Site Settings"""
   siteSettings(language: String!): SiteSettings @join__field(graph: CMS)
 
-  """
-  A 0bject
-  """
+  """A 0bject"""
   tag(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: TagIdType
   ): Tag @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the tag type
-  """
+  """Connection between the RootQuery type and the tag type"""
   tags(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14938,24 +11105,16 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToTagConnectionWhereArgs
   ): RootQueryToTagConnection @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the Taxonomy type
-  """
+  """Connection between the RootQuery type and the Taxonomy type"""
   taxonomies(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -14969,28 +11128,18 @@ type Query
     before: String
   ): RootQueryToTaxonomyConnection @join__field(graph: CMS)
 
-  """
-  Fetch a Taxonomy node by unique Identifier
-  """
+  """Fetch a Taxonomy node by unique Identifier"""
   taxonomy(
-    """
-    Unique Identifier for the Taxonomy node.
-    """
+    """Unique Identifier for the Taxonomy node."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch a taxonomy by. Default is Global ID
-    """
+    """Type of unique identifier to fetch a taxonomy by. Default is Global ID"""
     idType: TaxonomyIdTypeEnum
   ): Taxonomy @join__field(graph: CMS)
 
-  """
-  A node in a taxonomy used to group and relate content nodes
-  """
+  """A node in a taxonomy used to group and relate content nodes"""
   termNode(
-    """
-    Unique identifier for the term node.
-    """
+    """Unique identifier for the term node."""
     id: ID!
 
     """
@@ -15004,18 +11153,12 @@ type Query
     taxonomy: TaxonomyEnum
   ): TermNode @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the TermNode type
-  """
+  """Connection between the RootQuery type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15028,34 +11171,22 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToTermNodeConnectionWhereArgs
   ): RootQueryToTermNodeConnection @join__field(graph: CMS)
 
-  """
-  A Theme object
-  """
+  """A Theme object"""
   theme(
-    """
-    The globally unique identifier of the theme.
-    """
+    """The globally unique identifier of the theme."""
     id: ID!
   ): Theme @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the Theme type
-  """
+  """Connection between the RootQuery type and the Theme type"""
   themes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15069,73 +11200,44 @@ type Query
     before: String
   ): RootQueryToThemeConnection @join__field(graph: CMS)
 
-  """
-  Translate string using pll_translate_string() (Polylang)
-  """
-  translateString(string: String!, language: LanguageCodeEnum!): String
-    @join__field(graph: CMS)
+  """Translate string using pll_translate_string() (Polylang)"""
+  translateString(string: String!, language: LanguageCodeEnum!): String @join__field(graph: CMS)
 
-  """
-  An object of the translation Type. Translations
-  """
+  """An object of the translation Type. Translations"""
   translation(
-    """
-    The globally unique identifier of the object.
-    """
+    """The globally unique identifier of the object."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch by. Default is Global ID
-    """
+    """Type of unique identifier to fetch by. Default is Global ID"""
     idType: TranslationIdType
 
-    """
-    Whether to return the node as a preview instance
-    """
+    """Whether to return the node as a preview instance"""
     asPreview: Boolean
   ): Translation @join__field(graph: CMS)
 
-  """
-  A translation object
-  """
+  """A translation object"""
   translationBy(
-    """
-    Get the object by its global ID
-    """
+    """Get the object by its global ID"""
     id: ID
 
-    """
-    Get the translation by its database ID
-    """
+    """Get the translation by its database ID"""
     translationId: Int
 
-    """
-    Get the translation by its uri
-    """
+    """Get the translation by its uri"""
     uri: String
 
     """
     Get the translation by its slug (only available for non-hierarchical types)
     """
     slug: String
-  ): Translation
-    @join__field(graph: CMS)
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Translation @join__field(graph: CMS) @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
 
-  """
-  Connection between the RootQuery type and the translation type
-  """
+  """Connection between the RootQuery type and the translation type"""
   translations(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15148,49 +11250,31 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToTranslationConnectionWhereArgs
   ): RootQueryToTranslationConnection @join__field(graph: CMS)
 
-  """
-  Returns a user
-  """
+  """Returns a user"""
   user(
-    """
-    The globally unique identifier of the user.
-    """
+    """The globally unique identifier of the user."""
     id: ID!
 
-    """
-    Type of unique identifier to fetch a user by. Default is Global ID
-    """
+    """Type of unique identifier to fetch a user by. Default is Global ID"""
     idType: UserNodeIdTypeEnum
   ): User @join__field(graph: CMS)
 
-  """
-  Returns a user role
-  """
+  """Returns a user role"""
   userRole(
-    """
-    The globally unique identifier of the user object.
-    """
+    """The globally unique identifier of the user object."""
     id: ID!
   ): UserRole @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the UserRole type
-  """
+  """Connection between the RootQuery type and the UserRole type"""
   userRoles(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15204,18 +11288,12 @@ type Query
     before: String
   ): RootQueryToUserRoleConnection @join__field(graph: CMS)
 
-  """
-  Connection between the RootQuery type and the User type
-  """
+  """Connection between the RootQuery type and the User type"""
   users(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15228,113 +11306,30 @@ type Query
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: RootQueryToUserConnectionWhereArgs
   ): RootQueryToUserConnection @join__field(graph: CMS)
 
-  """
-  Returns the current user
-  """
+  """Returns the current user"""
   viewer: User @join__field(graph: CMS)
 
-  """
-  Fields of the &#039;WritingSettings&#039; settings group
-  """
+  """Fields of the &#039;WritingSettings&#039; settings group"""
   writingSettings: WritingSettings @join__field(graph: CMS)
   _empty: String @join__field(graph: EVENTS)
-  eventDetails(id: ID, include: [String]): EventDetails!
-    @join__field(graph: EVENTS)
-  eventsByIds(
-    eventType: [EventTypeId] = [General]
-    ids: [ID!]!
-    include: [String]
-    sort: String
-    pageSize: Int
-    page: Int
-    start: String
-    end: String
-  ): EventListResponse! @join__field(graph: EVENTS)
-  eventList(
-    eventType: [EventTypeId] = [General]
-    internetBased: Boolean
-    localOngoingAnd: [String]
-    localOngoingOr: [String]
-    localOngoingOrSet1: [String]
-    localOngoingOrSet2: [String]
-    localOngoingOrSet3: [String]
-    internetOngoingAnd: [String]
-    internetOngoingOr: [String]
-    allOngoing: Boolean
-    allOngoingAnd: [String]
-    allOngoingOr: [String]
-    combinedText: [String]
-    division: [String]
-    end: String
-    endsAfter: String
-    endsBefore: String
-    ids: [String]
-    inLanguage: String
-    include: [String]
-    isFree: Boolean
-    keywordAnd: [String]
-    keywordOrSet1: [String]
-    keywordOrSet2: [String]
-    keywordOrSet3: [String]
-    keywordNot: [String]
-    keyword: [String]
-    language: String
-    location: [String]
-    page: Int
-    pageSize: Int
-    publisher: ID
-    sort: String
-    start: String
-    startsAfter: String
-    startsBefore: String
-    superEvent: ID
-    superEventType: [String]
-    text: String
-    translation: String
-    suitableFor: [Int]
-    audienceMinAgeGt: String
-    audienceMinAgeLt: String
-    audienceMaxAgeGt: String
-    audienceMaxAgeLt: String
-  ): EventListResponse! @join__field(graph: EVENTS)
+  eventDetails(id: ID, include: [String]): EventDetails! @join__field(graph: EVENTS)
+  eventsByIds(eventType: [EventTypeId] = [General], ids: [ID!]!, include: [String], sort: String, pageSize: Int, page: Int, start: String, end: String): EventListResponse! @join__field(graph: EVENTS)
+  eventList(eventType: [EventTypeId] = [General], internetBased: Boolean, localOngoingAnd: [String], localOngoingOr: [String], localOngoingOrSet1: [String], localOngoingOrSet2: [String], localOngoingOrSet3: [String], internetOngoingAnd: [String], internetOngoingOr: [String], allOngoing: Boolean, allOngoingAnd: [String], allOngoingOr: [String], combinedText: [String], division: [String], end: String, endsAfter: String, endsBefore: String, ids: [String], inLanguage: String, include: [String], isFree: Boolean, keywordAnd: [String], keywordOrSet1: [String], keywordOrSet2: [String], keywordOrSet3: [String], keywordNot: [String], keyword: [String], language: String, location: [String], page: Int, pageSize: Int, publisher: ID, sort: String, start: String, startsAfter: String, startsBefore: String, superEvent: ID, superEventType: [String], text: String, translation: String, suitableFor: [Int], audienceMinAgeGt: String, audienceMinAgeLt: String, audienceMaxAgeGt: String, audienceMaxAgeLt: String): EventListResponse! @join__field(graph: EVENTS)
   keywordDetails(id: ID!): Keyword! @join__field(graph: EVENTS)
-  keywordList(
-    dataSource: String
-    hasUpcomingEvents: Boolean
-    page: Int
-    pageSize: Int
-    showAllKeywords: Boolean
-    sort: String
-    text: String
-  ): KeywordListResponse! @join__field(graph: EVENTS)
+  keywordList(dataSource: String, hasUpcomingEvents: Boolean, page: Int, pageSize: Int, showAllKeywords: Boolean, sort: String, text: String): KeywordListResponse! @join__field(graph: EVENTS)
   neighborhoodList: NeighborhoodListResponse! @join__field(graph: EVENTS)
   organizationDetails(id: ID!): OrganizationDetails! @join__field(graph: EVENTS)
   placeDetails(id: ID!): Place! @join__field(graph: EVENTS)
-  placeList(
-    dataSource: String
-    divisions: [String]
-    hasUpcomingEvents: Boolean
-    page: Int
-    pageSize: Int
-    showAllPlaces: Boolean
-    sort: String
-    text: String
-  ): PlaceListResponse! @join__field(graph: EVENTS)
+  placeList(dataSource: String, divisions: [String], hasUpcomingEvents: Boolean, page: Int, pageSize: Int, showAllPlaces: Boolean, sort: String, text: String): PlaceListResponse! @join__field(graph: EVENTS)
   unifiedSearch(
-    """
-    Free form query string, corresponding to user search input
-    """
+    """Free form query string, corresponding to user search input"""
     q: String
 
-    """
-    Optional, filter to match only these ontology words
-    """
+    """Optional, filter to match only these ontology words"""
     ontology: String
 
     """
@@ -15342,9 +11337,7 @@ type Query
     """
     administrativeDivisionId: ID
 
-    """
-    Optional, filter to match only these administrative divisions
-    """
+    """Optional, filter to match only these administrative divisions"""
     administrativeDivisionIds: [ID]
 
     """
@@ -15352,48 +11345,36 @@ type Query
     """
     ontologyTreeId: ID
 
-    """
-    Optional, filter to match only these ontology tree ids
-    """
+    """Optional, filter to match only these ontology tree ids"""
     ontologyTreeIds: [ID]
 
-    """
-    Optional, filter to match only these ontology word ids
-    """
+    """Optional, filter to match only these ontology word ids"""
     ontologyWordIds: [ID]
 
-    """
-    Optional search index.
-    """
+    """Optional search index."""
     index: String
 
-    """
-    Optional pagination variable, match results after this cursor.
-    """
+    """Optional pagination variable, match results after this cursor."""
     after: String
 
-    """
-    Optional pagination variable, limit the amount of results to N.
-    """
+    """Optional pagination variable, limit the amount of results to N."""
     first: Int
 
     """
     NOTE: Unsupported
-
+    
     Optional pagination variable, match results before this cursor.
     """
     before: String
 
     """
     NOTE: Unsupported
-
+    
     Optional pagination variable, match the N last results.
     """
     last: Int
 
-    """
-    Targets the search to fields of specified language
-    """
+    """Targets the search to fields of specified language"""
     languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
 
     """
@@ -15420,19 +11401,13 @@ type Query
     """
     prefix: String
 
-    """
-    Limits the result set into the specified languages
-    """
+    """Limits the result set into the specified languages"""
     languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
 
-    """
-    Optional search index.
-    """
+    """Optional search index."""
     index: String
 
-    """
-    Optional result size.
-    """
+    """Optional result size."""
     size: Int = 5
   ): SearchSuggestionConnection @join__field(graph: UNIFIED_SEARCH)
   administrativeDivisions(
@@ -15441,34 +11416,31 @@ type Query
     """
     helsinkiCommonOnly: Boolean
   ): [AdministrativeDivision] @join__field(graph: UNIFIED_SEARCH)
-  ontologyTree(rootId: ID, leavesOnly: Boolean): [OntologyTree]
-    @join__field(graph: UNIFIED_SEARCH)
+  ontologyTree(rootId: ID, leavesOnly: Boolean): [OntologyTree] @join__field(graph: UNIFIED_SEARCH)
   ontologyWords(ids: [ID!]): [OntologyWord] @join__field(graph: UNIFIED_SEARCH)
   venue(id: ID!): Venue! @join__field(graph: VENUES)
   venuesByIds(ids: [ID!]): [Venue!]! @join__field(graph: VENUES)
 }
 
-type RawJSON @join__type(graph: UNIFIED_SEARCH) {
+type RawJSON
+  @join__type(graph: UNIFIED_SEARCH)
+{
   data: String
 }
 
-"""
-The reading setting type
-"""
-type ReadingSettings @join__type(graph: CMS) {
-  """
-  Näytä enintään
-  """
+"""The reading setting type"""
+type ReadingSettings
+  @join__type(graph: CMS)
+{
+  """Näytä enintään"""
   postsPerPage: Int
 }
 
-"""
-Input for the registerUser mutation
-"""
-input RegisterUserInput @join__type(graph: CMS) {
-  """
-  User's AOL IM account.
-  """
+"""Input for the registerUser mutation"""
+input RegisterUserInput
+  @join__type(graph: CMS)
+{
+  """User's AOL IM account."""
   aim: String
 
   """
@@ -15476,9 +11448,7 @@ input RegisterUserInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  A string containing content about the user.
-  """
+  """A string containing content about the user."""
   description: String
 
   """
@@ -15486,29 +11456,19 @@ input RegisterUserInput @join__type(graph: CMS) {
   """
   displayName: String
 
-  """
-  A string containing the user's email address.
-  """
+  """A string containing the user's email address."""
   email: String
 
-  """
-  The user's first name.
-  """
+  """	The user's first name."""
   firstName: String
 
-  """
-  User's Jabber account.
-  """
+  """User's Jabber account."""
   jabber: String
 
-  """
-  The user's last name.
-  """
+  """The user's last name."""
   lastName: String
 
-  """
-  User's locale.
-  """
+  """User's locale."""
   locale: String
 
   """
@@ -15516,19 +11476,13 @@ input RegisterUserInput @join__type(graph: CMS) {
   """
   nicename: String
 
-  """
-  The user's nickname, defaults to the user's username.
-  """
+  """The user's nickname, defaults to the user's username."""
   nickname: String
 
-  """
-  A string that contains the plain text password for the user.
-  """
+  """A string that contains the plain text password for the user."""
   password: String
 
-  """
-  The date the user registered. Format is Y-m-d H:i:s.
-  """
+  """The date the user registered. Format is Y-m-d H:i:s."""
   registered: String
 
   """
@@ -15536,41 +11490,35 @@ input RegisterUserInput @join__type(graph: CMS) {
   """
   richEditing: String
 
-  """
-  A string that contains the user's username.
-  """
+  """A string that contains the user's username."""
   username: String!
 
-  """
-  A string containing the user's URL for the user's web site.
-  """
+  """A string containing the user's URL for the user's web site."""
   websiteUrl: String
 
-  """
-  User's Yahoo IM account.
-  """
+  """User's Yahoo IM account."""
   yim: String
 }
 
-"""
-The payload for the registerUser mutation
-"""
-type RegisterUserPayload @join__type(graph: CMS) {
+"""The payload for the registerUser mutation"""
+type RegisterUserPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The User object mutation type.
-  """
+  """The User object mutation type."""
   user: User
 }
 
 """
 The logical relation between each item in the array when there are more than one.
 """
-enum RelationEnum @join__type(graph: CMS) {
+enum RelationEnum
+  @join__type(graph: CMS)
+{
   """
   The logical AND condition returns true if both operands are true, otherwise, it returns false.
   """
@@ -15582,9 +11530,7 @@ enum RelationEnum @join__type(graph: CMS) {
   OR
 }
 
-"""
-The release type
-"""
+"""The release type"""
 type Release implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithContentEditor & NodeWithRevisions
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -15594,45 +11540,30 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   @join__implements(graph: CMS, interface: "NodeWithTitle")
   @join__implements(graph: CMS, interface: "NodeWithContentEditor")
   @join__implements(graph: CMS, interface: "NodeWithRevisions")
-  @join__type(graph: CMS) {
-  """
-  The content of the post.
-  """
+  @join__type(graph: CMS)
+{
+  """The content of the post."""
   content(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -15640,23 +11571,15 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15674,14 +11597,10 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15695,9 +11614,7 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
     before: String
   ): ContentNodeToEnqueuedStylesheetConnection
 
-  """
-  Vanhentumisaika
-  """
+  """Vanhentumisaika"""
   expirationTime: String
 
   """
@@ -15705,49 +11622,31 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   guid: String
 
-  """
-  The globally unique identifier of the release-cpt object.
-  """
+  """The globally unique identifier of the release-cpt object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  True if the node is a revision of another node
-  """
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  Polylang language
-  """
+  """Polylang language"""
   language: Language
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -15760,44 +11659,29 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   modifiedGmt: String
 
-  """
-  Connection between the release type and the release type
-  """
+  """Connection between the release type and the release type"""
   preview: ReleaseToPreviewConnectionEdge
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  releaseId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """The id field matches the WP_Post-&gt;ID field."""
+  releaseId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
   """
   If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.
   """
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 
-  """
-  Connection between the release type and the release type
-  """
+  """Connection between the release type and the release type"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15810,15 +11694,11 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: ReleaseToRevisionConnectionWhereArgs
   ): ReleaseToRevisionConnection
 
-  """
-  The SEO Framework data of the release
-  """
+  """The SEO Framework data of the release"""
   seo: SEO
 
   """
@@ -15826,28 +11706,18 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to the node
-  """
+  """The template assigned to the node"""
   template: ContentTemplate
 
-  """
-  Connection between the release type and the TermNode type
-  """
+  """Connection between the release type and the TermNode type"""
   terms(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -15860,9 +11730,7 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: ReleaseToTermNodeConnectionWhereArgs
   ): ReleaseToTermNodeConnection
 
@@ -15870,40 +11738,28 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): Release
 
-  """
-  List all translated versions of this post
-  """
+  """List all translated versions of this post"""
   translations: [Release]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum ReleaseIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum ReleaseIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
   """
@@ -15911,64 +11767,48 @@ enum ReleaseIdType @join__type(graph: CMS) {
   """
   SLUG
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-"""
-Connection between the release type and the release type
-"""
-type ReleaseToPreviewConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the release type and the release type"""
+type ReleaseToPreviewConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Release
 }
 
-"""
-Connection between the release type and the release type
-"""
-type ReleaseToRevisionConnection @join__type(graph: CMS) {
-  """
-  Edges for the releaseToRevisionConnection connection
-  """
+"""Connection between the release type and the release type"""
+type ReleaseToRevisionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the releaseToRevisionConnection connection"""
   edges: [ReleaseToRevisionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Release]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ReleaseToRevisionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ReleaseToRevisionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Release
 }
 
-"""
-Arguments for filtering the releaseToRevisionConnection connection
-"""
-input ReleaseToRevisionConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the releaseToRevisionConnection connection"""
+input ReleaseToRevisionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -15976,29 +11816,19 @@ input ReleaseToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -16006,91 +11836,63 @@ input ReleaseToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the release type and the TermNode type
-"""
-type ReleaseToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the ReleaseToTermNodeConnection connection
-  """
+"""Connection between the release type and the TermNode type"""
+type ReleaseToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the ReleaseToTermNodeConnection connection"""
   edges: [ReleaseToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type ReleaseToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type ReleaseToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the ReleaseToTermNodeConnection connection
-"""
-input ReleaseToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the ReleaseToTermNodeConnection connection"""
+input ReleaseToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -16131,19 +11933,13 @@ input ReleaseToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -16151,14 +11947,10 @@ input ReleaseToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -16166,9 +11958,7 @@ input ReleaseToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -16176,68 +11966,54 @@ input ReleaseToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Input for the resetUserPassword mutation
-"""
-input ResetUserPasswordInput @join__type(graph: CMS) {
+"""Input for the resetUserPassword mutation"""
+input ResetUserPasswordInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  Password reset key
-  """
+  """Password reset key"""
   key: String
 
-  """
-  The user's login (username).
-  """
+  """The user's login (username)."""
   login: String
 
-  """
-  The new password.
-  """
+  """The new password."""
   password: String
 }
 
-"""
-The payload for the resetUserPassword mutation
-"""
-type ResetUserPasswordPayload @join__type(graph: CMS) {
+"""The payload for the resetUserPassword mutation"""
+type ResetUserPasswordPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The User object mutation type.
-  """
+  """The User object mutation type."""
   user: User
 }
 
-enum ResourceState @join__type(graph: VENUES) {
+enum ResourceState
+  @join__type(graph: VENUES)
+{
   open
   closed
   undefined
@@ -16251,80 +12027,64 @@ enum ResourceState @join__type(graph: VENUES) {
   weather_permitting
 }
 
-"""
-Input for the restoreComment mutation
-"""
-input RestoreCommentInput @join__type(graph: CMS) {
+"""Input for the restoreComment mutation"""
+input RestoreCommentInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The ID of the comment to be restored
-  """
+  """The ID of the comment to be restored"""
   id: ID!
 }
 
-"""
-The payload for the restoreComment mutation
-"""
-type RestoreCommentPayload @join__type(graph: CMS) {
+"""The payload for the restoreComment mutation"""
+type RestoreCommentPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The restored comment object
-  """
+  """The restored comment object"""
   comment: Comment
 
-  """
-  The ID of the restored comment
-  """
+  """The ID of the restored comment"""
   restoredId: ID
 }
 
-"""
-Connection between the RootQuery type and the category type
-"""
-type RootQueryToCategoryConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToCategoryConnection connection
-  """
+"""Connection between the RootQuery type and the category type"""
+type RootQueryToCategoryConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToCategoryConnection connection"""
   edges: [RootQueryToCategoryConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Category]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToCategoryConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToCategoryConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Category
 }
 
-"""
-Arguments for filtering the RootQueryToCategoryConnection connection
-"""
-input RootQueryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the RootQueryToCategoryConnection connection"""
+input RootQueryToCategoryConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -16365,24 +12125,16 @@ input RootQueryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Filter by Categorys by language code (Polylang)
-  """
+  """Filter by Categorys by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -16390,14 +12142,10 @@ input RootQueryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -16405,9 +12153,7 @@ input RootQueryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -16415,64 +12161,46 @@ input RootQueryToCategoryConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the RootQuery type and the collection type
-"""
-type RootQueryToCollectionConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToCollectionConnection connection
-  """
+"""Connection between the RootQuery type and the collection type"""
+type RootQueryToCollectionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToCollectionConnection connection"""
   edges: [RootQueryToCollectionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Collection]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToCollectionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToCollectionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Collection
 }
 
-"""
-Arguments for filtering the RootQueryToCollectionConnection connection
-"""
-input RootQueryToCollectionConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the RootQueryToCollectionConnection connection"""
+input RootQueryToCollectionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -16480,34 +12208,22 @@ input RootQueryToCollectionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter by Collections by language code (Polylang)
-  """
+  """Filter by Collections by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -16515,114 +12231,76 @@ input RootQueryToCollectionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the Comment type
-"""
-type RootQueryToCommentConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToCommentConnection connection
-  """
+"""Connection between the RootQuery type and the Comment type"""
+type RootQueryToCommentConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToCommentConnection connection"""
   edges: [RootQueryToCommentConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Comment]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToCommentConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToCommentConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Comment
 }
 
-"""
-Arguments for filtering the RootQueryToCommentConnection connection
-"""
-input RootQueryToCommentConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Comment author email address.
-  """
+"""Arguments for filtering the RootQueryToCommentConnection connection"""
+input RootQueryToCommentConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Comment author email address."""
   authorEmail: String
 
-  """
-  Array of author IDs to include comments for.
-  """
+  """Array of author IDs to include comments for."""
   authorIn: [ID]
 
-  """
-  Array of author IDs to exclude comments for.
-  """
+  """Array of author IDs to exclude comments for."""
   authorNotIn: [ID]
 
-  """
-  Comment author URL.
-  """
+  """Comment author URL."""
   authorUrl: String
 
-  """
-  Array of comment IDs to include.
-  """
+  """Array of comment IDs to include."""
   commentIn: [ID]
 
   """
@@ -16630,59 +12308,37 @@ input RootQueryToCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   commentNotIn: [ID]
 
-  """
-  Include comments of a given type.
-  """
+  """Include comments of a given type."""
   commentType: String
 
-  """
-  Include comments from a given array of comment types.
-  """
+  """Include comments from a given array of comment types."""
   commentTypeIn: [String]
 
-  """
-  Exclude comments from a given array of comment types.
-  """
+  """Exclude comments from a given array of comment types."""
   commentTypeNotIn: String
 
-  """
-  Content object author ID to limit results by.
-  """
+  """Content object author ID to limit results by."""
   contentAuthor: [ID]
 
-  """
-  Array of author IDs to retrieve comments for.
-  """
+  """Array of author IDs to retrieve comments for."""
   contentAuthorIn: [ID]
 
-  """
-  Array of author IDs *not* to retrieve comments for.
-  """
+  """Array of author IDs *not* to retrieve comments for."""
   contentAuthorNotIn: [ID]
 
-  """
-  Limit results to those affiliated with a given content object ID.
-  """
+  """Limit results to those affiliated with a given content object ID."""
   contentId: ID
 
-  """
-  Array of content object IDs to include affiliated comments for.
-  """
+  """Array of content object IDs to include affiliated comments for."""
   contentIdIn: [ID]
 
-  """
-  Array of content object IDs to exclude affiliated comments for.
-  """
+  """Array of content object IDs to exclude affiliated comments for."""
   contentIdNotIn: [ID]
 
-  """
-  Content object name to retrieve affiliated comments for.
-  """
+  """Content object name to retrieve affiliated comments for."""
   contentName: String
 
-  """
-  Content Object parent ID to retrieve affiliated comments for.
-  """
+  """Content Object parent ID to retrieve affiliated comments for."""
   contentParent: Int
 
   """
@@ -16700,94 +12356,64 @@ input RootQueryToCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   includeUnapproved: [ID]
 
-  """
-  Karma score to retrieve matching comments for.
-  """
+  """Karma score to retrieve matching comments for."""
   karma: Int
 
-  """
-  The cardinality of the order of the connection
-  """
+  """The cardinality of the order of the connection"""
   order: OrderEnum
 
-  """
-  Field to order the comments by.
-  """
+  """Field to order the comments by."""
   orderby: CommentsConnectionOrderbyEnum
 
-  """
-  Parent ID of comment to retrieve children of.
-  """
+  """Parent ID of comment to retrieve children of."""
   parent: Int
 
-  """
-  Array of parent IDs of comments to retrieve children for.
-  """
+  """Array of parent IDs of comments to retrieve children for."""
   parentIn: [ID]
 
-  """
-  Array of parent IDs of comments *not* to retrieve children for.
-  """
+  """Array of parent IDs of comments *not* to retrieve children for."""
   parentNotIn: [ID]
 
-  """
-  Search term(s) to retrieve matching comments for.
-  """
+  """Search term(s) to retrieve matching comments for."""
   search: String
 
-  """
-  Comment status to limit results by.
-  """
+  """Comment status to limit results by."""
   status: String
 
-  """
-  Include comments for a specific user ID.
-  """
+  """Include comments for a specific user ID."""
   userId: ID
 }
 
-"""
-Connection between the RootQuery type and the contact type
-"""
-type RootQueryToContactConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToContactConnection connection
-  """
+"""Connection between the RootQuery type and the contact type"""
+type RootQueryToContactConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToContactConnection connection"""
   edges: [RootQueryToContactConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Contact]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToContactConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToContactConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Contact
 }
 
-"""
-Arguments for filtering the RootQueryToContactConnection connection
-"""
-input RootQueryToContactConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the RootQueryToContactConnection connection"""
+input RootQueryToContactConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -16795,34 +12421,22 @@ input RootQueryToContactConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter by Contacts by language code (Polylang)
-  """
+  """Filter by Contacts by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -16830,99 +12444,69 @@ input RootQueryToContactConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the ContentNode type
-"""
-type RootQueryToContentNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToContentNodeConnection connection
-  """
+"""Connection between the RootQuery type and the ContentNode type"""
+type RootQueryToContentNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToContentNodeConnection connection"""
   edges: [RootQueryToContentNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToContentNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToContentNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentNode
 }
 
 """
 Arguments for filtering the RootQueryToContentNodeConnection connection
 """
-input RootQueryToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+input RootQueryToContentNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -16930,34 +12514,22 @@ input RootQueryToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter content nodes by language code (Polylang)
-  """
+  """Filter content nodes by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -16965,84 +12537,58 @@ input RootQueryToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
 """
 Connection between the RootQuery type and the ContentRevisionUnion type
 """
-type RootQueryToContentRevisionUnionConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToContentRevisionUnionConnection connection
-  """
+type RootQueryToContentRevisionUnionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToContentRevisionUnionConnection connection"""
   edges: [RootQueryToContentRevisionUnionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentRevisionUnion]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToContentRevisionUnionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToContentRevisionUnionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentRevisionUnion
 }
 
@@ -17050,15 +12596,12 @@ type RootQueryToContentRevisionUnionConnectionEdge @join__type(graph: CMS) {
 Arguments for filtering the RootQueryToContentRevisionUnionConnection connection
 """
 input RootQueryToContentRevisionUnionConnectionWhereArgs
-  @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -17066,29 +12609,19 @@ input RootQueryToContentRevisionUnionConnectionWhereArgs
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -17096,199 +12629,141 @@ input RootQueryToContentRevisionUnionConnectionWhereArgs
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the ContentType type
-"""
-type RootQueryToContentTypeConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToContentTypeConnection connection
-  """
+"""Connection between the RootQuery type and the ContentType type"""
+type RootQueryToContentTypeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToContentTypeConnection connection"""
   edges: [RootQueryToContentTypeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentType]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToContentTypeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToContentTypeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentType
 }
 
-"""
-Connection between the RootQuery type and the EnqueuedScript type
-"""
-type RootQueryToEnqueuedScriptConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToEnqueuedScriptConnection connection
-  """
+"""Connection between the RootQuery type and the EnqueuedScript type"""
+type RootQueryToEnqueuedScriptConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToEnqueuedScriptConnection connection"""
   edges: [RootQueryToEnqueuedScriptConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedScript]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToEnqueuedScriptConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToEnqueuedScriptConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedScript
 }
 
-"""
-Connection between the RootQuery type and the EnqueuedStylesheet type
-"""
-type RootQueryToEnqueuedStylesheetConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToEnqueuedStylesheetConnection connection
-  """
+"""Connection between the RootQuery type and the EnqueuedStylesheet type"""
+type RootQueryToEnqueuedStylesheetConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToEnqueuedStylesheetConnection connection"""
   edges: [RootQueryToEnqueuedStylesheetConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedStylesheet]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToEnqueuedStylesheetConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToEnqueuedStylesheetConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedStylesheet
 }
 
-"""
-Connection between the RootQuery type and the landingPage type
-"""
-type RootQueryToLandingPageConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToLandingPageConnection connection
-  """
+"""Connection between the RootQuery type and the landingPage type"""
+type RootQueryToLandingPageConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToLandingPageConnection connection"""
   edges: [RootQueryToLandingPageConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [LandingPage]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToLandingPageConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToLandingPageConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: LandingPage
 }
 
 """
 Arguments for filtering the RootQueryToLandingPageConnection connection
 """
-input RootQueryToLandingPageConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+input RootQueryToLandingPageConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -17296,34 +12771,22 @@ input RootQueryToLandingPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter by LandingPages by language code (Polylang)
-  """
+  """Filter by LandingPages by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -17331,104 +12794,72 @@ input RootQueryToLandingPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the mediaItem type
-"""
-type RootQueryToMediaItemConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToMediaItemConnection connection
-  """
+"""Connection between the RootQuery type and the mediaItem type"""
+type RootQueryToMediaItemConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToMediaItemConnection connection"""
   edges: [RootQueryToMediaItemConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MediaItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToMediaItemConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToMediaItemConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MediaItem
 }
 
-"""
-Arguments for filtering the RootQueryToMediaItemConnection connection
-"""
-input RootQueryToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the RootQueryToMediaItemConnection connection"""
+input RootQueryToMediaItemConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -17436,9 +12867,7 @@ input RootQueryToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -17446,34 +12875,22 @@ input RootQueryToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter by MediaItems by language code (Polylang)
-  """
+  """Filter by MediaItems by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -17481,223 +12898,156 @@ input RootQueryToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the Menu type
-"""
-type RootQueryToMenuConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToMenuConnection connection
-  """
+"""Connection between the RootQuery type and the Menu type"""
+type RootQueryToMenuConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToMenuConnection connection"""
   edges: [RootQueryToMenuConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Menu]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToMenuConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToMenuConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Menu
 }
 
-"""
-Arguments for filtering the RootQueryToMenuConnection connection
-"""
-input RootQueryToMenuConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The ID of the object
-  """
+"""Arguments for filtering the RootQueryToMenuConnection connection"""
+input RootQueryToMenuConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The ID of the object"""
   id: Int
 
-  """
-  The menu location for the menu being queried
-  """
+  """The menu location for the menu being queried"""
   location: MenuLocationEnum
 
-  """
-  The slug of the menu to query items for
-  """
+  """The slug of the menu to query items for"""
   slug: String
 }
 
-"""
-Connection between the RootQuery type and the MenuItem type
-"""
-type RootQueryToMenuItemConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToMenuItemConnection connection
-  """
+"""Connection between the RootQuery type and the MenuItem type"""
+type RootQueryToMenuItemConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToMenuItemConnection connection"""
   edges: [RootQueryToMenuItemConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MenuItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToMenuItemConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToMenuItemConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MenuItem
 }
 
-"""
-Arguments for filtering the RootQueryToMenuItemConnection connection
-"""
-input RootQueryToMenuItemConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The ID of the object
-  """
+"""Arguments for filtering the RootQueryToMenuItemConnection connection"""
+input RootQueryToMenuItemConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The ID of the object"""
   id: Int
 
-  """
-  """
+  """"""
   language: LanguageCodeFilterEnum
 
-  """
-  The menu location for the menu being queried
-  """
+  """The menu location for the menu being queried"""
   location: MenuLocationEnum
 
-  """
-  The database ID of the parent menu object
-  """
+  """The database ID of the parent menu object"""
   parentDatabaseId: Int
 
-  """
-  The ID of the parent menu object
-  """
+  """The ID of the parent menu object"""
   parentId: ID
 }
 
-"""
-Connection between the RootQuery type and the page type
-"""
-type RootQueryToPageConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToPageConnection connection
-  """
+"""Connection between the RootQuery type and the page type"""
+type RootQueryToPageConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToPageConnection connection"""
   edges: [RootQueryToPageConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Page]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToPageConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToPageConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Page
 }
 
-"""
-Arguments for filtering the RootQueryToPageConnection connection
-"""
-input RootQueryToPageConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the RootQueryToPageConnection connection"""
+input RootQueryToPageConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -17705,9 +13055,7 @@ input RootQueryToPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -17715,34 +13063,22 @@ input RootQueryToPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter by Pages by language code (Polylang)
-  """
+  """Filter by Pages by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -17750,159 +13086,111 @@ input RootQueryToPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the Plugin type
-"""
-type RootQueryToPluginConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToPluginConnection connection
-  """
+"""Connection between the RootQuery type and the Plugin type"""
+type RootQueryToPluginConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToPluginConnection connection"""
   edges: [RootQueryToPluginConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Plugin]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToPluginConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToPluginConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Plugin
 }
 
-"""
-Arguments for filtering the RootQueryToPluginConnection connection
-"""
-input RootQueryToPluginConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Show plugin based on a keyword search.
-  """
+"""Arguments for filtering the RootQueryToPluginConnection connection"""
+input RootQueryToPluginConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Show plugin based on a keyword search."""
   search: String
 
-  """
-  Retrieve plugins where plugin status is in an array.
-  """
+  """Retrieve plugins where plugin status is in an array."""
   stati: [PluginStatusEnum]
 
-  """
-  Show plugins with a specific status.
-  """
+  """Show plugins with a specific status."""
   status: PluginStatusEnum
 }
 
-"""
-Connection between the RootQuery type and the post type
-"""
-type RootQueryToPostConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToPostConnection connection
-  """
+"""Connection between the RootQuery type and the post type"""
+type RootQueryToPostConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToPostConnection connection"""
   edges: [RootQueryToPostConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Post]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToPostConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToPostConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Post
 }
 
-"""
-Arguments for filtering the RootQueryToPostConnection connection
-"""
-input RootQueryToPostConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the RootQueryToPostConnection connection"""
+input RootQueryToPostConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -17910,9 +13198,7 @@ input RootQueryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Category ID
-  """
+  """Category ID"""
   categoryId: Int
 
   """
@@ -17920,9 +13206,7 @@ input RootQueryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryIn: [ID]
 
-  """
-  Use Category Slug
-  """
+  """Use Category Slug"""
   categoryName: String
 
   """
@@ -17930,9 +13214,7 @@ input RootQueryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -17940,34 +13222,22 @@ input RootQueryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter by Posts by language code (Polylang)
-  """
+  """Filter by Posts by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -17975,121 +13245,81 @@ input RootQueryToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Tag Slug
-  """
+  """Tag Slug"""
   tag: String
 
-  """
-  Use Tag ID
-  """
+  """Use Tag ID"""
   tagId: String
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagIn: [ID]
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagNotIn: [ID]
 
-  """
-  Array of tag slugs, used to display objects from one tag OR another
-  """
+  """Array of tag slugs, used to display objects from one tag OR another"""
   tagSlugAnd: [String]
 
-  """
-  Array of tag slugs, used to exclude objects in specified tags
-  """
+  """Array of tag slugs, used to exclude objects in specified tags"""
   tagSlugIn: [String]
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the postFormat type
-"""
-type RootQueryToPostFormatConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToPostFormatConnection connection
-  """
+"""Connection between the RootQuery type and the postFormat type"""
+type RootQueryToPostFormatConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToPostFormatConnection connection"""
   edges: [RootQueryToPostFormatConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [PostFormat]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToPostFormatConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToPostFormatConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: PostFormat
 }
 
-"""
-Arguments for filtering the RootQueryToPostFormatConnection connection
-"""
-input RootQueryToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the RootQueryToPostFormatConnection connection"""
+input RootQueryToPostFormatConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -18130,19 +13360,13 @@ input RootQueryToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -18150,14 +13374,10 @@ input RootQueryToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -18165,9 +13385,7 @@ input RootQueryToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -18175,64 +13393,46 @@ input RootQueryToPostFormatConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the RootQuery type and the release type
-"""
-type RootQueryToReleaseConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToReleaseConnection connection
-  """
+"""Connection between the RootQuery type and the release type"""
+type RootQueryToReleaseConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToReleaseConnection connection"""
   edges: [RootQueryToReleaseConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Release]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToReleaseConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToReleaseConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Release
 }
 
-"""
-Arguments for filtering the RootQueryToReleaseConnection connection
-"""
-input RootQueryToReleaseConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the RootQueryToReleaseConnection connection"""
+input RootQueryToReleaseConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -18240,34 +13440,22 @@ input RootQueryToReleaseConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Filter by Releases by language code (Polylang)
-  """
+  """Filter by Releases by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -18275,91 +13463,63 @@ input RootQueryToReleaseConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the tag type
-"""
-type RootQueryToTagConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToTagConnection connection
-  """
+"""Connection between the RootQuery type and the tag type"""
+type RootQueryToTagConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToTagConnection connection"""
   edges: [RootQueryToTagConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Tag]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToTagConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToTagConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Tag
 }
 
-"""
-Arguments for filtering the RootQueryToTagConnection connection
-"""
-input RootQueryToTagConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the RootQueryToTagConnection connection"""
+input RootQueryToTagConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -18400,24 +13560,16 @@ input RootQueryToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Filter by Tags by language code (Polylang)
-  """
+  """Filter by Tags by language code (Polylang)"""
   language: LanguageCodeFilterEnum
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -18425,14 +13577,10 @@ input RootQueryToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -18440,9 +13588,7 @@ input RootQueryToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -18450,96 +13596,70 @@ input RootQueryToTagConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the RootQuery type and the Taxonomy type
-"""
-type RootQueryToTaxonomyConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToTaxonomyConnection connection
-  """
+"""Connection between the RootQuery type and the Taxonomy type"""
+type RootQueryToTaxonomyConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToTaxonomyConnection connection"""
   edges: [RootQueryToTaxonomyConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Taxonomy]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToTaxonomyConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToTaxonomyConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Taxonomy
 }
 
-"""
-Connection between the RootQuery type and the TermNode type
-"""
-type RootQueryToTermNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToTermNodeConnection connection
-  """
+"""Connection between the RootQuery type and the TermNode type"""
+type RootQueryToTermNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToTermNodeConnection connection"""
   edges: [RootQueryToTermNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [TermNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToTermNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToTermNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: TermNode
 }
 
-"""
-Arguments for filtering the RootQueryToTermNodeConnection connection
-"""
-input RootQueryToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the RootQueryToTermNodeConnection connection"""
+input RootQueryToTermNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   Unique cache key to be produced when this query is stored in an object cache. Default is 'core'.
   """
@@ -18580,19 +13700,13 @@ input RootQueryToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hierarchical: Boolean
 
-  """
-  Array of term ids to include. Default empty array.
-  """
+  """Array of term ids to include. Default empty array."""
   include: [ID]
 
-  """
-  Array of names to return term(s) for. Default empty.
-  """
+  """Array of names to return term(s) for. Default empty."""
   name: [String]
 
-  """
-  Retrieve terms where the name is LIKE the input value. Default empty.
-  """
+  """Retrieve terms where the name is LIKE the input value. Default empty."""
   nameLike: String
 
   """
@@ -18600,14 +13714,10 @@ input RootQueryToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   objectIds: [ID]
 
-  """
-  Direction the connection should be ordered in
-  """
+  """Direction the connection should be ordered in"""
   order: OrderEnum
 
-  """
-  Field(s) to order terms by. Defaults to 'name'.
-  """
+  """Field(s) to order terms by. Defaults to 'name'."""
   orderby: TermObjectsConnectionOrderbyEnum
 
   """
@@ -18615,9 +13725,7 @@ input RootQueryToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   padCounts: Boolean
 
-  """
-  Parent term ID to retrieve direct-child terms of. Default empty.
-  """
+  """Parent term ID to retrieve direct-child terms of. Default empty."""
   parent: Int
 
   """
@@ -18625,104 +13733,76 @@ input RootQueryToTermNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   search: String
 
-  """
-  Array of slugs to return term(s) for. Default empty.
-  """
+  """Array of slugs to return term(s) for. Default empty."""
   slug: [String]
 
-  """
-  The Taxonomy to filter terms by
-  """
+  """The Taxonomy to filter terms by"""
   taxonomies: [TaxonomyEnum]
 
-  """
-  Array of term taxonomy IDs, to match when querying terms.
-  """
+  """Array of term taxonomy IDs, to match when querying terms."""
   termTaxonomId: [ID]
 
-  """
-  Whether to prime meta caches for matched terms. Default true.
-  """
+  """Whether to prime meta caches for matched terms. Default true."""
   updateTermMetaCache: Boolean
 }
 
-"""
-Connection between the RootQuery type and the Theme type
-"""
-type RootQueryToThemeConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToThemeConnection connection
-  """
+"""Connection between the RootQuery type and the Theme type"""
+type RootQueryToThemeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToThemeConnection connection"""
   edges: [RootQueryToThemeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Theme]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToThemeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToThemeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Theme
 }
 
-"""
-Connection between the RootQuery type and the translation type
-"""
-type RootQueryToTranslationConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToTranslationConnection connection
-  """
+"""Connection between the RootQuery type and the translation type"""
+type RootQueryToTranslationConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToTranslationConnection connection"""
   edges: [RootQueryToTranslationConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Translation]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToTranslationConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToTranslationConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Translation
 }
 
 """
 Arguments for filtering the RootQueryToTranslationConnection connection
 """
-input RootQueryToTranslationConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+input RootQueryToTranslationConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -18730,29 +13810,19 @@ input RootQueryToTranslationConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -18760,94 +13830,64 @@ input RootQueryToTranslationConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the RootQuery type and the User type
-"""
-type RootQueryToUserConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToUserConnection connection
-  """
+"""Connection between the RootQuery type and the User type"""
+type RootQueryToUserConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToUserConnection connection"""
   edges: [RootQueryToUserConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [User]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToUserConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToUserConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: User
 }
 
-"""
-Arguments for filtering the RootQueryToUserConnection connection
-"""
-input RootQueryToUserConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Array of userIds to exclude.
-  """
+"""Arguments for filtering the RootQueryToUserConnection connection"""
+input RootQueryToUserConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Array of userIds to exclude."""
   exclude: [Int]
 
   """
@@ -18855,14 +13895,10 @@ input RootQueryToUserConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPublishedPosts: [ContentTypeEnum]
 
-  """
-  Array of userIds to include.
-  """
+  """Array of userIds to include."""
   include: [Int]
 
-  """
-  The user login.
-  """
+  """The user login."""
   login: String
 
   """
@@ -18875,9 +13911,7 @@ input RootQueryToUserConnectionWhereArgs @join__type(graph: CMS) {
   """
   loginNotIn: [String]
 
-  """
-  The user nicename.
-  """
+  """The user nicename."""
   nicename: String
 
   """
@@ -18890,9 +13924,7 @@ input RootQueryToUserConnectionWhereArgs @join__type(graph: CMS) {
   """
   nicenameNotIn: [String]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [UsersConnectionOrderbyInput]
 
   """
@@ -18921,45 +13953,35 @@ input RootQueryToUserConnectionWhereArgs @join__type(graph: CMS) {
   searchColumns: [UsersConnectionSearchColumnEnum]
 }
 
-"""
-Connection between the RootQuery type and the UserRole type
-"""
-type RootQueryToUserRoleConnection @join__type(graph: CMS) {
-  """
-  Edges for the RootQueryToUserRoleConnection connection
-  """
+"""Connection between the RootQuery type and the UserRole type"""
+type RootQueryToUserRoleConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the RootQueryToUserRoleConnection connection"""
   edges: [RootQueryToUserRoleConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [UserRole]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type RootQueryToUserRoleConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type RootQueryToUserRoleConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: UserRole
 }
 
-type SearchResultConnection @join__type(graph: UNIFIED_SEARCH) {
-  """
-  Elasticsearch raw results
-  """
+type SearchResultConnection
+  @join__type(graph: UNIFIED_SEARCH)
+{
+  """Elasticsearch raw results"""
   es_results: [ElasticSearchResult]
   count: Int
   max_score: Float
@@ -18967,12 +13989,16 @@ type SearchResultConnection @join__type(graph: UNIFIED_SEARCH) {
   edges: [SearchResultEdge!]!
 }
 
-type SearchResultEdge @join__type(graph: UNIFIED_SEARCH) {
+type SearchResultEdge
+  @join__type(graph: UNIFIED_SEARCH)
+{
   cursor: String!
   node: SearchResultNode!
 }
 
-type SearchResultNode @join__type(graph: UNIFIED_SEARCH) {
+type SearchResultNode
+  @join__type(graph: UNIFIED_SEARCH)
+{
   _score: Float
   id: ID!
   venue: UnifiedSearchVenue
@@ -18980,217 +14006,164 @@ type SearchResultNode @join__type(graph: UNIFIED_SEARCH) {
   searchCategories: [UnifiedSearchResultCategory!]!
 }
 
-type SearchResultPageInfo @join__type(graph: UNIFIED_SEARCH) {
+type SearchResultPageInfo
+  @join__type(graph: UNIFIED_SEARCH)
+{
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
   startCursor: String
   endCursor: String
 }
 
-type SearchSuggestionConnection @join__type(graph: UNIFIED_SEARCH) {
+type SearchSuggestionConnection
+  @join__type(graph: UNIFIED_SEARCH)
+{
   suggestions: [Suggestion]!
 }
 
-"""
-Input for the sendPasswordResetEmail mutation
-"""
-input SendPasswordResetEmailInput @join__type(graph: CMS) {
+"""Input for the sendPasswordResetEmail mutation"""
+input SendPasswordResetEmailInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  A string that contains the user's username or email address.
-  """
+  """A string that contains the user's username or email address."""
   username: String!
 }
 
-"""
-The payload for the sendPasswordResetEmail mutation
-"""
-type SendPasswordResetEmailPayload @join__type(graph: CMS) {
+"""The payload for the sendPasswordResetEmail mutation"""
+type SendPasswordResetEmailPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The user that the password reset email was sent to
-  """
+  """The user that the password reset email was sent to"""
   user: User
 }
 
-"""
-"""
-type SEO @join__type(graph: CMS) {
-  """
-  Canonical URL
-  """
+""""""
+type SEO
+  @join__type(graph: CMS)
+{
+  """Canonical URL"""
   canonicalUrl: String
 
-  """
-  SEO Description
-  """
+  """SEO Description"""
   description: String
 
-  """
-  Whether this page should be excluded from all archive queries
-  """
+  """Whether this page should be excluded from all archive queries"""
   excludeFromArchive: Boolean
 
-  """
-  Whether this page should be excluded from all search queries
-  """
+  """Whether this page should be excluded from all search queries"""
   excludeLocalSearch: Boolean
 
-  """
-  Whether search engines should show cached links of this page
-  """
+  """Whether search engines should show cached links of this page"""
   noArchive: Boolean
 
-  """
-  Whether search engines should follow the links of this page
-  """
+  """Whether search engines should follow the links of this page"""
   noFollow: Boolean
 
-  """
-  Whether search engines should index this page
-  """
+  """Whether search engines should index this page"""
   noIndex: Boolean
 
-  """
-  Open Graph description
-  """
+  """Open Graph description"""
   openGraphDescription: String
 
-  """
-  Open Graph title
-  """
+  """Open Graph title"""
   openGraphTitle: String
 
-  """
-  Open Graph type (&#039;website&#039;, &#039;article&#039;, ...)
-  """
+  """Open Graph type (&#039;website&#039;, &#039;article&#039;, ...)"""
   openGraphType: String
 
-  """
-  301 redirect URL to force visitors to another page
-  """
+  """301 redirect URL to force visitors to another page"""
   redirectUrl: String
 
-  """
-  If true, site title is/should not be added to the end of the SEO title
-  """
+  """If true, site title is/should not be added to the end of the SEO title"""
   removeSiteTitle: Boolean
 
-  """
-  """
+  """"""
   socialImage: MediaItem
 
-  """
-  SEO Title
-  """
+  """SEO Title"""
   title: String
 
-  """
-  Twitter description
-  """
+  """Twitter description"""
   twitterDescription: String
 
-  """
-  Twitter title
-  """
+  """Twitter title"""
   twitterTitle: String
 }
 
-"""
-"""
-type SeoSettings @join__type(graph: CMS) {
-  """
-  Title separator setting for seo titles
-  """
+""""""
+type SeoSettings
+  @join__type(graph: CMS)
+{
+  """Title separator setting for seo titles"""
   separator: String
 }
 
-"""
-All of the registered settings
-"""
-type Settings @join__type(graph: CMS) {
-  """
-  Settings of the the string Settings Group
-  """
+"""All of the registered settings"""
+type Settings
+  @join__type(graph: CMS)
+{
+  """Settings of the the string Settings Group"""
   discussionSettingsDefaultCommentStatus: String
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   discussionSettingsDefaultPingStatus: String
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   generalSettingsDateFormat: String
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   generalSettingsDescription: String
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   generalSettingsLanguage: String
 
-  """
-  Settings of the the integer Settings Group
-  """
+  """Settings of the the integer Settings Group"""
   generalSettingsStartOfWeek: Int
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   generalSettingsTimeFormat: String
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   generalSettingsTimezone: String
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   generalSettingsTitle: String
 
-  """
-  Settings of the the integer Settings Group
-  """
+  """Settings of the the integer Settings Group"""
   readingSettingsPostsPerPage: Int
 
-  """
-  Settings of the the integer Settings Group
-  """
+  """Settings of the the integer Settings Group"""
   writingSettingsDefaultCategory: Int
 
-  """
-  Settings of the the string Settings Group
-  """
+  """Settings of the the string Settings Group"""
   writingSettingsDefaultPostFormat: String
 
-  """
-  Settings of the the boolean Settings Group
-  """
+  """Settings of the the boolean Settings Group"""
   writingSettingsUseSmilies: Boolean
 }
 
-type Shards @join__type(graph: UNIFIED_SEARCH) {
+type Shards
+  @join__type(graph: UNIFIED_SEARCH)
+{
   total: Int
   successful: Int
   skipped: Int
   failed: Int
 }
 
-type SingleHit @join__type(graph: UNIFIED_SEARCH) {
+type SingleHit
+  @join__type(graph: UNIFIED_SEARCH)
+{
   _index: String
   _type: String
   _score: Float
@@ -19198,26 +14171,27 @@ type SingleHit @join__type(graph: UNIFIED_SEARCH) {
   _source: RawJSON
 }
 
-"""
-"""
-type SiteSettings @join__type(graph: CMS) {
-  """
-  Attachment ID for logo
-  """
+""""""
+type SiteSettings
+  @join__type(graph: CMS)
+{
+  """Attachment ID for logo"""
   logo: String
 
-  """
-  Identifying name
-  """
+  """Identifying name"""
   siteName: String
 }
 
-enum SortOrder @join__type(graph: UNIFIED_SEARCH) {
+enum SortOrder
+  @join__type(graph: UNIFIED_SEARCH)
+{
   ASCENDING
   DESCENDING
 }
 
-type StaticPage @join__type(graph: EVENTS) {
+type StaticPage
+  @join__type(graph: EVENTS)
+{
   id: ID!
   path: String
   depth: Int
@@ -19248,36 +14222,33 @@ type StaticPage @join__type(graph: EVENTS) {
   liveRevision: Int
 }
 
-type Subscription @join__type(graph: EVENTS) {
+type Subscription
+  @join__type(graph: EVENTS)
+{
   _empty: String
 }
 
-type Suggestion @join__type(graph: UNIFIED_SEARCH) {
+type Suggestion
+  @join__type(graph: UNIFIED_SEARCH)
+{
   label: String!
 }
 
-"""
-The tag type
-"""
+"""The tag type"""
 type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIdentifier & MenuItemLinkable
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "TermNode")
   @join__implements(graph: CMS, interface: "UniformResourceIdentifiable")
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
   @join__implements(graph: CMS, interface: "MenuItemLinkable")
-  @join__type(graph: CMS) {
-  """
-  Connection between the tag type and the ContentNode type
-  """
+  @join__type(graph: CMS)
+{
+  """Connection between the tag type and the ContentNode type"""
   contentNodes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -19290,39 +14261,25 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: TagToContentNodeConnectionWhereArgs
   ): TagToContentNodeConnection
 
-  """
-  The number of objects connected to the object
-  """
+  """The number of objects connected to the object"""
   count: Int
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   databaseId: Int!
 
-  """
-  The description of the object
-  """
+  """The description of the object"""
   description: String
 
-  """
-  Connection between the TermNode type and the EnqueuedScript type
-  """
+  """Connection between the TermNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -19336,18 +14293,12 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     before: String
   ): TermNodeToEnqueuedScriptConnection
 
-  """
-  Connection between the TermNode type and the EnqueuedStylesheet type
-  """
+  """Connection between the TermNode type and the EnqueuedStylesheet type"""
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -19361,53 +14312,33 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     before: String
   ): TermNodeToEnqueuedStylesheetConnection
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  List available translations for this post
-  """
+  """List available translations for this post"""
   language: Language
 
-  """
-  The link to the term
-  """
+  """The link to the term"""
   link: String
 
-  """
-  The human friendly name of the object.
-  """
+  """The human friendly name of the object."""
   name: String
 
-  """
-  Connection between the tag type and the post type
-  """
+  """Connection between the tag type and the post type"""
   posts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -19420,135 +14351,91 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: TagToPostConnectionWhereArgs
   ): TagToPostConnection
 
-  """
-  An alphanumeric identifier for the object unique to its type.
-  """
+  """An alphanumeric identifier for the object unique to its type."""
   slug: String
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
+  """The id field matches the WP_Post-&gt;ID field."""
   tagId: Int @deprecated(reason: "Deprecated in favor of databaseId")
 
-  """
-  Connection between the tag type and the Taxonomy type
-  """
+  """Connection between the tag type and the Taxonomy type"""
   taxonomy: TagToTaxonomyConnectionEdge
 
-  """
-  The name of the taxonomy that the object is associated with
-  """
+  """The name of the taxonomy that the object is associated with"""
   taxonomyName: String
 
-  """
-  The ID of the term group that this term object belongs to
-  """
+  """The ID of the term group that this term object belongs to"""
   termGroupId: Int
 
-  """
-  The taxonomy ID that the object is associated with
-  """
+  """The taxonomy ID that the object is associated with"""
   termTaxonomyId: Int
 
-  """
-  Get specific translation version of this object
-  """
+  """Get specific translation version of this object"""
   translation(language: LanguageCodeEnum!): Tag
 
-  """
-  List all translated versions of this term
-  """
+  """List all translated versions of this term"""
   translations: [Tag]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum TagIdType @join__type(graph: CMS) {
-  """
-  The Database ID for the node
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum TagIdType
+  @join__type(graph: CMS)
+{
+  """The Database ID for the node"""
   DATABASE_ID
 
-  """
-  The hashed Global ID
-  """
+  """The hashed Global ID"""
   ID
 
-  """
-  The name of the node
-  """
+  """The name of the node"""
   NAME
 
-  """
-  Url friendly name of the node
-  """
+  """Url friendly name of the node"""
   SLUG
 
-  """
-  The URI for the node
-  """
+  """The URI for the node"""
   URI
 }
 
-"""
-Connection between the tag type and the ContentNode type
-"""
-type TagToContentNodeConnection @join__type(graph: CMS) {
-  """
-  Edges for the TagToContentNodeConnection connection
-  """
+"""Connection between the tag type and the ContentNode type"""
+type TagToContentNodeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the TagToContentNodeConnection connection"""
   edges: [TagToContentNodeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentNode]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type TagToContentNodeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type TagToContentNodeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentNode
 }
 
-"""
-Arguments for filtering the TagToContentNodeConnection connection
-"""
-input TagToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+"""Arguments for filtering the TagToContentNodeConnection connection"""
+input TagToContentNodeConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypesOfTagEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -19556,29 +14443,19 @@ input TagToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -19586,104 +14463,72 @@ input TagToContentNodeConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the tag type and the post type
-"""
-type TagToPostConnection @join__type(graph: CMS) {
-  """
-  Edges for the TagToPostConnection connection
-  """
+"""Connection between the tag type and the post type"""
+type TagToPostConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the TagToPostConnection connection"""
   edges: [TagToPostConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Post]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type TagToPostConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type TagToPostConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Post
 }
 
-"""
-Arguments for filtering the TagToPostConnection connection
-"""
-input TagToPostConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the TagToPostConnection connection"""
+input TagToPostConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -19691,9 +14536,7 @@ input TagToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Category ID
-  """
+  """Category ID"""
   categoryId: Int
 
   """
@@ -19701,9 +14544,7 @@ input TagToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryIn: [ID]
 
-  """
-  Use Category Slug
-  """
+  """Use Category Slug"""
   categoryName: String
 
   """
@@ -19711,9 +14552,7 @@ input TagToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -19721,29 +14560,19 @@ input TagToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -19751,110 +14580,71 @@ input TagToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Tag Slug
-  """
+  """Tag Slug"""
   tag: String
 
-  """
-  Use Tag ID
-  """
+  """Use Tag ID"""
   tagId: String
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagIn: [ID]
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagNotIn: [ID]
 
-  """
-  Array of tag slugs, used to display objects from one tag OR another
-  """
+  """Array of tag slugs, used to display objects from one tag OR another"""
   tagSlugAnd: [String]
 
-  """
-  Array of tag slugs, used to exclude objects in specified tags
-  """
+  """Array of tag slugs, used to exclude objects in specified tags"""
   tagSlugIn: [String]
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the tag type and the Taxonomy type
-"""
-type TagToTaxonomyConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the tag type and the Taxonomy type"""
+type TagToTaxonomyConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Taxonomy
 }
 
-"""
-A taxonomy object
-"""
+"""A taxonomy object"""
 type Taxonomy implements Node
   @join__implements(graph: CMS, interface: "Node")
-  @join__type(graph: CMS) {
-  """
-  List of Content Types associated with the Taxonomy
-  """
+  @join__type(graph: CMS)
+{
+  """List of Content Types associated with the Taxonomy"""
   connectedContentTypes(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -19873,34 +14663,22 @@ type Taxonomy implements Node
   """
   description: String
 
-  """
-  The plural name of the post type within the GraphQL Schema.
-  """
+  """The plural name of the post type within the GraphQL Schema."""
   graphqlPluralName: String
 
-  """
-  The singular name of the post type within the GraphQL Schema.
-  """
+  """The singular name of the post type within the GraphQL Schema."""
   graphqlSingleName: String
 
-  """
-  Whether the taxonomy is hierarchical
-  """
+  """Whether the taxonomy is hierarchical"""
   hierarchical: Boolean
 
-  """
-  The globally unique identifier of the taxonomy object.
-  """
+  """The globally unique identifier of the taxonomy object."""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Name of the taxonomy shown in the menu. Usually plural.
-  """
+  """Name of the taxonomy shown in the menu. Usually plural."""
   label: String
 
   """
@@ -19908,9 +14686,7 @@ type Taxonomy implements Node
   """
   name: String
 
-  """
-  Whether the taxonomy is publicly queryable
-  """
+  """Whether the taxonomy is publicly queryable"""
   public: Boolean
 
   """
@@ -19918,9 +14694,7 @@ type Taxonomy implements Node
   """
   restBase: String
 
-  """
-  The REST Controller class assigned to handling this content type.
-  """
+  """The REST Controller class assigned to handling this content type."""
   restControllerClass: String
 
   """
@@ -19933,24 +14707,16 @@ type Taxonomy implements Node
   """
   showInAdminColumn: Boolean
 
-  """
-  Whether to add the post type to the GraphQL Schema.
-  """
+  """Whether to add the post type to the GraphQL Schema."""
   showInGraphql: Boolean
 
-  """
-  Whether to show the taxonomy in the admin menu
-  """
+  """Whether to show the taxonomy in the admin menu"""
   showInMenu: Boolean
 
-  """
-  Whether the taxonomy is available for selection in navigation menus.
-  """
+  """Whether the taxonomy is available for selection in navigation menus."""
   showInNavMenus: Boolean
 
-  """
-  Whether to show the taxonomy in the quick/bulk edit panel.
-  """
+  """Whether to show the taxonomy in the quick/bulk edit panel."""
   showInQuickEdit: Boolean
 
   """
@@ -19964,80 +14730,62 @@ type Taxonomy implements Node
   showUi: Boolean
 }
 
-"""
-Allowed taxonomies
-"""
-enum TaxonomyEnum @join__type(graph: CMS) {
-  """
-  Taxonomy enum category
-  """
+"""Allowed taxonomies"""
+enum TaxonomyEnum
+  @join__type(graph: CMS)
+{
+  """Taxonomy enum category"""
   CATEGORY
 
-  """
-  Taxonomy enum post_format
-  """
+  """Taxonomy enum post_format"""
   POSTFORMAT
 
-  """
-  Taxonomy enum post_tag
-  """
+  """Taxonomy enum post_tag"""
   TAG
 }
 
 """
 The Type of Identifier used to fetch a single Taxonomy node. To be used along with the "id" field. Default is "ID".
 """
-enum TaxonomyIdTypeEnum @join__type(graph: CMS) {
-  """
-  The globally unique ID
-  """
+enum TaxonomyIdTypeEnum
+  @join__type(graph: CMS)
+{
+  """The globally unique ID"""
   ID
 
-  """
-  The name of the taxonomy
-  """
+  """The name of the taxonomy"""
   NAME
 }
 
-"""
-Connection between the Taxonomy type and the ContentType type
-"""
-type TaxonomyToContentTypeConnection @join__type(graph: CMS) {
-  """
-  Edges for the TaxonomyToContentTypeConnection connection
-  """
+"""Connection between the Taxonomy type and the ContentType type"""
+type TaxonomyToContentTypeConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the TaxonomyToContentTypeConnection connection"""
   edges: [TaxonomyToContentTypeConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentType]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type TaxonomyToContentTypeConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type TaxonomyToContentTypeConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentType
 }
 
-"""
-Get page object by template
-"""
-enum TemplateEnum @join__type(graph: CMS) {
+"""Get page object by template"""
+enum TemplateEnum
+  @join__type(graph: CMS)
+{
   frontPage
   postsPage
 }
@@ -20048,34 +14796,23 @@ Terms are nodes within a Taxonomy, used to group and relate other nodes.
 interface TermNode implements Node & UniformResourceIdentifiable
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "UniformResourceIdentifiable")
-  @join__type(graph: CMS) {
-  """
-  The number of objects connected to the object
-  """
+  @join__type(graph: CMS)
+{
+  """The number of objects connected to the object"""
   count: Int
 
-  """
-  Identifies the primary key from the database.
-  """
+  """Identifies the primary key from the database."""
   databaseId: Int!
 
-  """
-  The description of the object
-  """
+  """The description of the object"""
   description: String
 
-  """
-  Connection between the TermNode type and the EnqueuedScript type
-  """
+  """Connection between the TermNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -20089,18 +14826,12 @@ interface TermNode implements Node & UniformResourceIdentifiable
     before: String
   ): TermNodeToEnqueuedScriptConnection
 
-  """
-  Connection between the TermNode type and the EnqueuedStylesheet type
-  """
+  """Connection between the TermNode type and the EnqueuedStylesheet type"""
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -20114,208 +14845,143 @@ interface TermNode implements Node & UniformResourceIdentifiable
     before: String
   ): TermNodeToEnqueuedStylesheetConnection
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  The link to the term
-  """
+  """The link to the term"""
   link: String
 
-  """
-  The human friendly name of the object.
-  """
+  """The human friendly name of the object."""
   name: String
 
-  """
-  An alphanumeric identifier for the object unique to its type.
-  """
+  """An alphanumeric identifier for the object unique to its type."""
   slug: String
 
-  """
-  The name of the taxonomy that the object is associated with
-  """
+  """The name of the taxonomy that the object is associated with"""
   taxonomyName: String
 
-  """
-  The ID of the term group that this term object belongs to
-  """
+  """The ID of the term group that this term object belongs to"""
   termGroupId: Int
 
-  """
-  The taxonomy ID that the object is associated with
-  """
+  """The taxonomy ID that the object is associated with"""
   termTaxonomyId: Int
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
 """
 The Type of Identifier used to fetch a single resource. Default is "ID". To be used along with the "id" field.
 """
-enum TermNodeIdTypeEnum @join__type(graph: CMS) {
-  """
-  The Database ID for the node
-  """
+enum TermNodeIdTypeEnum
+  @join__type(graph: CMS)
+{
+  """The Database ID for the node"""
   DATABASE_ID
 
-  """
-  The hashed Global ID
-  """
+  """The hashed Global ID"""
   ID
 
-  """
-  The name of the node
-  """
+  """The name of the node"""
   NAME
 
-  """
-  Url friendly name of the node
-  """
+  """Url friendly name of the node"""
   SLUG
 
-  """
-  The URI for the node
-  """
+  """The URI for the node"""
   URI
 }
 
-"""
-Connection between the TermNode type and the EnqueuedScript type
-"""
-type TermNodeToEnqueuedScriptConnection @join__type(graph: CMS) {
-  """
-  Edges for the TermNodeToEnqueuedScriptConnection connection
-  """
+"""Connection between the TermNode type and the EnqueuedScript type"""
+type TermNodeToEnqueuedScriptConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the TermNodeToEnqueuedScriptConnection connection"""
   edges: [TermNodeToEnqueuedScriptConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedScript]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type TermNodeToEnqueuedScriptConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type TermNodeToEnqueuedScriptConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedScript
 }
 
-"""
-Connection between the TermNode type and the EnqueuedStylesheet type
-"""
-type TermNodeToEnqueuedStylesheetConnection @join__type(graph: CMS) {
-  """
-  Edges for the TermNodeToEnqueuedStylesheetConnection connection
-  """
+"""Connection between the TermNode type and the EnqueuedStylesheet type"""
+type TermNodeToEnqueuedStylesheetConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the TermNodeToEnqueuedStylesheetConnection connection"""
   edges: [TermNodeToEnqueuedStylesheetConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedStylesheet]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type TermNodeToEnqueuedStylesheetConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type TermNodeToEnqueuedStylesheetConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedStylesheet
 }
 
-"""
-Options for ordering the connection by
-"""
-enum TermObjectsConnectionOrderbyEnum @join__type(graph: CMS) {
-  """
-  Order the connection by item count.
-  """
+"""Options for ordering the connection by"""
+enum TermObjectsConnectionOrderbyEnum
+  @join__type(graph: CMS)
+{
+  """Order the connection by item count."""
   COUNT
 
-  """
-  Order the connection by description.
-  """
+  """Order the connection by description."""
   DESCRIPTION
 
-  """
-  Order the connection by name.
-  """
+  """Order the connection by name."""
   NAME
 
-  """
-  Order the connection by slug.
-  """
+  """Order the connection by slug."""
   SLUG
 
-  """
-  Order the connection by term group.
-  """
+  """Order the connection by term group."""
   TERM_GROUP
 
-  """
-  Order the connection by term id.
-  """
+  """Order the connection by term id."""
   TERM_ID
 
-  """
-  Order the connection by term order.
-  """
+  """Order the connection by term order."""
   TERM_ORDER
 }
 
-"""
-A theme object
-"""
+"""A theme object"""
 type Theme implements Node
   @join__implements(graph: CMS, interface: "Node")
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   Name of the theme author(s), could also be a company name. This field is equivalent to WP_Theme-&gt;get( &quot;Author&quot; ).
   """
@@ -20331,14 +14997,10 @@ type Theme implements Node
   """
   description: String
 
-  """
-  The globally unique identifier of the theme object.
-  """
+  """The globally unique identifier of the theme object."""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
   """
@@ -20372,7 +15034,9 @@ type Theme implements Node
   version: String
 }
 
-type Time @join__type(graph: VENUES) {
+type Time
+  @join__type(graph: VENUES)
+{
   name: String!
   description: String!
   startTime: String!
@@ -20383,18 +15047,16 @@ type Time @join__type(graph: VENUES) {
   periods: [Int!]!
 }
 
-"""
-any kind of description answering the question "when".
-"""
-type TimeDescription @join__type(graph: UNIFIED_SEARCH) {
+"""any kind of description answering the question "when"."""
+type TimeDescription
+  @join__type(graph: UNIFIED_SEARCH)
+{
   starting: DateTime
   ending: DateTime
   otherTime: TimeDescription
 }
 
-"""
-The translation type
-"""
+"""The translation type"""
 type Translation implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & NodeWithTitle & NodeWithRevisions
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "ContentNode")
@@ -20403,35 +15065,24 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   @join__implements(graph: CMS, interface: "NodeWithTemplate")
   @join__implements(graph: CMS, interface: "NodeWithTitle")
   @join__implements(graph: CMS, interface: "NodeWithRevisions")
-  @join__type(graph: CMS) {
-  """
-  Connection between the ContentNode type and the ContentType type
-  """
+  @join__type(graph: CMS)
+{
+  """Connection between the ContentNode type and the ContentType type"""
   contentType: ContentNodeToContentTypeConnectionEdge
 
-  """
-  The name of the Content Type the node belongs to
-  """
+  """The name of the Content Type the node belongs to"""
   contentTypeName: String!
 
-  """
-  The unique identifier stored in the database
-  """
+  """The unique identifier stored in the database"""
   databaseId: Int!
 
-  """
-  Post publishing date.
-  """
+  """Post publishing date."""
   date: String
 
-  """
-  The publishing date set in GMT.
-  """
+  """The publishing date set in GMT."""
   dateGmt: String
 
-  """
-  The desired slug of the post
-  """
+  """The desired slug of the post"""
   desiredSlug: String
 
   """
@@ -20439,23 +15090,15 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   editingLockedBy: ContentNodeToEditLockConnectionEdge
 
-  """
-  The RSS enclosure for the object
-  """
+  """The RSS enclosure for the object"""
   enclosure: String
 
-  """
-  Connection between the ContentNode type and the EnqueuedScript type
-  """
+  """Connection between the ContentNode type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -20473,14 +15116,10 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   Connection between the ContentNode type and the EnqueuedStylesheet type
   """
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -20499,44 +15138,28 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   guid: String
 
-  """
-  The globally unique identifier of the translation-cpt object.
-  """
+  """The globally unique identifier of the translation-cpt object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   isPreview: Boolean
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  True if the node is a revision of another node
-  """
+  """True if the node is a revision of another node"""
   isRevision: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  The user that most recently edited the node
-  """
+  """The user that most recently edited the node"""
   lastEditedBy: ContentNodeToEditLastConnectionEdge
 
-  """
-  The permalink of the post
-  """
+  """The permalink of the post"""
   link: String
 
   """
@@ -20549,19 +15172,13 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   modifiedGmt: String
 
-  """
-  Connection between the translation type and the translation type
-  """
+  """Connection between the translation type and the translation type"""
   preview: TranslationToPreviewConnectionEdge
 
-  """
-  The database id of the preview node
-  """
+  """The database id of the preview node"""
   previewRevisionDatabaseId: Int
 
-  """
-  Whether the object is a node in the preview state
-  """
+  """Whether the object is a node in the preview state"""
   previewRevisionId: ID
 
   """
@@ -20569,18 +15186,12 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
 
-  """
-  Connection between the translation type and the translation type
-  """
+  """Connection between the translation type and the translation type"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -20593,15 +15204,11 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: TranslationToRevisionConnectionWhereArgs
   ): TranslationToRevisionConnection
 
-  """
-  The SEO Framework data of the translation
-  """
+  """The SEO Framework data of the translation"""
   seo: SEO
 
   """
@@ -20609,55 +15216,38 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   """
   slug: String
 
-  """
-  The current status of the object
-  """
+  """The current status of the object"""
   status: String
 
-  """
-  The template assigned to the node
-  """
+  """The template assigned to the node"""
   template: ContentTemplate
 
   """
   The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
   """
   title(
-    """
-    Format of the field output
-    """
+    """Format of the field output"""
     format: PostObjectFieldFormatEnum
   ): String
 
-  """
-  The id field matches the WP_Post-&gt;ID field.
-  """
-  translationId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  """The id field matches the WP_Post-&gt;ID field."""
+  translationId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
 
-  """
-  Translations
-  """
+  """Translations"""
   translations: [TranslationResponse]
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-The Type of Identifier used to fetch a single resource. Default is ID.
-"""
-enum TranslationIdType @join__type(graph: CMS) {
-  """
-  Identify a resource by the Database ID.
-  """
+"""The Type of Identifier used to fetch a single resource. Default is ID."""
+enum TranslationIdType
+  @join__type(graph: CMS)
+{
+  """Identify a resource by the Database ID."""
   DATABASE_ID
 
-  """
-  Identify a resource by the (hashed) Global ID.
-  """
+  """Identify a resource by the (hashed) Global ID."""
   ID
 
   """
@@ -20665,99 +15255,73 @@ enum TranslationIdType @join__type(graph: CMS) {
   """
   SLUG
 
-  """
-  Identify a resource by the URI.
-  """
+  """Identify a resource by the URI."""
   URI
 }
 
-"""
-Translation with language/value pairs
-"""
-type TranslationItems @join__type(graph: CMS) {
-  """
-  Translation string
-  """
+"""Translation with language/value pairs"""
+type TranslationItems
+  @join__type(graph: CMS)
+{
+  """Translation string"""
   en: String
 
-  """
-  Translation string
-  """
+  """Translation string"""
   fi: String
 
-  """
-  Translation string
-  """
+  """Translation string"""
   sv: String
 }
 
-"""
-Translation response contains translation key and translations
-"""
-type TranslationResponse @join__type(graph: CMS) {
-  """
-  Translation key for frontend
-  """
+"""Translation response contains translation key and translations"""
+type TranslationResponse
+  @join__type(graph: CMS)
+{
+  """Translation key for frontend"""
   key: String
 
-  """
-  Translations for frontend
-  """
+  """Translations for frontend"""
   translations: TranslationItems
 }
 
-"""
-Connection between the translation type and the translation type
-"""
-type TranslationToPreviewConnectionEdge @join__type(graph: CMS) {
-  """
-  The node of the connection, without the edges
-  """
+"""Connection between the translation type and the translation type"""
+type TranslationToPreviewConnectionEdge
+  @join__type(graph: CMS)
+{
+  """The node of the connection, without the edges"""
   node: Translation
 }
 
-"""
-Connection between the translation type and the translation type
-"""
-type TranslationToRevisionConnection @join__type(graph: CMS) {
-  """
-  Edges for the translationToRevisionConnection connection
-  """
+"""Connection between the translation type and the translation type"""
+type TranslationToRevisionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the translationToRevisionConnection connection"""
   edges: [TranslationToRevisionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Translation]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type TranslationToRevisionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type TranslationToRevisionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Translation
 }
 
-"""
-Arguments for filtering the translationToRevisionConnection connection
-"""
-input TranslationToRevisionConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Filter the connection based on dates
-  """
+"""Arguments for filtering the translationToRevisionConnection connection"""
+input TranslationToRevisionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -20765,29 +15329,19 @@ input TranslationToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -20795,66 +15349,52 @@ input TranslationToRevisionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-enum UnifiedSearchLanguage @join__type(graph: UNIFIED_SEARCH) {
+enum UnifiedSearchLanguage
+  @join__type(graph: UNIFIED_SEARCH)
+{
   FINNISH
   SWEDISH
   ENGLISH
 }
 
-"""
-TODO: take from Profile or external source
-"""
-enum UnifiedSearchLanguageEnum @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: take from Profile or external source"""
+enum UnifiedSearchLanguageEnum
+  @join__type(graph: UNIFIED_SEARCH)
+{
   FI
 }
 
-enum UnifiedSearchResultCategory @join__type(graph: UNIFIED_SEARCH) {
+enum UnifiedSearchResultCategory
+  @join__type(graph: UNIFIED_SEARCH)
+{
   POINT_OF_INTEREST
   EVENT
   RESERVABLE
@@ -20869,7 +15409,9 @@ A place that forms a unit and can be used for some specific purpose -
 respa unit or resource, service map unit, beta.kultus venue, linked
 events place, Kukkuu venue
 """
-type UnifiedSearchVenue @join__type(graph: UNIFIED_SEARCH) {
+type UnifiedSearchVenue
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   name: LanguageString
   location: LocationDescription
@@ -20888,38 +15430,28 @@ type UnifiedSearchVenue @join__type(graph: UNIFIED_SEARCH) {
   ontologyWords: [OntologyWord]
 }
 
-"""
-Any node that has a URI
-"""
-interface UniformResourceIdentifiable @join__type(graph: CMS) {
-  """
-  The unique resource identifier path
-  """
+"""Any node that has a URI"""
+interface UniformResourceIdentifiable
+  @join__type(graph: CMS)
+{
+  """The unique resource identifier path"""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 }
 
-"""
-Input for the UpdateCategory mutation
-"""
-input UpdateCategoryInput @join__type(graph: CMS) {
-  """
-  The slug that the category will be an alias of
-  """
+"""Input for the UpdateCategory mutation"""
+input UpdateCategoryInput
+  @join__type(graph: CMS)
+{
+  """The slug that the category will be an alias of"""
   aliasOf: String
 
   """
@@ -20927,25 +15459,17 @@ input UpdateCategoryInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The description of the category object
-  """
+  """The description of the category object"""
   description: String
 
-  """
-  The ID of the category object to update
-  """
+  """The ID of the category object to update"""
   id: ID!
   language: LanguageCodeEnum
 
-  """
-  The name of the category object to mutate
-  """
+  """The name of the category object to mutate"""
   name: String
 
-  """
-  The ID of the category that should be set as the parent
-  """
+  """The ID of the category that should be set as the parent"""
   parentId: ID
 
   """
@@ -20954,13 +15478,11 @@ input UpdateCategoryInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-The payload for the UpdateCategory mutation
-"""
-type UpdateCategoryPayload @join__type(graph: CMS) {
-  """
-  The created category
-  """
+"""The payload for the UpdateCategory mutation"""
+type UpdateCategoryPayload
+  @join__type(graph: CMS)
+{
+  """The created category"""
   category: Category
 
   """
@@ -20969,10 +15491,10 @@ type UpdateCategoryPayload @join__type(graph: CMS) {
   clientMutationId: String
 }
 
-"""
-Input for the updateCollection mutation
-"""
-input UpdateCollectionInput @join__type(graph: CMS) {
+"""Input for the updateCollection mutation"""
+input UpdateCollectionInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -20983,9 +15505,7 @@ input UpdateCollectionInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the collection object
-  """
+  """The ID of the collection object"""
   id: ID!
   language: LanguageCodeEnum
 
@@ -20994,64 +15514,46 @@ input UpdateCollectionInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the updateCollection mutation
-"""
-type UpdateCollectionPayload @join__type(graph: CMS) {
+"""The payload for the updateCollection mutation"""
+type UpdateCollectionPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   collection: Collection
 }
 
-"""
-Input for the updateComment mutation
-"""
-input UpdateCommentInput @join__type(graph: CMS) {
-  """
-  The approval status of the comment.
-  """
+"""Input for the updateComment mutation"""
+input UpdateCommentInput
+  @join__type(graph: CMS)
+{
+  """The approval status of the comment."""
   approved: String
 
-  """
-  The name of the comment's author.
-  """
+  """The name of the comment's author."""
   author: String
 
-  """
-  The email of the comment's author.
-  """
+  """The email of the comment's author."""
   authorEmail: String
 
-  """
-  The url of the comment's author.
-  """
+  """The url of the comment's author."""
   authorUrl: String
 
   """
@@ -21059,14 +15561,10 @@ input UpdateCommentInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The ID of the post object the comment belongs to.
-  """
+  """The ID of the post object the comment belongs to."""
   commentOn: Int
 
-  """
-  Content of the comment.
-  """
+  """Content of the comment."""
   content: String
 
   """
@@ -21074,34 +15572,26 @@ input UpdateCommentInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the comment being updated.
-  """
+  """The ID of the comment being updated."""
   id: ID!
 
-  """
-  Parent comment of current comment.
-  """
+  """Parent comment of current comment."""
   parent: ID
 
-  """
-  Type of comment.
-  """
+  """Type of comment."""
   type: String
 }
 
-"""
-The payload for the updateComment mutation
-"""
-type UpdateCommentPayload @join__type(graph: CMS) {
+"""The payload for the updateComment mutation"""
+type UpdateCommentPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The comment that was created
-  """
+  """The comment that was created"""
   comment: Comment
 
   """
@@ -21110,10 +15600,10 @@ type UpdateCommentPayload @join__type(graph: CMS) {
   success: Boolean
 }
 
-"""
-Input for the updateContact mutation
-"""
-input UpdateContactInput @join__type(graph: CMS) {
+"""Input for the updateContact mutation"""
+input UpdateContactInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -21124,9 +15614,7 @@ input UpdateContactInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the contact object
-  """
+  """The ID of the contact object"""
   id: ID!
   language: LanguageCodeEnum
 
@@ -21135,46 +15623,36 @@ input UpdateContactInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the updateContact mutation
-"""
-type UpdateContactPayload @join__type(graph: CMS) {
+"""The payload for the updateContact mutation"""
+type UpdateContactPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   contact: Contact
 }
 
-"""
-Input for the updateLandingPage mutation
-"""
-input UpdateLandingPageInput @join__type(graph: CMS) {
+"""Input for the updateLandingPage mutation"""
+input UpdateLandingPageInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -21185,9 +15663,7 @@ input UpdateLandingPageInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the landingPage object
-  """
+  """The ID of the landingPage object"""
   id: ID!
   language: LanguageCodeEnum
 
@@ -21196,59 +15672,43 @@ input UpdateLandingPageInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the updateLandingPage mutation
-"""
-type UpdateLandingPagePayload @join__type(graph: CMS) {
+"""The payload for the updateLandingPage mutation"""
+type UpdateLandingPagePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   landingPage: LandingPage
 }
 
-"""
-Input for the updateMediaItem mutation
-"""
-input UpdateMediaItemInput @join__type(graph: CMS) {
-  """
-  Alternative text to display when mediaItem is not displayed
-  """
+"""Input for the updateMediaItem mutation"""
+input UpdateMediaItemInput
+  @join__type(graph: CMS)
+{
+  """Alternative text to display when mediaItem is not displayed"""
   altText: String
 
-  """
-  The userId to assign as the author of the mediaItem
-  """
+  """The userId to assign as the author of the mediaItem"""
   authorId: ID
 
-  """
-  The caption for the mediaItem
-  """
+  """The caption for the mediaItem"""
   caption: String
 
   """
@@ -21256,90 +15716,62 @@ input UpdateMediaItemInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The comment status for the mediaItem
-  """
+  """The comment status for the mediaItem"""
   commentStatus: String
 
-  """
-  The date of the mediaItem
-  """
+  """The date of the mediaItem"""
   date: String
 
-  """
-  The date (in GMT zone) of the mediaItem
-  """
+  """The date (in GMT zone) of the mediaItem"""
   dateGmt: String
 
-  """
-  Description of the mediaItem
-  """
+  """Description of the mediaItem"""
   description: String
 
-  """
-  The file name of the mediaItem
-  """
+  """The file name of the mediaItem"""
   filePath: String
 
-  """
-  The file type of the mediaItem
-  """
+  """The file type of the mediaItem"""
   fileType: MimeTypeEnum
 
-  """
-  The ID of the mediaItem object
-  """
+  """The ID of the mediaItem object"""
   id: ID!
   language: LanguageCodeEnum
 
-  """
-  The WordPress post ID or the graphQL postId of the parent object
-  """
+  """The WordPress post ID or the graphQL postId of the parent object"""
   parentId: ID
 
-  """
-  The ping status for the mediaItem
-  """
+  """The ping status for the mediaItem"""
   pingStatus: String
 
-  """
-  The slug of the mediaItem
-  """
+  """The slug of the mediaItem"""
   slug: String
 
-  """
-  The status of the mediaItem
-  """
+  """The status of the mediaItem"""
   status: MediaItemStatusEnum
 
-  """
-  The title of the mediaItem
-  """
+  """The title of the mediaItem"""
   title: String
 }
 
-"""
-The payload for the updateMediaItem mutation
-"""
-type UpdateMediaItemPayload @join__type(graph: CMS) {
+"""The payload for the updateMediaItem mutation"""
+type UpdateMediaItemPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The MediaItem object mutation type.
-  """
+  """The MediaItem object mutation type."""
   mediaItem: MediaItem
 }
 
-"""
-Input for the updatePage mutation
-"""
-input UpdatePageInput @join__type(graph: CMS) {
-  """
-  The userId to assign as the author of the object
-  """
+"""Input for the updatePage mutation"""
+input UpdatePageInput
+  @join__type(graph: CMS)
+{
+  """The userId to assign as the author of the object"""
   authorId: ID
 
   """
@@ -21347,9 +15779,7 @@ input UpdatePageInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The content of the object
-  """
+  """The content of the object"""
   content: String
 
   """
@@ -21357,9 +15787,7 @@ input UpdatePageInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the page object
-  """
+  """The ID of the page object"""
   id: ID!
   language: LanguageCodeEnum
 
@@ -21368,54 +15796,40 @@ input UpdatePageInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The ID of the parent object
-  """
+  """The ID of the parent object"""
   parentId: ID
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the updatePage mutation
-"""
-type UpdatePagePayload @join__type(graph: CMS) {
+"""The payload for the updatePage mutation"""
+type UpdatePagePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   page: Page
 }
 
-"""
-Input for the UpdatePostFormat mutation
-"""
-input UpdatePostFormatInput @join__type(graph: CMS) {
-  """
-  The slug that the post_format will be an alias of
-  """
+"""Input for the UpdatePostFormat mutation"""
+input UpdatePostFormatInput
+  @join__type(graph: CMS)
+{
+  """The slug that the post_format will be an alias of"""
   aliasOf: String
 
   """
@@ -21423,19 +15837,13 @@ input UpdatePostFormatInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The description of the post_format object
-  """
+  """The description of the post_format object"""
   description: String
 
-  """
-  The ID of the postFormat object to update
-  """
+  """The ID of the postFormat object to update"""
   id: ID!
 
-  """
-  The name of the post_format object to mutate
-  """
+  """The name of the post_format object to mutate"""
   name: String
 
   """
@@ -21444,33 +15852,27 @@ input UpdatePostFormatInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-The payload for the UpdatePostFormat mutation
-"""
-type UpdatePostFormatPayload @join__type(graph: CMS) {
+"""The payload for the UpdatePostFormat mutation"""
+type UpdatePostFormatPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The created post_format
-  """
+  """The created post_format"""
   postFormat: PostFormat
 }
 
-"""
-Input for the updatePost mutation
-"""
-input UpdatePostInput @join__type(graph: CMS) {
-  """
-  The userId to assign as the author of the object
-  """
+"""Input for the updatePost mutation"""
+input UpdatePostInput
+  @join__type(graph: CMS)
+{
+  """The userId to assign as the author of the object"""
   authorId: ID
 
-  """
-  Set connections between the post and categories
-  """
+  """Set connections between the post and categories"""
   categories: PostCategoriesInput
 
   """
@@ -21478,9 +15880,7 @@ input UpdatePostInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The content of the object
-  """
+  """The content of the object"""
   content: String
 
   """
@@ -21488,9 +15888,7 @@ input UpdatePostInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the post object
-  """
+  """The ID of the post object"""
   id: ID!
   language: LanguageCodeEnum
 
@@ -21499,64 +15897,48 @@ input UpdatePostInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  Set connections between the post and postFormats
-  """
+  """Set connections between the post and postFormats"""
   postFormats: PostPostFormatsInput
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  Set connections between the post and tags
-  """
+  """Set connections between the post and tags"""
   tags: PostTagsInput
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the updatePost mutation
-"""
-type UpdatePostPayload @join__type(graph: CMS) {
+"""The payload for the updatePost mutation"""
+type UpdatePostPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   post: Post
 }
 
-"""
-Input for the updateRelease mutation
-"""
-input UpdateReleaseInput @join__type(graph: CMS) {
+"""Input for the updateRelease mutation"""
+input UpdateReleaseInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The content of the object
-  """
+  """The content of the object"""
   content: String
 
   """
@@ -21564,9 +15946,7 @@ input UpdateReleaseInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the release object
-  """
+  """The ID of the release object"""
   id: ID!
   language: LanguageCodeEnum
 
@@ -21575,54 +15955,42 @@ input UpdateReleaseInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the updateRelease mutation
-"""
-type UpdateReleasePayload @join__type(graph: CMS) {
+"""The payload for the updateRelease mutation"""
+type UpdateReleasePayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   release: Release
 }
 
-"""
-Input for the updateSettings mutation
-"""
-input UpdateSettingsInput @join__type(graph: CMS) {
+"""Input for the updateSettings mutation"""
+input UpdateSettingsInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  Salli uusien artikkelien kommentointi.
-  """
+  """Salli uusien artikkelien kommentointi."""
   discussionSettingsDefaultCommentStatus: String
 
   """
@@ -21630,69 +15998,45 @@ input UpdateSettingsInput @join__type(graph: CMS) {
   """
   discussionSettingsDefaultPingStatus: String
 
-  """
-  Muoto kaikille päivämäärän merkkijonoille.
-  """
+  """Muoto kaikille päivämäärän merkkijonoille."""
   generalSettingsDateFormat: String
 
-  """
-  Sivuston kuvaus.
-  """
+  """Sivuston kuvaus."""
   generalSettingsDescription: String
 
-  """
-  WordPressin kieli- ja maakoodi.
-  """
+  """WordPressin kieli- ja maakoodi."""
   generalSettingsLanguage: String
 
-  """
-  Viikonpäivän numero josta viikko alkaa.
-  """
+  """Viikonpäivän numero josta viikko alkaa."""
   generalSettingsStartOfWeek: Int
 
-  """
-  Muoto kaikille kellonajan merkkijonoille.
-  """
+  """Muoto kaikille kellonajan merkkijonoille."""
   generalSettingsTimeFormat: String
 
-  """
-  Kaupunki samalla aikavyöhykkeellä kuin sinä.
-  """
+  """Kaupunki samalla aikavyöhykkeellä kuin sinä."""
   generalSettingsTimezone: String
 
-  """
-  Sivuston otsikko.
-  """
+  """Sivuston otsikko."""
   generalSettingsTitle: String
 
-  """
-  Näytä enintään
-  """
+  """Näytä enintään"""
   readingSettingsPostsPerPage: Int
 
-  """
-  Oletuskategoria artikkeleille.
-  """
+  """Oletuskategoria artikkeleille."""
   writingSettingsDefaultCategory: Int
 
-  """
-  Artikkelisivujen oletusmuoto.
-  """
+  """Artikkelisivujen oletusmuoto."""
   writingSettingsDefaultPostFormat: String
 
-  """
-  Muunna hymiöt kuviksi.
-  """
+  """Muunna hymiöt kuviksi."""
   writingSettingsUseSmilies: Boolean
 }
 
-"""
-The payload for the updateSettings mutation
-"""
-type UpdateSettingsPayload @join__type(graph: CMS) {
-  """
-  Update all settings.
-  """
+"""The payload for the updateSettings mutation"""
+type UpdateSettingsPayload
+  @join__type(graph: CMS)
+{
+  """Update all settings."""
   allSettings: Settings
 
   """
@@ -21700,34 +16044,24 @@ type UpdateSettingsPayload @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  Update the DiscussionSettings setting.
-  """
+  """Update the DiscussionSettings setting."""
   discussionSettings: DiscussionSettings
 
-  """
-  Update the GeneralSettings setting.
-  """
+  """Update the GeneralSettings setting."""
   generalSettings: GeneralSettings
 
-  """
-  Update the ReadingSettings setting.
-  """
+  """Update the ReadingSettings setting."""
   readingSettings: ReadingSettings
 
-  """
-  Update the WritingSettings setting.
-  """
+  """Update the WritingSettings setting."""
   writingSettings: WritingSettings
 }
 
-"""
-Input for the UpdateTag mutation
-"""
-input UpdateTagInput @join__type(graph: CMS) {
-  """
-  The slug that the post_tag will be an alias of
-  """
+"""Input for the UpdateTag mutation"""
+input UpdateTagInput
+  @join__type(graph: CMS)
+{
+  """The slug that the post_tag will be an alias of"""
   aliasOf: String
 
   """
@@ -21735,20 +16069,14 @@ input UpdateTagInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  The description of the post_tag object
-  """
+  """The description of the post_tag object"""
   description: String
 
-  """
-  The ID of the tag object to update
-  """
+  """The ID of the tag object to update"""
   id: ID!
   language: LanguageCodeEnum
 
-  """
-  The name of the post_tag object to mutate
-  """
+  """The name of the post_tag object to mutate"""
   name: String
 
   """
@@ -21757,25 +16085,23 @@ input UpdateTagInput @join__type(graph: CMS) {
   slug: String
 }
 
-"""
-The payload for the UpdateTag mutation
-"""
-type UpdateTagPayload @join__type(graph: CMS) {
+"""The payload for the UpdateTag mutation"""
+type UpdateTagPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The created post_tag
-  """
+  """The created post_tag"""
   tag: Tag
 }
 
-"""
-Input for the updateTranslation mutation
-"""
-input UpdateTranslationInput @join__type(graph: CMS) {
+"""Input for the updateTranslation mutation"""
+input UpdateTranslationInput
+  @join__type(graph: CMS)
+{
   """
   This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
@@ -21786,9 +16112,7 @@ input UpdateTranslationInput @join__type(graph: CMS) {
   """
   date: String
 
-  """
-  The ID of the translation object
-  """
+  """The ID of the translation object"""
   id: ID!
 
   """
@@ -21796,49 +16120,37 @@ input UpdateTranslationInput @join__type(graph: CMS) {
   """
   menuOrder: Int
 
-  """
-  The password used to protect the content of the object
-  """
+  """The password used to protect the content of the object"""
   password: String
 
-  """
-  The slug of the object
-  """
+  """The slug of the object"""
   slug: String
 
-  """
-  The status of the object
-  """
+  """The status of the object"""
   status: PostStatusEnum
 
-  """
-  The title of the object
-  """
+  """The title of the object"""
   title: String
 }
 
-"""
-The payload for the updateTranslation mutation
-"""
-type UpdateTranslationPayload @join__type(graph: CMS) {
+"""The payload for the updateTranslation mutation"""
+type UpdateTranslationPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The Post object mutation type.
-  """
+  """The Post object mutation type."""
   translation: Translation
 }
 
-"""
-Input for the updateUser mutation
-"""
-input UpdateUserInput @join__type(graph: CMS) {
-  """
-  User's AOL IM account.
-  """
+"""Input for the updateUser mutation"""
+input UpdateUserInput
+  @join__type(graph: CMS)
+{
+  """User's AOL IM account."""
   aim: String
 
   """
@@ -21846,9 +16158,7 @@ input UpdateUserInput @join__type(graph: CMS) {
   """
   clientMutationId: String
 
-  """
-  A string containing content about the user.
-  """
+  """A string containing content about the user."""
   description: String
 
   """
@@ -21856,34 +16166,22 @@ input UpdateUserInput @join__type(graph: CMS) {
   """
   displayName: String
 
-  """
-  A string containing the user's email address.
-  """
+  """A string containing the user's email address."""
   email: String
 
-  """
-  The user's first name.
-  """
+  """	The user's first name."""
   firstName: String
 
-  """
-  The ID of the user
-  """
+  """The ID of the user"""
   id: ID!
 
-  """
-  User's Jabber account.
-  """
+  """User's Jabber account."""
   jabber: String
 
-  """
-  The user's last name.
-  """
+  """The user's last name."""
   lastName: String
 
-  """
-  User's locale.
-  """
+  """User's locale."""
   locale: String
 
   """
@@ -21891,19 +16189,13 @@ input UpdateUserInput @join__type(graph: CMS) {
   """
   nicename: String
 
-  """
-  The user's nickname, defaults to the user's username.
-  """
+  """The user's nickname, defaults to the user's username."""
   nickname: String
 
-  """
-  A string that contains the plain text password for the user.
-  """
+  """A string that contains the plain text password for the user."""
   password: String
 
-  """
-  The date the user registered. Format is Y-m-d H:i:s.
-  """
+  """The date the user registered. Format is Y-m-d H:i:s."""
   registered: String
 
   """
@@ -21911,46 +16203,37 @@ input UpdateUserInput @join__type(graph: CMS) {
   """
   richEditing: String
 
-  """
-  An array of roles to be assigned to the user.
-  """
+  """An array of roles to be assigned to the user."""
   roles: [String]
 
-  """
-  A string containing the user's URL for the user's web site.
-  """
+  """A string containing the user's URL for the user's web site."""
   websiteUrl: String
 
-  """
-  User's Yahoo IM account.
-  """
+  """User's Yahoo IM account."""
   yim: String
 }
 
-"""
-The payload for the updateUser mutation
-"""
-type UpdateUserPayload @join__type(graph: CMS) {
+"""The payload for the updateUser mutation"""
+type UpdateUserPayload
+  @join__type(graph: CMS)
+{
   """
   If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
   """
   clientMutationId: String
 
-  """
-  The User object mutation type.
-  """
+  """The User object mutation type."""
   user: User
 }
 
-"""
-A User object
-"""
+"""A User object"""
 type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseIdentifier
   @join__implements(graph: CMS, interface: "Node")
   @join__implements(graph: CMS, interface: "UniformResourceIdentifiable")
   @join__implements(graph: CMS, interface: "Commenter")
   @join__implements(graph: CMS, interface: "DatabaseIdentifier")
-  @join__type(graph: CMS) {
+  @join__type(graph: CMS)
+{
   """
   Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.
   """
@@ -21965,9 +16248,7 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     forceDefault: Boolean
 
-    """
-    The rating level of the avatar.
-    """
+    """The rating level of the avatar."""
     rating: AvatarRatingEnum
   ): Avatar
 
@@ -21976,23 +16257,15 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   """
   capKey: String
 
-  """
-  A list of capabilities (permissions) granted to the user
-  """
+  """A list of capabilities (permissions) granted to the user"""
   capabilities: [String]
 
-  """
-  Connection between the User type and the Comment type
-  """
+  """Connection between the User type and the Comment type"""
   comments(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22005,20 +16278,14 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: UserToCommentConnectionWhereArgs
   ): UserToCommentConnection
 
-  """
-  Identifies the primary key from the database.
-  """
+  """Identifies the primary key from the database."""
   databaseId: Int!
 
-  """
-  Description of the user.
-  """
+  """Description of the user."""
   description: String
 
   """
@@ -22026,18 +16293,12 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   """
   email: String
 
-  """
-  Connection between the User type and the EnqueuedScript type
-  """
+  """Connection between the User type and the EnqueuedScript type"""
   enqueuedScripts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22051,18 +16312,12 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     before: String
   ): UserToEnqueuedScriptConnection
 
-  """
-  Connection between the User type and the EnqueuedStylesheet type
-  """
+  """Connection between the User type and the EnqueuedStylesheet type"""
   enqueuedStylesheets(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22086,24 +16341,16 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   """
   firstName: String
 
-  """
-  The globally unique identifier for the user object.
-  """
+  """The globally unique identifier for the user object."""
   id: ID!
 
-  """
-  Whether the node is a Content Node
-  """
+  """Whether the node is a Content Node"""
   isContentNode: Boolean!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  Whether the node is a Term
-  """
+  """Whether the node is a Term"""
   isTermNode: Boolean!
 
   """
@@ -22116,18 +16363,12 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   """
   locale: String
 
-  """
-  Connection between the User type and the mediaItem type
-  """
+  """Connection between the User type and the mediaItem type"""
   mediaItems(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22140,9 +16381,7 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: UserToMediaItemConnectionWhereArgs
   ): UserToMediaItemConnection
 
@@ -22156,23 +16395,15 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   """
   nicename: String
 
-  """
-  Nickname of the user.
-  """
+  """Nickname of the user."""
   nickname: String
 
-  """
-  Connection between the User type and the page type
-  """
+  """Connection between the User type and the page type"""
   pages(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22185,24 +16416,16 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: UserToPageConnectionWhereArgs
   ): UserToPageConnection
 
-  """
-  Connection between the User type and the post type
-  """
+  """Connection between the User type and the post type"""
   posts(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22215,9 +16438,7 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: UserToPostConnectionWhereArgs
   ): UserToPostConnection
 
@@ -22226,18 +16447,12 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   """
   registeredDate: String
 
-  """
-  Connection between the User and Revisions authored by the user
-  """
+  """Connection between the User and Revisions authored by the user"""
   revisions(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22250,24 +16465,16 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     before: String
 
-    """
-    Arguments for filtering the connection
-    """
+    """Arguments for filtering the connection"""
     where: UserToContentRevisionUnionConnectionWhereArgs
   ): UserToContentRevisionUnionConnection
 
-  """
-  Connection between the User type and the UserRole type
-  """
+  """Connection between the User type and the UserRole type"""
   roles(
-    """
-    The number of items to return after the referenced "after" cursor
-    """
+    """The number of items to return after the referenced "after" cursor"""
     first: Int
 
-    """
-    The number of items to return before the referenced "before" cursor
-    """
+    """The number of items to return before the referenced "before" cursor"""
     last: Int
 
     """
@@ -22286,19 +16493,13 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   """
   slug: String
 
-  """
-  The unique resource identifier path
-  """
+  """The unique resource identifier path"""
   uri: String
 
-  """
-  A website url that is associated with the user.
-  """
+  """A website url that is associated with the user."""
   url: String
 
-  """
-  The Id of the user. Equivalent to WP_User-&gt;ID
-  """
+  """The Id of the user. Equivalent to WP_User-&gt;ID"""
   userId: Int @deprecated(reason: "Deprecated in favor of the databaseId field")
 
   """
@@ -22310,272 +16511,183 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
 """
 The Type of Identifier used to fetch a single User node. To be used along with the "id" field. Default is "ID".
 """
-enum UserNodeIdTypeEnum @join__type(graph: CMS) {
-  """
-  The Database ID for the node
-  """
+enum UserNodeIdTypeEnum
+  @join__type(graph: CMS)
+{
+  """The Database ID for the node"""
   DATABASE_ID
 
-  """
-  The Email of the User
-  """
+  """The Email of the User"""
   EMAIL
 
-  """
-  The hashed Global ID
-  """
+  """The hashed Global ID"""
   ID
 
-  """
-  The slug of the User
-  """
+  """The slug of the User"""
   SLUG
 
-  """
-  The URI for the node
-  """
+  """The URI for the node"""
   URI
 
-  """
-  The username the User uses to login with
-  """
+  """The username the User uses to login with"""
   USERNAME
 }
 
-"""
-A user role object
-"""
+"""A user role object"""
 type UserRole implements Node
   @join__implements(graph: CMS, interface: "Node")
-  @join__type(graph: CMS) {
-  """
-  The capabilities that belong to this role
-  """
+  @join__type(graph: CMS)
+{
+  """The capabilities that belong to this role"""
   capabilities: [String]
 
-  """
-  The display name of the role
-  """
+  """The display name of the role"""
   displayName: String
 
-  """
-  The globally unique identifier for the user role object.
-  """
+  """The globally unique identifier for the user role object."""
   id: ID!
 
-  """
-  Whether the object is restricted from the current viewer
-  """
+  """Whether the object is restricted from the current viewer"""
   isRestricted: Boolean
 
-  """
-  The registered name of the role
-  """
+  """The registered name of the role"""
   name: String
 }
 
-"""
-Names of available user roles
-"""
-enum UserRoleEnum @join__type(graph: CMS) {
-  """
-  User role with specific capabilities
-  """
+"""Names of available user roles"""
+enum UserRoleEnum
+  @join__type(graph: CMS)
+{
+  """User role with specific capabilities"""
   ADMINISTRATOR
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   AUTHOR
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   CONTRIBUTOR
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   EDITOR
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   HEADLESS_CMS_ADMIN
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   HEADLESS_CMS_CONTRIBUTOR
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   HEADLESS_CMS_EDITOR
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   HEADLESS_CMS_VIEWER
 
-  """
-  User role with specific capabilities
-  """
+  """User role with specific capabilities"""
   SUBSCRIBER
 }
 
-"""
-Field to order the connection by
-"""
-enum UsersConnectionOrderbyEnum @join__type(graph: CMS) {
-  """
-  Order by display name
-  """
+"""Field to order the connection by"""
+enum UsersConnectionOrderbyEnum
+  @join__type(graph: CMS)
+{
+  """Order by display name"""
   DISPLAY_NAME
 
-  """
-  Order by email address
-  """
+  """Order by email address"""
   EMAIL
 
-  """
-  Order by login
-  """
+  """Order by login"""
   LOGIN
 
-  """
-  Preserve the login order given in the LOGIN_IN array
-  """
+  """Preserve the login order given in the LOGIN_IN array"""
   LOGIN_IN
 
-  """
-  Order by nice name
-  """
+  """Order by nice name"""
   NICE_NAME
 
-  """
-  Preserve the nice name order given in the NICE_NAME_IN array
-  """
+  """Preserve the nice name order given in the NICE_NAME_IN array"""
   NICE_NAME_IN
 
-  """
-  Order by registration date
-  """
+  """Order by registration date"""
   REGISTERED
 
-  """
-  Order by URL
-  """
+  """Order by URL"""
   URL
 }
 
-"""
-Options for ordering the connection
-"""
-input UsersConnectionOrderbyInput @join__type(graph: CMS) {
-  """
-  The field name used to sort the results.
-  """
+"""Options for ordering the connection"""
+input UsersConnectionOrderbyInput
+  @join__type(graph: CMS)
+{
+  """The field name used to sort the results."""
   field: UsersConnectionOrderbyEnum!
 
-  """
-  The cardinality of the order of the connection
-  """
+  """The cardinality of the order of the connection"""
   order: OrderEnum
 }
 
-"""
-Column used for searching for users.
-"""
-enum UsersConnectionSearchColumnEnum @join__type(graph: CMS) {
-  """
-  The user's email address.
-  """
+"""Column used for searching for users."""
+enum UsersConnectionSearchColumnEnum
+  @join__type(graph: CMS)
+{
+  """The user's email address."""
   EMAIL
 
-  """
-  The globally unique ID.
-  """
+  """The globally unique ID."""
   ID
 
-  """
-  The username the User uses to login with.
-  """
+  """The username the User uses to login with."""
   LOGIN
 
-  """
-  A URL-friendly name for the user. The default is the user's username.
-  """
+  """A URL-friendly name for the user. The default is the user's username."""
   NICENAME
 
-  """
-  The URL of the users website.
-  """
+  """The URL of the users website."""
   URL
 }
 
-"""
-Connection between the User type and the Comment type
-"""
-type UserToCommentConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToCommentConnection connection
-  """
+"""Connection between the User type and the Comment type"""
+type UserToCommentConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToCommentConnection connection"""
   edges: [UserToCommentConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Comment]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToCommentConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToCommentConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Comment
 }
 
-"""
-Arguments for filtering the UserToCommentConnection connection
-"""
-input UserToCommentConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  Comment author email address.
-  """
+"""Arguments for filtering the UserToCommentConnection connection"""
+input UserToCommentConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """Comment author email address."""
   authorEmail: String
 
-  """
-  Array of author IDs to include comments for.
-  """
+  """Array of author IDs to include comments for."""
   authorIn: [ID]
 
-  """
-  Array of author IDs to exclude comments for.
-  """
+  """Array of author IDs to exclude comments for."""
   authorNotIn: [ID]
 
-  """
-  Comment author URL.
-  """
+  """Comment author URL."""
   authorUrl: String
 
-  """
-  Array of comment IDs to include.
-  """
+  """Array of comment IDs to include."""
   commentIn: [ID]
 
   """
@@ -22583,59 +16695,37 @@ input UserToCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   commentNotIn: [ID]
 
-  """
-  Include comments of a given type.
-  """
+  """Include comments of a given type."""
   commentType: String
 
-  """
-  Include comments from a given array of comment types.
-  """
+  """Include comments from a given array of comment types."""
   commentTypeIn: [String]
 
-  """
-  Exclude comments from a given array of comment types.
-  """
+  """Exclude comments from a given array of comment types."""
   commentTypeNotIn: String
 
-  """
-  Content object author ID to limit results by.
-  """
+  """Content object author ID to limit results by."""
   contentAuthor: [ID]
 
-  """
-  Array of author IDs to retrieve comments for.
-  """
+  """Array of author IDs to retrieve comments for."""
   contentAuthorIn: [ID]
 
-  """
-  Array of author IDs *not* to retrieve comments for.
-  """
+  """Array of author IDs *not* to retrieve comments for."""
   contentAuthorNotIn: [ID]
 
-  """
-  Limit results to those affiliated with a given content object ID.
-  """
+  """Limit results to those affiliated with a given content object ID."""
   contentId: ID
 
-  """
-  Array of content object IDs to include affiliated comments for.
-  """
+  """Array of content object IDs to include affiliated comments for."""
   contentIdIn: [ID]
 
-  """
-  Array of content object IDs to exclude affiliated comments for.
-  """
+  """Array of content object IDs to exclude affiliated comments for."""
   contentIdNotIn: [ID]
 
-  """
-  Content object name to retrieve affiliated comments for.
-  """
+  """Content object name to retrieve affiliated comments for."""
   contentName: String
 
-  """
-  Content Object parent ID to retrieve affiliated comments for.
-  """
+  """Content Object parent ID to retrieve affiliated comments for."""
   contentParent: Int
 
   """
@@ -22653,99 +16743,69 @@ input UserToCommentConnectionWhereArgs @join__type(graph: CMS) {
   """
   includeUnapproved: [ID]
 
-  """
-  Karma score to retrieve matching comments for.
-  """
+  """Karma score to retrieve matching comments for."""
   karma: Int
 
-  """
-  The cardinality of the order of the connection
-  """
+  """The cardinality of the order of the connection"""
   order: OrderEnum
 
-  """
-  Field to order the comments by.
-  """
+  """Field to order the comments by."""
   orderby: CommentsConnectionOrderbyEnum
 
-  """
-  Parent ID of comment to retrieve children of.
-  """
+  """Parent ID of comment to retrieve children of."""
   parent: Int
 
-  """
-  Array of parent IDs of comments to retrieve children for.
-  """
+  """Array of parent IDs of comments to retrieve children for."""
   parentIn: [ID]
 
-  """
-  Array of parent IDs of comments *not* to retrieve children for.
-  """
+  """Array of parent IDs of comments *not* to retrieve children for."""
   parentNotIn: [ID]
 
-  """
-  Search term(s) to retrieve matching comments for.
-  """
+  """Search term(s) to retrieve matching comments for."""
   search: String
 
-  """
-  Comment status to limit results by.
-  """
+  """Comment status to limit results by."""
   status: String
 
-  """
-  Include comments for a specific user ID.
-  """
+  """Include comments for a specific user ID."""
   userId: ID
 }
 
-"""
-Connection between the User type and the ContentRevisionUnion type
-"""
-type UserToContentRevisionUnionConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToContentRevisionUnionConnection connection
-  """
+"""Connection between the User type and the ContentRevisionUnion type"""
+type UserToContentRevisionUnionConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToContentRevisionUnionConnection connection"""
   edges: [UserToContentRevisionUnionConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [ContentRevisionUnion]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToContentRevisionUnionConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToContentRevisionUnionConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ContentRevisionUnion
 }
 
 """
 Arguments for filtering the UserToContentRevisionUnionConnection connection
 """
-input UserToContentRevisionUnionConnectionWhereArgs @join__type(graph: CMS) {
-  """
-  The Types of content to filter
-  """
+input UserToContentRevisionUnionConnectionWhereArgs
+  @join__type(graph: CMS)
+{
+  """The Types of content to filter"""
   contentTypes: [ContentTypeEnum]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -22753,29 +16813,19 @@ input UserToContentRevisionUnionConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -22783,174 +16833,122 @@ input UserToContentRevisionUnionConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the User type and the EnqueuedScript type
-"""
-type UserToEnqueuedScriptConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToEnqueuedScriptConnection connection
-  """
+"""Connection between the User type and the EnqueuedScript type"""
+type UserToEnqueuedScriptConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToEnqueuedScriptConnection connection"""
   edges: [UserToEnqueuedScriptConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedScript]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToEnqueuedScriptConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToEnqueuedScriptConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedScript
 }
 
-"""
-Connection between the User type and the EnqueuedStylesheet type
-"""
-type UserToEnqueuedStylesheetConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToEnqueuedStylesheetConnection connection
-  """
+"""Connection between the User type and the EnqueuedStylesheet type"""
+type UserToEnqueuedStylesheetConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToEnqueuedStylesheetConnection connection"""
   edges: [UserToEnqueuedStylesheetConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [EnqueuedStylesheet]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToEnqueuedStylesheetConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToEnqueuedStylesheetConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: EnqueuedStylesheet
 }
 
-"""
-Connection between the User type and the mediaItem type
-"""
-type UserToMediaItemConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToMediaItemConnection connection
-  """
+"""Connection between the User type and the mediaItem type"""
+type UserToMediaItemConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToMediaItemConnection connection"""
   edges: [UserToMediaItemConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [MediaItem]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToMediaItemConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToMediaItemConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: MediaItem
 }
 
-"""
-Arguments for filtering the UserToMediaItemConnection connection
-"""
-input UserToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the UserToMediaItemConnection connection"""
+input UserToMediaItemConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -22958,9 +16956,7 @@ input UserToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -22968,29 +16964,19 @@ input UserToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -22998,104 +16984,72 @@ input UserToMediaItemConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the User type and the page type
-"""
-type UserToPageConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToPageConnection connection
-  """
+"""Connection between the User type and the page type"""
+type UserToPageConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToPageConnection connection"""
   edges: [UserToPageConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Page]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToPageConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToPageConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Page
 }
 
-"""
-Arguments for filtering the UserToPageConnection connection
-"""
-input UserToPageConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the UserToPageConnection connection"""
+input UserToPageConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -23103,9 +17057,7 @@ input UserToPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -23113,29 +17065,19 @@ input UserToPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -23143,104 +17085,72 @@ input UserToPageConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the User type and the post type
-"""
-type UserToPostConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToPostConnection connection
-  """
+"""Connection between the User type and the post type"""
+type UserToPostConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToPostConnection connection"""
   edges: [UserToPostConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [Post]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToPostConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToPostConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Post
 }
 
-"""
-Arguments for filtering the UserToPostConnection connection
-"""
-input UserToPostConnectionWhereArgs @join__type(graph: CMS) {
+"""Arguments for filtering the UserToPostConnection connection"""
+input UserToPostConnectionWhereArgs
+  @join__type(graph: CMS)
+{
   """
   The user that's connected as the author of the object. Use the userId for the author object.
   """
   author: Int
 
-  """
-  Find objects connected to author(s) in the array of author's userIds
-  """
+  """Find objects connected to author(s) in the array of author's userIds"""
   authorIn: [ID]
 
-  """
-  Find objects connected to the author by the author's nicename
-  """
+  """Find objects connected to the author by the author's nicename"""
   authorName: String
 
   """
@@ -23248,9 +17158,7 @@ input UserToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   authorNotIn: [ID]
 
-  """
-  Category ID
-  """
+  """Category ID"""
   categoryId: Int
 
   """
@@ -23258,9 +17166,7 @@ input UserToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryIn: [ID]
 
-  """
-  Use Category Slug
-  """
+  """Use Category Slug"""
   categoryName: String
 
   """
@@ -23268,9 +17174,7 @@ input UserToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   categoryNotIn: [ID]
 
-  """
-  Filter the connection based on dates
-  """
+  """Filter the connection based on dates"""
   dateQuery: DateQueryInput
 
   """
@@ -23278,29 +17182,19 @@ input UserToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   hasPassword: Boolean
 
-  """
-  Specific ID of the object
-  """
+  """Specific ID of the object"""
   id: Int
 
-  """
-  Array of IDs for the objects to retrieve
-  """
+  """Array of IDs for the objects to retrieve"""
   in: [ID]
 
-  """
-  Get objects with a specific mimeType property
-  """
+  """Get objects with a specific mimeType property"""
   mimeType: MimeTypeEnum
 
-  """
-  Slug / post_name of the object
-  """
+  """Slug / post_name of the object"""
   name: String
 
-  """
-  Specify objects to retrieve. Use slugs
-  """
+  """Specify objects to retrieve. Use slugs"""
   nameIn: [String]
 
   """
@@ -23308,118 +17202,80 @@ input UserToPostConnectionWhereArgs @join__type(graph: CMS) {
   """
   notIn: [ID]
 
-  """
-  What paramater to use to order the objects by.
-  """
+  """What paramater to use to order the objects by."""
   orderby: [PostObjectsConnectionOrderbyInput]
 
-  """
-  Use ID to return only children. Use 0 to return only top-level items
-  """
+  """Use ID to return only children. Use 0 to return only top-level items"""
   parent: ID
 
-  """
-  Specify objects whose parent is in an array
-  """
+  """Specify objects whose parent is in an array"""
   parentIn: [ID]
 
-  """
-  Specify posts whose parent is not in an array
-  """
+  """Specify posts whose parent is not in an array"""
   parentNotIn: [ID]
 
-  """
-  Show posts with a specific password.
-  """
+  """Show posts with a specific password."""
   password: String
 
-  """
-  Show Posts based on a keyword search
-  """
+  """Show Posts based on a keyword search"""
   search: String
 
-  """
-  Retrieve posts where post status is in an array.
-  """
+  """Retrieve posts where post status is in an array."""
   stati: [PostStatusEnum]
 
-  """
-  Show posts with a specific status.
-  """
+  """Show posts with a specific status."""
   status: PostStatusEnum
 
-  """
-  Tag Slug
-  """
+  """Tag Slug"""
   tag: String
 
-  """
-  Use Tag ID
-  """
+  """Use Tag ID"""
   tagId: String
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagIn: [ID]
 
-  """
-  Array of tag IDs, used to display objects from one tag OR another
-  """
+  """Array of tag IDs, used to display objects from one tag OR another"""
   tagNotIn: [ID]
 
-  """
-  Array of tag slugs, used to display objects from one tag OR another
-  """
+  """Array of tag slugs, used to display objects from one tag OR another"""
   tagSlugAnd: [String]
 
-  """
-  Array of tag slugs, used to exclude objects in specified tags
-  """
+  """Array of tag slugs, used to exclude objects in specified tags"""
   tagSlugIn: [String]
 
-  """
-  Title of the object
-  """
+  """Title of the object"""
   title: String
 }
 
-"""
-Connection between the User type and the UserRole type
-"""
-type UserToUserRoleConnection @join__type(graph: CMS) {
-  """
-  Edges for the UserToUserRoleConnection connection
-  """
+"""Connection between the User type and the UserRole type"""
+type UserToUserRoleConnection
+  @join__type(graph: CMS)
+{
+  """Edges for the UserToUserRoleConnection connection"""
   edges: [UserToUserRoleConnectionEdge]
 
-  """
-  The nodes of the connection, without the edges
-  """
+  """The nodes of the connection, without the edges"""
   nodes: [UserRole]
 
-  """
-  Information about pagination in a connection.
-  """
+  """Information about pagination in a connection."""
   pageInfo: WPPageInfo
 }
 
-"""
-An edge in a connection
-"""
-type UserToUserRoleConnectionEdge @join__type(graph: CMS) {
-  """
-  A cursor for use in pagination
-  """
+"""An edge in a connection"""
+type UserToUserRoleConnectionEdge
+  @join__type(graph: CMS)
+{
+  """A cursor for use in pagination"""
   cursor: String
 
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: UserRole
 }
 
-type Venue @join__type(graph: VENUES) {
+type Venue
+  @join__type(graph: VENUES)
+{
   addressLocality: String
   dataSource: String
   description: String
@@ -23436,81 +17292,61 @@ type Venue @join__type(graph: VENUES) {
   """
   This field is currently disabled because the Hauki integration is not enabled
   """
-  openingHours: [OpeningHour!]
-    @deprecated(
-      reason: "Hauki integration is currently disabled so this field can not be accessed"
-    )
+  openingHours: [OpeningHour!] @deprecated(reason: "Hauki integration is currently disabled so this field can not be accessed")
 
   """
   This field is currently disabled because the Hauki integration is not enabled
   """
-  isOpen: Boolean
-    @deprecated(
-      reason: "Hauki integration is currently disabled so this field can not be accessed"
-    )
+  isOpen: Boolean @deprecated(reason: "Hauki integration is currently disabled so this field can not be accessed")
   ontologyTree: [Ontology]!
   ontologyWords: [Ontology]!
   accessibilitySentences: [AccessibilitySentences]!
   connections: [Connection]!
 }
 
-"""
-TODO: combine beta.kultus Venue stuff with respa equipment type
-"""
-type VenueFacility @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: combine beta.kultus Venue stuff with respa equipment type"""
+type VenueFacility
+  @join__type(graph: UNIFIED_SEARCH)
+{
   meta: NodeMeta
   name: String!
   categories: [KeywordString!]
 }
 
-"""
-TODO: this comes from respa resource/unit types
-"""
-type VenueReservationPolicy @join__type(graph: UNIFIED_SEARCH) {
+"""TODO: this comes from respa resource/unit types"""
+type VenueReservationPolicy
+  @join__type(graph: UNIFIED_SEARCH)
+{
   todo: String
 }
 
-"""
-Information about pagination in a connection.
-"""
-type WPPageInfo @join__type(graph: CMS) {
-  """
-  When paginating forwards, the cursor to continue.
-  """
+"""Information about pagination in a connection."""
+type WPPageInfo
+  @join__type(graph: CMS)
+{
+  """When paginating forwards, the cursor to continue."""
   endCursor: String
 
-  """
-  When paginating forwards, are there more items?
-  """
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  """
-  When paginating backwards, are there more items?
-  """
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  """
-  When paginating backwards, the cursor to continue.
-  """
+  """When paginating backwards, the cursor to continue."""
   startCursor: String
 }
 
-"""
-The writing setting type
-"""
-type WritingSettings @join__type(graph: CMS) {
-  """
-  Oletuskategoria artikkeleille.
-  """
+"""The writing setting type"""
+type WritingSettings
+  @join__type(graph: CMS)
+{
+  """Oletuskategoria artikkeleille."""
   defaultCategory: Int
 
-  """
-  Artikkelisivujen oletusmuoto.
-  """
+  """Artikkelisivujen oletusmuoto."""
   defaultPostFormat: String
 
-  """
-  Muunna hymiöt kuviksi.
-  """
+  """Muunna hymiöt kuviksi."""
   useSmilies: Boolean
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14294,6 +14294,7 @@ __metadata:
     react-helsinki-headless-cms: "npm:1.0.0-alpha83"
     react-i18next: "npm:11.18.6"
     react-leaflet: "npm:4.2.0"
+    react-toastify: "npm:^9.0.3"
     require-from-string: "npm:2.0.2"
     rimraf: "npm:3.0.2"
     rollup: "npm:^2.79.1"


### PR DESCRIPTION
LIIKUNTA-340.
The CMS schema should finally be equal in all the staging CMS server instances.
Also, it seems that there is a new (module-) type for a carousel implementation
of sports locations.

NOTE: This should probably be merged (and so also deployed) in the main instead of `sports-locations` branch and #141. Like that the federation router is there when the actual app branch is reviewed.