### PR TITLE
feat: add events additional info to all apps

### DIFF
--- a/apps/hobbies-helsinki/src/domain/event/eventContent/EventContent.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventContent/EventContent.tsx
@@ -68,7 +68,7 @@ const EventContent: React.FC<Props> = ({
                     {description}
                   </HtmlToReact>
                 </div>
-                {AppConfig.showEventLocationExtraInfo && locationExtraInfo && (
+                {locationExtraInfo && (
                   <>
                     <h2 className={styles.descriptionTitle}>
                       {t('event:locationExtraInfo.title')}

--- a/apps/hobbies-helsinki/src/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -111,3 +111,23 @@ it('should hide map if internet event', () => {
   );
   expect(screen.queryByText(/sijainti/i)).not.toBeInTheDocument();
 });
+
+it('should show location extra info when available', () => {
+  render(
+    <EventContent
+      event={
+        {
+          ...event,
+          locationExtraInfo: { fi: 'Sisään takaovesta' },
+        } as EventFieldsFragment
+      }
+    />
+  );
+  expect(screen.getByText(/Paikan lisätiedot/i)).toBeInTheDocument();
+  expect(screen.getByText(/Sisään takaovesta/i)).toBeInTheDocument();
+});
+
+it('should not show location extra info title when location extra info not available', () => {
+  render(<EventContent event={event} />);
+  expect(screen.queryByText(/Paikan lisätiedot/i)).not.toBeInTheDocument();
+});

--- a/apps/hobbies-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -47,6 +47,7 @@ const getFakeEvent = (overrides?: Partial<EventDetails>) => {
       streetAddress: { fi: streetAddress },
     },
     externalLinks: [],
+    locationExtraInfo: null,
     ...overrides,
   }) as EventFieldsFragment;
 };

--- a/apps/sports-helsinki/src/domain/event/eventContent/EventContent.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventContent/EventContent.tsx
@@ -68,7 +68,7 @@ const EventContent: React.FC<Props> = ({
                     {description}
                   </HtmlToReact>
                 </div>
-                {AppConfig.showEventLocationExtraInfo && locationExtraInfo && (
+                {locationExtraInfo && (
                   <>
                     <h2 className={styles.descriptionTitle}>
                       {t('event:locationExtraInfo.title')}

--- a/apps/sports-helsinki/src/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -111,3 +111,23 @@ it('should hide map if internet event', () => {
   );
   expect(screen.queryByText(/sijainti/i)).not.toBeInTheDocument();
 });
+
+it('should show location extra info when available', () => {
+  render(
+    <EventContent
+      event={
+        {
+          ...event,
+          locationExtraInfo: { fi: 'Sisään takaovesta' },
+        } as EventFieldsFragment
+      }
+    />
+  );
+  expect(screen.getByText(/Paikan lisätiedot/i)).toBeInTheDocument();
+  expect(screen.getByText(/Sisään takaovesta/i)).toBeInTheDocument();
+});
+
+it('should not show location extra info title when location extra info not available', () => {
+  render(<EventContent event={event} />);
+  expect(screen.queryByText(/Paikan lisätiedot/i)).not.toBeInTheDocument();
+});

--- a/apps/sports-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -47,6 +47,7 @@ const getFakeEvent = (overrides?: Partial<EventDetails>) => {
       streetAddress: { fi: streetAddress },
     },
     externalLinks: [],
+    locationExtraInfo: null,
     ...overrides,
   }) as EventFieldsFragment;
 };


### PR DESCRIPTION
## Description
add event additional info in the bottom of the page (in hobbies and sports, in events already implemented)

<img width="1168" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/16116141/b258dea3-b743-4e94-8ab1-ac8720150acd">


## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
