### PR TITLE
fix: the return paths of the the event cards

### DIFF
--- a/apps/events-helsinki/src/domain/event/eventCard/EventCard.tsx
+++ b/apps/events-helsinki/src/domain/event/eventCard/EventCard.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import {
-  addParamsToQueryString,
   getDateRangeStr,
   useLocale,
   IconButton,
@@ -39,14 +38,22 @@ const EventCard: React.FC<Props> = ({ event }) => {
     locale
   );
 
-  const queryString = addParamsToQueryString(router.asPath, {
-    returnPath: router.pathname,
-  });
-  const eventUrl = `${routerHelper.getLocalizedCmsItemUrl(
+  const eventUrl = routerHelper.getLocalizedCmsItemUrl(
     ROUTES.EVENTS,
-    { eventId: event.id },
+    {
+      eventId: event.id,
+      returnPath: routerHelper.getLocalizedCmsItemUrl(
+        ROUTES.SEARCH,
+        {
+          ...router.query,
+          eventId: event.id,
+        },
+        locale
+      ),
+    },
     locale
-  )}${queryString}`;
+  );
+
   const eventClosed = isEventClosed(event);
   const eventPriceText = getEventPrice(event, locale, t('eventCard.isFree'));
 

--- a/apps/events-helsinki/src/domain/event/eventCard/LargeEventCard.tsx
+++ b/apps/events-helsinki/src/domain/event/eventCard/LargeEventCard.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import {
-  addParamsToQueryString,
   getDateRangeStr,
   buttonStyles,
   useLocale,
@@ -56,22 +55,22 @@ const LargeEventCard: React.FC<Props> = ({ event }) => {
   const audienceAge = getAudienceAgeText(t, audienceMinAge, audienceMaxAge);
 
   const eventClosed = isEventClosed(event);
-  const queryString = addParamsToQueryString(
-    router.asPath.split('?')[1] ?? '',
-    {
-      returnPath: `${routerHelper.getLocalizedCmsItemUrl(
-        ROUTES.SEARCH,
-        {},
-        locale
-      )}?eventId=${event.id}`,
-    }
-  );
 
-  const eventUrl = `${routerHelper.getLocalizedCmsItemUrl(
+  const eventUrl = routerHelper.getLocalizedCmsItemUrl(
     ROUTES.EVENTS,
-    { eventId: event.id },
+    {
+      eventId: event.id,
+      returnPath: routerHelper.getLocalizedCmsItemUrl(
+        ROUTES.SEARCH,
+        {
+          ...router.query,
+          eventId: event.id,
+        },
+        locale
+      ),
+    },
     locale
-  )}${queryString}`;
+  );
 
   const showBuyButton = !eventClosed && !!offerInfoUrl && !isEventFree(event);
 

--- a/apps/hobbies-helsinki/src/domain/event/eventCard/EventCard.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventCard/EventCard.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import type { EventFields } from 'events-helsinki-components';
 import {
-  addParamsToQueryString,
   getDateRangeStr,
   useLocale,
   IconButton,
@@ -38,14 +37,21 @@ const EventCard: React.FC<Props> = ({ event }) => {
     locale
   );
 
-  const queryString = addParamsToQueryString(router.asPath, {
-    returnPath: router.pathname,
-  });
-  const eventUrl = `${routerHelper.getLocalizedCmsItemUrl(
+  const eventUrl = routerHelper.getLocalizedCmsItemUrl(
     ROUTES.COURSES,
-    { eventId: event.id },
+    {
+      eventId: event.id,
+      returnPath: routerHelper.getLocalizedCmsItemUrl(
+        ROUTES.SEARCH,
+        {
+          ...router.query,
+          eventId: event.id,
+        },
+        locale
+      ),
+    },
     locale
-  )}${queryString}`;
+  );
   const eventClosed = isEventClosed(event);
   const eventPriceText = getEventPrice(event, locale, t('eventCard.isFree'));
 

--- a/apps/hobbies-helsinki/src/domain/event/eventCard/LargeEventCard.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventCard/LargeEventCard.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import type { EventFields } from 'events-helsinki-components';
 import {
-  addParamsToQueryString,
   getDateRangeStr,
   buttonStyles,
   useLocale,
@@ -56,22 +55,22 @@ const LargeEventCard: React.FC<Props> = ({ event }) => {
   const audienceAge = getAudienceAgeText(t, audienceMinAge, audienceMaxAge);
 
   const eventClosed = isEventClosed(event);
-  const queryString = addParamsToQueryString(
-    router.asPath.split('?')[1] ?? '',
-    {
-      returnPath: `${routerHelper.getLocalizedCmsItemUrl(
-        ROUTES.SEARCH,
-        {},
-        locale
-      )}?eventId=${event.id}`,
-    }
-  );
 
-  const eventUrl = `${routerHelper.getLocalizedCmsItemUrl(
+  const eventUrl = routerHelper.getLocalizedCmsItemUrl(
     ROUTES.COURSES,
-    { eventId: event.id },
+    {
+      eventId: event.id,
+      returnPath: routerHelper.getLocalizedCmsItemUrl(
+        ROUTES.SEARCH,
+        {
+          ...router.query,
+          eventId: event.id,
+        },
+        locale
+      ),
+    },
     locale
-  )}${queryString}`;
+  );
 
   const showBuyButton = !eventClosed && !!offerInfoUrl && !isEventFree(event);
 

--- a/apps/sports-helsinki/src/domain/event/eventCard/EventCard.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventCard/EventCard.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import type { EventFields } from 'events-helsinki-components';
 import {
-  addParamsToQueryString,
   getDateRangeStr,
   useLocale,
   IconButton,
@@ -16,7 +15,7 @@ import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { BackgroundImage, LinkBox } from 'react-helsinki-headless-cms';
-
+import { PARAM_SEARCH_TYPE } from 'domain/search/combinedSearch/constants';
 import { ROUTES } from '../../../constants';
 import routerHelper from '../../../domain/app/routerHelper';
 import EventKeywords from '../eventKeywords/EventKeywords';
@@ -38,15 +37,22 @@ const EventCard: React.FC<Props> = ({ event }) => {
     event,
     locale
   );
-
-  const queryString = addParamsToQueryString(router.asPath, {
-    returnPath: router.pathname,
-  });
-  const eventUrl = `${routerHelper.getLocalizedCmsItemUrl(
+  const eventUrl = routerHelper.getLocalizedCmsItemUrl(
     ROUTES.COURSES,
-    { eventId: event.id },
+    {
+      eventId: event.id,
+      returnPath: routerHelper.getLocalizedCmsItemUrl(
+        ROUTES.SEARCH,
+        {
+          ...router.query,
+          eventId: event.id,
+          [PARAM_SEARCH_TYPE]: event.typeId ?? '',
+        },
+        locale
+      ),
+    },
     locale
-  )}${queryString}`;
+  );
   const eventClosed = isEventClosed(event);
   const eventPriceText = getEventPrice(event, locale, t('eventCard.isFree'));
 

--- a/apps/sports-helsinki/src/domain/event/eventCard/LargeEventCard.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventCard/LargeEventCard.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import type { EventFields } from 'events-helsinki-components';
 import {
-  addParamsToQueryString,
   getDateRangeStr,
   buttonStyles,
   useLocale,
@@ -57,23 +56,23 @@ const LargeEventCard: React.FC<Props> = ({ event }) => {
   const audienceAge = getAudienceAgeText(t, audienceMinAge, audienceMaxAge);
 
   const eventClosed = isEventClosed(event);
-  const queryString = addParamsToQueryString('', {
-    returnPath: routerHelper.getLocalizedCmsItemUrl(
-      ROUTES.SEARCH,
-      {
-        ...router.query,
-        eventId: event.id,
-        [PARAM_SEARCH_TYPE]: event.typeId ?? '',
-      },
-      locale
-    ),
-  });
 
-  const eventUrl = `${routerHelper.getLocalizedCmsItemUrl(
+  const eventUrl = routerHelper.getLocalizedCmsItemUrl(
     ROUTES.COURSES,
-    { eventId: event.id },
+    {
+      eventId: event.id,
+      returnPath: routerHelper.getLocalizedCmsItemUrl(
+        ROUTES.SEARCH,
+        {
+          ...router.query,
+          eventId: event.id,
+          [PARAM_SEARCH_TYPE]: event.typeId ?? '',
+        },
+        locale
+      ),
+    },
     locale
-  )}${queryString}`;
+  );
 
   const showBuyButton = !eventClosed && !!offerInfoUrl && !isEventFree(event);
 


### PR DESCRIPTION
TH-1295. Make all the event card return path handling simpler and consistent.
The search parameters should persist in the return path, so when returning to the search from the details page, the search filters still applies.