### PR TITLE
feat: enable hauki for sports graphql queries

### DIFF
--- a/apps/sports-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/sports-helsinki/src/domain/app/AppConfig.ts
@@ -137,7 +137,7 @@ class AppConfig {
   }
 
   static get isHaukiEnabled() {
-    return false;
+    return true;
   }
 }
 

--- a/apps/sports-helsinki/src/domain/graphql/venue/venueQueryResolver.ts
+++ b/apps/sports-helsinki/src/domain/graphql/venue/venueQueryResolver.ts
@@ -1,0 +1,75 @@
+import { GraphQLError } from 'graphql';
+import { Sources } from '../../app/appConstants';
+import type { AnyObject, Context, Source } from '../../nextApi/types';
+import type { LiikuntaServerConfig } from '../createApolloServer';
+import createQueryResolver from '../createQueryResolver';
+import VenueHaukiIntegration from './instructions/VenueHaukiIntegration';
+import VenueLinkedIntegration from './instructions/VenueLinkedIntegration';
+import VenueOntologyEnricher from './instructions/VenueOntologyEnricher';
+import VenueResolver from './instructions/VenueResolver';
+import type VenueResolverIntegration from './instructions/VenueResolverIntegration';
+import VenueTprekIntegration from './instructions/VenueTprekIntegration';
+import parseVenueId, { IdParseError } from './parseVenueId';
+
+const resolvers: Map<Source, (config: LiikuntaServerConfig) => VenueResolver> =
+  new Map();
+resolvers.set(
+  Sources.TPREK,
+  (config) =>
+    new VenueResolver({
+      integrations: [
+        new VenueTprekIntegration({
+          enrichers: [new VenueOntologyEnricher()],
+        }),
+        config.haukiEnabled
+          ? new VenueHaukiIntegration({
+              getId: (id, source) => `${source}:${id}`,
+            })
+          : null,
+      ].filter((item) => !!item) as VenueResolverIntegration<AnyObject>[],
+    })
+);
+resolvers.set(
+  Sources.LINKED,
+  (config) =>
+    new VenueResolver({
+      integrations: [
+        new VenueLinkedIntegration({
+          enrichers: [],
+        }),
+        config.haukiEnabled
+          ? new VenueHaukiIntegration({
+              // I'm not sure if we can expect for this to always work
+              getId: (id) => `tprek:${id}`,
+            })
+          : null,
+      ].filter((item) => item) as VenueResolverIntegration<AnyObject>[],
+    })
+);
+
+async function resolver(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { id: idWithSource }: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { language, dataSources, haukiEnabled }: Context
+) {
+  const [source, id] = parseVenueId(idWithSource) ?? [];
+  const dataResolverFactory = source ? resolvers.get(source) ?? null : null;
+  const dataResolver = dataResolverFactory
+    ? dataResolverFactory({ haukiEnabled })
+    : null;
+
+  return id && source
+    ? dataResolver?.resolveVenue(id, source, { language, dataSources })
+    : null;
+}
+
+function onError(e: unknown) {
+  if (e instanceof IdParseError) {
+    throw new GraphQLError('Invalid ID parameter');
+  }
+}
+
+export default createQueryResolver(resolver, onError);

--- a/apps/sports-helsinki/src/domain/nextApi/types.ts
+++ b/apps/sports-helsinki/src/domain/nextApi/types.ts
@@ -1,0 +1,252 @@
+import type { UrlObject } from 'url';
+
+import type { OperationVariables, QueryResult } from '@apollo/client';
+
+import type {
+  TimeResourceState,
+  UnifiedSearchVenue,
+} from 'events-helsinki-components';
+import type { Sources } from '../../domain/app/appConstants';
+import type { PageInfoFragment } from '../../domain/nextApi/pageInfoFragment';
+
+export type Locale = 'fi' | 'sv' | 'en';
+
+export type MenuItem = {
+  id: string;
+  order: number;
+  path: string;
+  target: string;
+  title: string;
+  url: string;
+  label: string;
+};
+
+export type NavigationItem = MenuItem;
+
+export type Language = {
+  id: string;
+  name: string;
+  slug: string;
+  code: string;
+  locale: string;
+};
+
+export type Keyword = {
+  label: string | JSX.Element;
+  isHighlighted?: boolean;
+  href: string | UrlObject;
+};
+
+export type ItemInfoLineObject = {
+  text: string;
+  icon: React.ReactNode;
+};
+
+export type Item = {
+  id: string;
+  title: string;
+  pre?: string;
+  infoLines: (ItemInfoLineObject | string)[];
+  keywords: Keyword[];
+  href: string | UrlObject;
+  location?: number[];
+  image: string;
+};
+
+export type LandingPage = {
+  title: string;
+  desktopImage: {
+    uri: string;
+  };
+  link: string;
+};
+
+export type Recommendation = {
+  id: string;
+  keywords: string[];
+  pre: string;
+  title: string;
+  infoLines: string[];
+  href: string;
+  image: string;
+};
+
+export type Node<T> = {
+  cursor: string;
+  node: T;
+};
+
+export type Connection<T> = {
+  edges: Node<T>[];
+};
+
+export type EventSelected = {
+  module: 'event_selected';
+  events: string[];
+  title: string;
+};
+
+export type EventSearch = {
+  module: 'event_search';
+  url: string;
+  title: string;
+};
+
+export type LocationsSelected = {
+  module: 'locations_selected';
+  url: string;
+  title: string;
+};
+
+export type Collection = {
+  id: string;
+  translation?: {
+    title?: string;
+    description?: string;
+    image?: string;
+    slug: string;
+    modules: Array<EventSelected | EventSearch | LocationsSelected>;
+  };
+};
+
+export type LocalizedString = {
+  fi?: string;
+  sv?: string;
+  en?: string;
+};
+
+type Image = {
+  url: string;
+  caption: string | null;
+};
+
+export type Venue = {
+  name: LocalizedString;
+  description: LocalizedString;
+  meta: {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+  };
+  images: Image[] | null;
+  location: {
+    geoLocation: {
+      geometry: {
+        coordinates: number[];
+      };
+    };
+    address: {
+      streetAddress?: LocalizedString;
+      postalCode?: string;
+      city?: LocalizedString;
+    };
+  };
+  ontologyWords: [
+    {
+      id: string;
+      label: LocalizedString;
+    }
+  ];
+  openingHours: {
+    today: Time[];
+  };
+};
+
+export type SearchResult = {
+  venue: UnifiedSearchVenue;
+};
+
+export type TranslationsObject = {
+  fi?: string;
+  en?: string;
+  sv?: string;
+};
+
+export type AccessibilitySentences = {
+  groupName: string;
+  sentences: string[];
+};
+
+export type AccessibilityTranslationsObject = {
+  fi?: AccessibilitySentences[];
+  en?: AccessibilitySentences[];
+  sv?: AccessibilitySentences[];
+};
+
+export type Point = {
+  type: 'Point';
+  coordinates: number[];
+};
+
+type Ontology = {
+  id: number;
+  label: string;
+};
+
+export type VenueDetails<T = TranslationsObject> = {
+  id: string;
+  dataSource: string | null;
+  email: string | null;
+  postalCode: string;
+  image: string | null;
+  addressLocality: T | null;
+  position: Point | null;
+  description: T | null;
+  name: T | null;
+  infoUrl: T | null;
+  streetAddress: T | null;
+  telephone: T | null;
+  ontologyTree: Ontology[];
+  ontologyWords: Ontology[];
+  accessibilitySentences:
+    | AccessibilityTranslationsObject
+    | AccessibilitySentences;
+  connections: Array<{
+    sectionType: string;
+    name: T;
+    phone: string;
+    url: T | null;
+  }>;
+};
+
+export type Source = typeof Sources[keyof typeof Sources];
+
+export type Time = {
+  name: string;
+  description: string;
+  startTime: string;
+  endTime: string;
+  endTimeOnNextDay: boolean;
+  resourceState: TimeResourceState;
+  fullDay: boolean;
+  periods: number[];
+};
+
+export type OpeningHour = {
+  date: string;
+  times: Time[];
+};
+
+export type AnyObject = Record<string, unknown>;
+
+export type Context = {
+  language?: Locale;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dataSources?: any;
+  haukiEnabled?: boolean;
+};
+
+export type Address = {
+  streetName: string;
+  zip: string;
+  city: string;
+};
+
+export type ItemQueryResult<
+  TData = null,
+  TVariables = OperationVariables
+> = Omit<QueryResult<TData, TVariables>, 'data'> & {
+  items: Item[];
+  pageInfo?: PageInfoFragment;
+  totalCount: number;
+};

--- a/apps/sports-helsinki/src/pages/api/graphql.ts
+++ b/apps/sports-helsinki/src/pages/api/graphql.ts
@@ -1,0 +1,44 @@
+import { startServerAndCreateNextHandler } from '@as-integrations/next';
+import accepts from 'accepts';
+import type { NextApiRequest } from 'next';
+// import LinkedDataSource from 'domain/graphql/services/linked/LinkedDataSource';
+import AppConfig from '../../domain/app/AppConfig';
+import createApolloServer from '../../domain/graphql/createApolloServer';
+import HaukiDataSource from '../../domain/graphql/services/HaukiDataSource';
+import TprekDataSource from '../../domain/graphql/services/TprekDataSource';
+import type { Context } from '../../domain/nextApi/types';
+
+// TODO: Implement sentry connection
+const apolloServer = createApolloServer({
+  haukiEnabled: AppConfig.isHaukiEnabled,
+});
+
+function acceptsLanguages(
+  req: NextApiRequest,
+  languages: string[]
+): typeof languages[number] | false {
+  const accept = accepts(req);
+
+  return accept.languages(languages);
+}
+
+export default startServerAndCreateNextHandler(apolloServer, {
+  context: async (req: NextApiRequest) => {
+    const { cache } = apolloServer;
+    const language = acceptsLanguages(req, AppConfig.locales);
+    return {
+      // We create new instances of our data sources with each request,
+      // passing in our server's cache.
+      dataSources: {
+        hauki: new HaukiDataSource({ cache }),
+        tprek: new TprekDataSource({ cache }),
+        // linked: new LinkedDataSource({ cache }),
+      },
+      // Some fields are relying on language set in the header.
+      // The translation object will be returned as a string
+      // and the language from the context is used to select the right translation.
+      language,
+      haukiEnabled: AppConfig.isHaukiEnabled,
+    } as Context;
+  },
+});


### PR DESCRIPTION
## Description
This enables Aukioloajat integration for sports venues on the GraphQL side.

*NOTE: Obviously to be merged only when we actually need to enable this feature :)*

*NOTE 2: This is now obsolete, the functionality is venue-graphql-proxy/src/resolvers*

## Issues

### Closes

**[LIIKUNTA-386](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-386):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-386]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ