### PR TITLE
fix: fallback image hero

### DIFF
--- a/apps/events-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/events-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -29,6 +29,7 @@ import {
   BackgroundImage,
   ContentContainer,
   PageSection,
+  useConfig,
 } from 'react-helsinki-headless-cms';
 
 import EventKeywords from '../eventKeywords/EventKeywords';
@@ -45,6 +46,7 @@ export interface Props {
 const EventHero: React.FC<Props> = ({ event, superEvent }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
+  const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
   const router = useRouter();
   const search = router.asPath.split('?')[1];
@@ -98,15 +100,13 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
               size="default"
             />
           </div>
-          {imageUrl && (
-            <div>
-              <BackgroundImage
-                className={styles.image}
-                id={`event-background-${event.id}`}
-                url={imageUrl}
-              />
-            </div>
-          )}
+          <div>
+            <BackgroundImage
+              className={styles.image}
+              id={`event-background-${event.id}`}
+              url={imageUrl || fallbackImageUrls[0]}
+            />
+          </div>
           <div className={styles.leftPanel}>
             <div className={styles.leftPanelWrapper}>
               <div className={styles.leftPanelEmpty} />

--- a/apps/events-helsinki/src/hooks/useRHHCConfig.tsx
+++ b/apps/events-helsinki/src/hooks/useRHHCConfig.tsx
@@ -81,6 +81,7 @@ export default function useRHHCConfig() {
       currentLanguageCode: locale.toUpperCase(),
       apolloClient,
       eventsApolloClient: apolloClient,
+      venuesApolloClient: apolloClient,
       copy: {
         next: commonTranslation('common:next'),
         previous: commonTranslation('common:previous'),

--- a/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -29,6 +29,7 @@ import {
   BackgroundImage,
   ContentContainer,
   PageSection,
+  useConfig,
 } from 'react-helsinki-headless-cms';
 
 import EventKeywords from '../eventKeywords/EventKeywords';
@@ -45,6 +46,7 @@ export interface Props {
 const EventHero: React.FC<Props> = ({ event, superEvent }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
+  const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
   const router = useRouter();
   const search = router.asPath.split('?')[1];
@@ -98,15 +100,13 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
               size="default"
             />
           </div>
-          {imageUrl && (
-            <div>
-              <BackgroundImage
-                className={styles.image}
-                id={`event-background-${event.id}`}
-                url={imageUrl}
-              />
-            </div>
-          )}
+          <div>
+            <BackgroundImage
+              className={styles.image}
+              id={`event-background-${event.id}`}
+              url={imageUrl || fallbackImageUrls[0]}
+            />
+          </div>
           <div className={styles.leftPanel}>
             <div className={styles.leftPanelWrapper}>
               <div className={styles.leftPanelEmpty} />

--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -16,6 +16,7 @@ import {
   BackgroundImage,
   ContentContainer,
   PageSection,
+  useConfig,
 } from 'react-helsinki-headless-cms';
 import { SEARCH_ROUTES } from '../../../constants';
 import type { ReturnParams } from '../../event/eventQueryString.util';
@@ -24,8 +25,6 @@ import getVenueOpeningTimeDescription from '../utils/getVenueOpeningTimeDescript
 import VenueKeywords from '../venueKeywords/VenueKeywords';
 import styles from './venueHero.module.scss';
 
-const heroPlaceholderImage = '/shared-assets/images/no_image.svg';
-
 export interface Props {
   venue: Venue;
 }
@@ -33,6 +32,7 @@ export interface Props {
 const VenueHero: React.FC<Props> = ({ venue }) => {
   const { t } = useVenueTranslation();
   const { t: commonTranslation } = useTranslation('common');
+  const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
   const router = useRouter();
   const search = router.asPath.split('?')[1];
@@ -86,8 +86,6 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
       : null,
   ].filter((item) => Boolean(item));
 
-  const heroImage = imageUrl || heroPlaceholderImage;
-
   return (
     <PageSection className={classNames(styles.heroSection)}>
       <ContentContainer className={styles.contentContainer}>
@@ -102,15 +100,13 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
               size="default"
             />
           </div>
-          {heroImage && (
-            <div>
-              <BackgroundImage
-                className={styles.image}
-                id={`venue-background-${venue.id}`}
-                url={heroImage}
-              />
-            </div>
-          )}
+          <div>
+            <BackgroundImage
+              className={styles.image}
+              id={`venue-background-${venue.id}`}
+              url={imageUrl || fallbackImageUrls[0]}
+            />
+          </div>
           <div className={styles.leftPanel}>
             <div className={styles.leftPanelWrapper}>
               <div className={styles.leftPanelEmpty} />


### PR DESCRIPTION
## Description
Fix the default fallback image in Hero of the details page to be always blue version placeholder.
Add the venue apollo client to events hcrc config, otherwise failing to start the project

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
