### PR TITLE
fix: hardcode sports filter into keywordOrSet1 for queries

### DIFF
--- a/apps/sports-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/sports-helsinki/src/domain/event/queryUtils.ts
@@ -42,6 +42,8 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
         superEventType: ['umbrella', 'none'],
         eventType: event.typeId ? [event.typeId] : undefined,
       }),
+      // Set to undefined, because keywordOrSet1 contains SPORT_COURSES_KEYWORDS, which shouldn't
+      // be included in similar events query
       keywordOrSet1: undefined,
     };
   }, [event]);

--- a/apps/sports-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/sports-helsinki/src/domain/event/queryUtils.ts
@@ -32,15 +32,18 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
         .join(), // make a string
     };
 
-    return getEventSearchVariables({
-      include: ['keywords', 'location'],
-      // eslint-disable-next-line max-len
-      pageSize: 100, // TODO: use SIMILAR_EVENTS_AMOUNT when LinkedEvents-query with keyword_OR_set* -param is fixed and it returns distinct results
-      params: new URLSearchParams(searchParams),
-      sortOrder: EVENT_SORT_OPTIONS.END_TIME,
-      superEventType: ['umbrella', 'none'],
-      eventType: event.typeId ? [event.typeId] : undefined,
-    });
+    return {
+      ...getEventSearchVariables({
+        include: ['keywords', 'location'],
+        // eslint-disable-next-line max-len
+        pageSize: 100, // TODO: use SIMILAR_EVENTS_AMOUNT when LinkedEvents-query with keyword_OR_set* -param is fixed and it returns distinct results
+        params: new URLSearchParams(searchParams),
+        sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+        superEventType: ['umbrella', 'none'],
+        eventType: event.typeId ? [event.typeId] : undefined,
+      }),
+      keywordOrSet1: undefined,
+    };
   }, [event]);
 };
 

--- a/apps/sports-helsinki/src/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
@@ -23,9 +23,9 @@ const startTime = '2020-10-05T07:00:00.000000Z';
 const endTime = '2020-10-05T10:00:00.000000Z';
 const audience = ['Aikuiset', 'Lapset'];
 const keywords = [
-  { name: 'Avouinti', id: 'keyword1' },
-  { name: 'Eläimet', id: 'keyword2' },
-  { name: 'Grillaus', id: 'keyword3' },
+  { name: 'Avouinti', id: 'yso:p916' },
+  { name: 'Eläimet', id: 'kulke:710' },
+  { name: 'Grillaus', id: 'yso:p17018' },
 ];
 
 const expectedSimilarEvents = fakeEvents(3);
@@ -47,7 +47,7 @@ const event = fakeEvent({
 const similarEventQueryVariables = {
   pageSize: 100,
   allOngoing: true,
-  keywordOrSet2: [''],
+  keywordOrSet2: keywords.map((k) => k.id),
   language: undefined,
 };
 

--- a/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -24,6 +24,7 @@ import isEmpty from 'lodash/isEmpty';
 import type { TFunction } from 'next-i18next';
 import type { EVENT_SORT_OPTIONS, SPORTS_CATEGORIES } from './constants';
 import {
+  SPORT_COURSES_KEYWORDS,
   CATEGORY_CATALOG,
   EVENT_SEARCH_FILTERS,
   MAPPED_PLACES,
@@ -193,6 +194,7 @@ export const getEventSearchVariables = ({
     isFree: isFree || undefined,
     end,
     include,
+    keywordOrSet1: SPORT_COURSES_KEYWORDS, // Limit search to sport keywords only
     keywordOrSet2: [...(keyword ?? [])],
     keywordAnd,
     keywordNot,


### PR DESCRIPTION
## Description
Hardcodes sports filters for sports queries, so they will only return results including either "liikunta" or "urheilu" keywords.
## Issues

### Closes

**[LIIKUNTA-373](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-373):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-373]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ