### PR TITLE
fix(liikunta-374): fix readiness and healthz routes

### DIFF
--- a/packages/graphql-proxy-server/src/server.ts
+++ b/packages/graphql-proxy-server/src/server.ts
@@ -84,14 +84,19 @@ export const startServer = async <
         }),
     })
   );
-  app.get(
+
+  const readinessRouter = express.Router();
+
+  app.use('/api', readinessRouter);
+
+  readinessRouter.get(
     '/healthz',
     (request: express.Request, response: express.Response) => {
       checkIsServerReady(response);
     }
   );
 
-  app.get(
+  readinessRouter.get(
     '/readiness',
     (request: express.Request, response: express.Response) => {
       checkIsServerReady(response);


### PR DESCRIPTION
## Description
I got the 200 OK now:
```
codelicious@Jaakkos-MBP sports-helsinki % curl -v http://localhost:4100/api/readiness                                                                                           git events-helsinki-monorepo/apps/sports-helsinki main 

*   Trying 127.0.0.1:4100...
* Connected to localhost (127.0.0.1) port 4100 (#0)
> GET /api/readiness HTTP/1.1
> Host: localhost:4100
> User-Agent: curl/7.86.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Content-Type: text/html; charset=utf-8
< Content-Length: 2
< ETag: W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
< Date: Fri, 27 Jan 2023 08:30:30 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< 
* Connection #0 to host localhost left intact
OK%                                                                                                                                                                                                                                     
codelicious@Jaakkos-MBP sports-helsinki % curl -v http://localhost:4100/api/healthz                                                                                             git events-helsinki-monorepo/apps/sports-helsinki main 

*   Trying 127.0.0.1:4100...
* Connected to localhost (127.0.0.1) port 4100 (#0)
> GET /api/healthz HTTP/1.1
> Host: localhost:4100
> User-Agent: curl/7.86.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Content-Type: text/html; charset=utf-8
< Content-Length: 2
< ETag: W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
< Date: Fri, 27 Jan 2023 08:30:45 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< 
* Connection #0 to host localhost left intact
OK%     
```
## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
