### PR TITLE
fix: similar venues results localization issues

### DIFF
--- a/apps/sports-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/sports-helsinki/src/domain/event/queryUtils.ts
@@ -4,6 +4,7 @@ import {
   getEventIdFromUrl,
   useEventListQuery,
   useVenuesByIdsLazyQuery,
+  useLocale,
 } from 'events-helsinki-components';
 import type {
   EventListQuery,
@@ -238,6 +239,7 @@ export const useLocationUpcomingEventsQuery = ({
 };
 
 export const useSimilarVenuesQuery = (venue: Venue) => {
+  const locale = useLocale();
   const ontologyWordIds = venue.ontologyWords.reduce(
     (ontologies: string[], ontology) => {
       if (ontology?.id) {
@@ -261,6 +263,11 @@ export const useSimilarVenuesQuery = (venue: Venue) => {
   // Search for venues from venues-proxy (e.g. TPREK as a datasource) with the venue ids.
   const [getVenuesByIds, queryProps] = useVenuesByIdsLazyQuery({
     ssr: false,
+    context: {
+      headers: {
+        'Accept-Language': locale,
+      },
+    },
   });
 
   // Trigger the venues by ids search when the ids are fetched.


### PR DESCRIPTION
LIIKUNTA-406. Use the current locale in the Apollo client query context.

Earlier: 
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/389204/218113125-b3da4c6c-7a90-4cf2-9b83-6d7abcf3190e.png">

After:
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/389204/218113197-a2fa78c5-1f83-4d79-ba11-acec7f4b9a6b.png">
