### PR TITLE
fix: the navigation bar of the CMS pages and articles

### DIFF
--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -32,6 +32,7 @@ import type {
 } from 'react-helsinki-headless-cms/apollo';
 import { ArticleDocument } from 'react-helsinki-headless-cms/apollo';
 import AppConfig from '../../domain/app/AppConfig';
+import getEventsStaticProps from '../../domain/app/getEventsStaticProps';
 import cmsHelper from '../../domain/app/headlessCmsHelper';
 import routerHelper from '../../domain/app/routerHelper';
 import { apolloClient } from '../../domain/clients/eventsFederationApolloClient';
@@ -106,46 +107,52 @@ type ResultProps =
       };
     };
 
-export async function getStaticProps(
-  context: GetStaticPropsContext
-): Promise<GetStaticPropsResult<ResultProps>> {
-  try {
-    const {
-      currentArticle: article,
-      breadcrumbs,
-      apolloClient,
-    } = await getProps(context);
+export async function getStaticProps(context: GetStaticPropsContext) {
+  return getEventsStaticProps(
+    context,
+    async (): Promise<GetStaticPropsResult<ResultProps>> => {
+      try {
+        const {
+          currentArticle: article,
+          breadcrumbs,
+          apolloClient,
+        } = await getProps(context);
 
-    if (!article) {
-      return {
-        notFound: true,
-        revalidate: true,
-      };
+        if (!article) {
+          return {
+            notFound: true,
+            revalidate: true,
+          };
+        }
+        const locale = routerHelper.getLocaleOrError(context.locale);
+
+        return {
+          props: {
+            initialApolloState: apolloClient.cache.extract(),
+            ...(await serverSideTranslationsWithCommon(locale, [
+              'cms',
+              'event',
+            ])),
+            article,
+            breadcrumbs,
+            collections: getCollections(article.modules ?? []),
+          },
+          revalidate: 60,
+        };
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Error while generating content page', e);
+        return {
+          props: {
+            error: {
+              statusCode: 400,
+            },
+          },
+          revalidate: 10,
+        };
+      }
     }
-    const locale = routerHelper.getLocaleOrError(context.locale);
-
-    return {
-      props: {
-        initialApolloState: apolloClient.cache.extract(),
-        ...(await serverSideTranslationsWithCommon(locale, ['cms', 'event'])),
-        article,
-        breadcrumbs,
-        collections: getCollections(article.modules ?? []),
-      },
-      revalidate: 60,
-    };
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Error while generating content page', e);
-    return {
-      props: {
-        error: {
-          statusCode: 400,
-        },
-      },
-      revalidate: 10,
-    };
-  }
+  );
 }
 
 const getProps = async (context: GetStaticPropsContext) => {

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -28,6 +28,7 @@ import type {
 import { PageDocument } from 'react-helsinki-headless-cms/apollo';
 import Navigation from '../../../../../packages/components/src/components/navigation/Navigation';
 import AppConfig from '../../domain/app/AppConfig';
+import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
 import cmsHelper from '../../domain/app/headlessCmsHelper';
 import routerHelper from '../../domain/app/routerHelper';
 import { apolloClient } from '../../domain/clients/eventsFederationApolloClient';
@@ -96,43 +97,46 @@ type ResultProps =
       };
     };
 
-export async function getStaticProps(
-  context: GetStaticPropsContext
-): Promise<GetStaticPropsResult<ResultProps>> {
-  try {
-    const {
-      currentPage: page,
-      breadcrumbs,
-      apolloClient,
-    } = await getProps(context);
-    if (!page) {
-      return {
-        notFound: true,
-        revalidate: true,
-      };
-    }
-    const locale = routerHelper.getLocaleOrError(context.locale);
+export async function getStaticProps(context: GetStaticPropsContext) {
+  return getHobbiesStaticProps(
+    context,
+    async (): Promise<GetStaticPropsResult<ResultProps>> => {
+      try {
+        const {
+          currentPage: page,
+          breadcrumbs,
+          apolloClient,
+        } = await getProps(context);
+        if (!page) {
+          return {
+            notFound: true,
+            revalidate: true,
+          };
+        }
+        const locale = routerHelper.getLocaleOrError(context.locale);
 
-    return {
-      props: {
-        initialApolloState: apolloClient.cache.extract(),
-        ...(await serverSideTranslationsWithCommon(locale, ['cms'])),
-        page,
-        breadcrumbs,
-        collections: getCollections(page.modules ?? []),
-      },
-      revalidate: 60,
-    };
-  } catch (e) {
-    return {
-      props: {
-        error: {
-          statusCode: 400,
-        },
-      },
-      revalidate: 10,
-    };
-  }
+        return {
+          props: {
+            initialApolloState: apolloClient.cache.extract(),
+            ...(await serverSideTranslationsWithCommon(locale, ['cms'])),
+            page,
+            breadcrumbs,
+            collections: getCollections(page.modules ?? []),
+          },
+          revalidate: 60,
+        };
+      } catch (e) {
+        return {
+          props: {
+            error: {
+              statusCode: 400,
+            },
+          },
+          revalidate: 10,
+        };
+      }
+    }
+  );
 }
 
 const getProps = async (context: GetStaticPropsContext) => {

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -32,6 +32,7 @@ import type {
 } from 'react-helsinki-headless-cms/apollo';
 import { ArticleDocument } from 'react-helsinki-headless-cms/apollo';
 import AppConfig from '../../domain/app/AppConfig';
+import getSportsStaticProps from '../../domain/app/getSportsStaticProps';
 import cmsHelper from '../../domain/app/headlessCmsHelper';
 import routerHelper from '../../domain/app/routerHelper';
 import { apolloClient } from '../../domain/clients/eventsFederationApolloClient';
@@ -106,46 +107,52 @@ type ResultProps =
       };
     };
 
-export async function getStaticProps(
-  context: GetStaticPropsContext
-): Promise<GetStaticPropsResult<ResultProps>> {
-  try {
-    const {
-      currentArticle: article,
-      breadcrumbs,
-      apolloClient,
-    } = await getProps(context);
+export async function getStaticProps(context: GetStaticPropsContext) {
+  return getSportsStaticProps(
+    context,
+    async (): Promise<GetStaticPropsResult<ResultProps>> => {
+      try {
+        const {
+          currentArticle: article,
+          breadcrumbs,
+          apolloClient,
+        } = await getProps(context);
 
-    if (!article) {
-      return {
-        notFound: true,
-        revalidate: true,
-      };
+        if (!article) {
+          return {
+            notFound: true,
+            revalidate: true,
+          };
+        }
+        const locale = routerHelper.getLocaleOrError(context.locale);
+
+        return {
+          props: {
+            initialApolloState: apolloClient.cache.extract(),
+            ...(await serverSideTranslationsWithCommon(locale, [
+              'cms',
+              'event',
+            ])),
+            article,
+            breadcrumbs,
+            collections: getCollections(article.modules ?? []),
+          },
+          revalidate: 60,
+        };
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Error while generating content page', e);
+        return {
+          props: {
+            error: {
+              statusCode: 400,
+            },
+          },
+          revalidate: 10,
+        };
+      }
     }
-    const locale = routerHelper.getLocaleOrError(context.locale);
-
-    return {
-      props: {
-        initialApolloState: apolloClient.cache.extract(),
-        ...(await serverSideTranslationsWithCommon(locale, ['cms', 'event'])),
-        article,
-        breadcrumbs,
-        collections: getCollections(article.modules ?? []),
-      },
-      revalidate: 60,
-    };
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Error while generating content page', e);
-    return {
-      props: {
-        error: {
-          statusCode: 400,
-        },
-      },
-      revalidate: 10,
-    };
-  }
+  );
 }
 
 const getProps = async (context: GetStaticPropsContext) => {

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -31,6 +31,7 @@ import type {
 } from 'react-helsinki-headless-cms/apollo';
 import { PageDocument } from 'react-helsinki-headless-cms/apollo';
 import AppConfig from '../../domain/app/AppConfig';
+import getSportsStaticProps from '../../domain/app/getSportsStaticProps';
 import cmsHelper from '../../domain/app/headlessCmsHelper';
 import routerHelper from '../../domain/app/routerHelper';
 import { apolloClient } from '../../domain/clients/eventsFederationApolloClient';
@@ -99,43 +100,46 @@ type ResultProps =
       };
     };
 
-export async function getStaticProps(
-  context: GetStaticPropsContext
-): Promise<GetStaticPropsResult<ResultProps>> {
-  try {
-    const {
-      currentPage: page,
-      breadcrumbs,
-      apolloClient,
-    } = await getProps(context);
-    if (!page) {
-      return {
-        notFound: true,
-        revalidate: true,
-      };
-    }
-    const locale = routerHelper.getLocaleOrError(context.locale);
+export async function getStaticProps(context: GetStaticPropsContext) {
+  return getSportsStaticProps(
+    context,
+    async (): Promise<GetStaticPropsResult<ResultProps>> => {
+      try {
+        const {
+          currentPage: page,
+          breadcrumbs,
+          apolloClient,
+        } = await getProps(context);
+        if (!page) {
+          return {
+            notFound: true,
+            revalidate: true,
+          };
+        }
+        const locale = routerHelper.getLocaleOrError(context.locale);
 
-    return {
-      props: {
-        initialApolloState: apolloClient.cache.extract(),
-        ...(await serverSideTranslationsWithCommon(locale, ['cms'])),
-        page,
-        breadcrumbs,
-        collections: getCollections(page.modules ?? []),
-      },
-      revalidate: 60,
-    };
-  } catch (e) {
-    return {
-      props: {
-        error: {
-          statusCode: 400,
-        },
-      },
-      revalidate: 10,
-    };
-  }
+        return {
+          props: {
+            initialApolloState: apolloClient.cache.extract(),
+            ...(await serverSideTranslationsWithCommon(locale, ['cms'])),
+            page,
+            breadcrumbs,
+            collections: getCollections(page.modules ?? []),
+          },
+          revalidate: 60,
+        };
+      } catch (e) {
+        return {
+          props: {
+            error: {
+              statusCode: 400,
+            },
+          },
+          revalidate: 10,
+        };
+      }
+    }
+  );
 }
 
 const getProps = async (context: GetStaticPropsContext) => {


### PR DESCRIPTION
HH-292. 
The navigation bar was empty on CMS articles and dynamic pages, because of the earlier refactoring of the Navigation component.

The navigation bar is now rendered in each apps articles and dynamic pages:

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/389204/216012199-f01ccc30-c57a-46eb-b3eb-d1c67237e475.png">

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/389204/216012226-69d181fd-fde7-4052-9bba-8f3f3f66f246.png">

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/389204/216012254-59a429ea-87de-4916-80e9-5f8d30aa05d5.png">
