### PR TITLE
Propagate errors from all subgraphs

### DIFF
--- a/proxies/events-graphql-federation/router.yaml
+++ b/proxies/events-graphql-federation/router.yaml
@@ -15,6 +15,8 @@ headers:
       request:
         - propagate: # propagate all headers. Note that Accept-Language is the most important.
             matching: .*
+include_subgraph_errors:
+  all: true # Propagate errors from all subgraphs
 cors:
   # Set to true to allow any origin
   # (Defaults to false)


### PR DESCRIPTION
Include the subgraph errors from all sources.

By default, the Apollo Router redacts the details of subgraph errors in its responses to clients.
The router instead returns a default error with the following message:
"Subgraph errors redacted".

More about this in Apollo docs:
https://www.apollographql.com/docs/router/configuration/subgraph-error-inclusion