### PR TITLE
fix(components): scroll back to original position when accordion is closed

### DIFF
--- a/packages/components/src/components/ellipsedTextWithToggle/EllipsedTextWithToggle.tsx
+++ b/packages/components/src/components/ellipsedTextWithToggle/EllipsedTextWithToggle.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { useAccordion } from 'hds-react';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useCommonTranslation } from '../../hooks';
 import styles from './ellipsedTextWithToggle.module.scss';
 
@@ -21,6 +21,17 @@ export default function EllipsedTextWithToggle({
   const { isOpen, buttonProps, contentProps } = useAccordion({
     initiallyOpen: false,
   });
+
+  const scrollY = useRef(0);
+  useEffect(() => {
+    if (isOpen) {
+      scrollY.current = window.scrollY;
+    } else {
+      window.scrollTo({
+        top: scrollY.current,
+      });
+    }
+  }, [isOpen]);
 
   const firstLines = lines.slice(0, initialVisibleLinesCount).join('\n');
   const restOfLines = lines.slice(initialVisibleLinesCount).join('\n');


### PR DESCRIPTION
## Description

Simply scrolls window back to the point where accordion was opened when closing it. Implemented in `EllipsedTextWithToggle`, since the accordion comes from HDS.

Right now there are no other controls, flags, or thresholds when to trigger the behaviour, since `EllipsedTextWithToggle` is just used on sports, but could be added of course.

## Issues

### Closes

**[LIIKUNTA-383](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-383):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-383]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ