### PR TITLE
LIIKUNTA-356 | fix: use 2rem margin under order by selects & black "Show on map" button

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/SearchUtilities.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/SearchUtilities.tsx
@@ -56,6 +56,7 @@ function SearchUtilities() {
           {activeTab === 'Venue' ? (
             <Button
               variant="secondary"
+              theme="black"
               onClick={switchShowMode}
               className={styles.buttonWrapper}
             >

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/eventsOrderBySelect.module.scss
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/eventsOrderBySelect.module.scss
@@ -1,3 +1,4 @@
 .eventsOrderBySelect {
   min-width: 15rem;
+  margin-bottom: var(--spacing-l);
 }

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/unifiedSearchOrderBySelect.module.scss
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/unifiedSearchOrderBySelect.module.scss
@@ -1,3 +1,4 @@
 .unifiedSearchOrderBySelect {
   min-width: 15rem;
+  margin-bottom: var(--spacing-l);
 }

--- a/apps/sports-helsinki/src/domain/search/venueSearch/VenueSearch.tsx
+++ b/apps/sports-helsinki/src/domain/search/venueSearch/VenueSearch.tsx
@@ -174,7 +174,7 @@ export const VenueSearchUtilities: React.FC<SearchUtilitiesProps> = ({
   const { t } = useCommonTranslation();
   return (
     <>
-      <Button variant="secondary" onClick={switchShowMode}>
+      <Button variant="secondary" theme="black" onClick={switchShowMode}>
         {t('common:mapSearch.showOnMap')}
       </Button>
     </>


### PR DESCRIPTION
## Description

### fix: use 2rem margin under order by selects & black "Show on map" button

refs LIIKUNTA-355 (UI fixes related to unified search)
refs LIIKUNTA-356 (UI fixes related to linked events search)

## Issues

**[LIIKUNTA-355](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-355)**
**[LIIKUNTA-356](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-356)**

### Closes

`-`

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Hobbies & events search
![1](https://user-images.githubusercontent.com/77663720/216058969-0fc0930f-4992-480c-ac19-73bda688cdc6.png)

### Venues search
![2](https://user-images.githubusercontent.com/77663720/216058966-3f30e323-2094-4d03-a4f0-7be6c84fa175.png)

## Additional notes


[LIIKUNTA-355]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIIKUNTA-356]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ