### PR TITLE
ci: trigger release-please update on pull request closing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The pull requests created by the Release-Please are not getting updated
when another Release-Please PR is been merged, but they should, so that 
we don't need to manually maintain the version numbers 
when we want to deploy multiple apps at once.