### PR TITLE
LIIKUNTA-412 | feat(sports): make "Show other events/hobbies by publisher" link on event detail page work

### DIFF
--- a/apps/events-helsinki/src/domain/event/eventInfo/OrganizationInfo.tsx
+++ b/apps/events-helsinki/src/domain/event/eventInfo/OrganizationInfo.tsx
@@ -52,7 +52,7 @@ const OrganizationInfo: React.FC<Props> = ({ event }) => {
                     locale
                   )}?publisher=${publisher}`}
                 >
-                  {t('info.linkSearchByPublisher')}
+                  {t('info.linkSearchByPublisher.general')}
                 </SecondaryLink>
               </>
             )}

--- a/apps/events-helsinki/src/domain/event/eventInfo/__tests__/EventInfo.test.tsx
+++ b/apps/events-helsinki/src/domain/event/eventInfo/__tests__/EventInfo.test.tsx
@@ -289,7 +289,7 @@ describe('OrganizationInfo', () => {
     render(<EventInfo event={event} />, { mocks });
     await waitFor(() => {
       expect(
-        screen.getByText('Katso julkaisijan muut harrastukset')
+        screen.getByText('Katso julkaisijan muut tapahtumat')
       ).toBeInTheDocument();
     });
   });

--- a/apps/hobbies-helsinki/src/domain/event/eventInfo/OrganizationInfo.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventInfo/OrganizationInfo.tsx
@@ -51,7 +51,7 @@ const OrganizationInfo: React.FC<Props> = ({ event }) => {
                     locale
                   )}?publisher=${publisher}`}
                 >
-                  {t('info.linkSearchByPublisher')}
+                  {t('info.linkSearchByPublisher.course')}
                 </SecondaryLink>
               </>
             )}

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/utils.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/utils.ts
@@ -12,6 +12,7 @@
  */
 export const TRANSFORM_MAP = new Map<string, string>([
   ['q', 'text'],
+  ['publisher', 'publisher'],
   ['sportsCategories', 'sportsCategories'],
 ]);
 

--- a/packages/common-i18n/src/locales/en/event.json
+++ b/packages/common-i18n/src/locales/en/event.json
@@ -55,7 +55,10 @@
     "labelOtherInfo": "Other information",
     "labelPrice": "Price",
     "labelPublisher": "Publisher information",
-    "linkSearchByPublisher": "See other hobbies by publisher",
+    "linkSearchByPublisher": {
+      "general": "See other events by publisher",
+      "course": "See other hobbies by publisher"
+    },
     "linkWebPage": "Web page",
     "offers": {
       "isFree": "Free"

--- a/packages/common-i18n/src/locales/fi/event.json
+++ b/packages/common-i18n/src/locales/fi/event.json
@@ -55,7 +55,10 @@
     "labelOtherInfo": "Muut tiedot",
     "labelPrice": "Hinta",
     "labelPublisher": "Julkaisijan tiedot",
-    "linkSearchByPublisher": "Katso julkaisijan muut harrastukset",
+    "linkSearchByPublisher": {
+      "general": "Katso julkaisijan muut tapahtumat",
+      "course": "Katso julkaisijan muut harrastukset"
+    },
     "linkWebPage": "Verkkosivu",
     "offers": {
       "isFree": "Maksuton"

--- a/packages/common-i18n/src/locales/sv/event.json
+++ b/packages/common-i18n/src/locales/sv/event.json
@@ -55,7 +55,10 @@
     "labelOtherInfo": "Övrig information",
     "labelPrice": "Pris",
     "labelPublisher": "Utgivare",
-    "linkSearchByPublisher": "Se utgivarens övriga hobbyer",
+    "linkSearchByPublisher": {
+      "general": "Se utgivarens övriga evenemang",
+      "course": "Se utgivarens övriga hobbyer"
+    },
     "linkWebPage": "Webbsida",
     "offers": {
       "isFree": "Gratis"

--- a/packages/components/src/types/event-types.ts
+++ b/packages/components/src/types/event-types.ts
@@ -19,3 +19,6 @@ export const eventTypeToId: Record<EventType, EventTypeId> = {
   event: EventTypeId.General,
   course: EventTypeId.Course,
 };
+
+export const isEventTypeId = (value: unknown): value is EventTypeId =>
+  Object.values(EventTypeId).includes(value as EventTypeId);


### PR DESCRIPTION
## Description

### feat(sports): add combined search publisher filtering to hobbies/events 

Filtering venues by publisher does not work because no publisher
information is currently available in the venue data to the best of my
current knowledge.

refs LIIKUNTA-412
 
### feat(sports): use right publisher link/label in event/hobby detail page

Now links back to the search page using URL parameter:
 - `searchType=General` for events
 - `searchType=Course` for hobbies

The label of the link is also now changed based on whether it points
back to events or hobbies.

Add tests for the publisher link label and URL.

refs LIIKUNTA-412

## Issues

### Closes

**[LIIKUNTA-412](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-412)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Sports hobby detail page:

#### Page with the link:
- ![sports-hobby](https://user-images.githubusercontent.com/77663720/222413853-02f964c1-64bc-443f-87b4-c4ae350f16a2.png)

#### Translations (fi/en/sv):
- ![hobby-fi](https://user-images.githubusercontent.com/77663720/222413336-7e15d429-3817-4ceb-b5d3-792b14e267f0.png)
- ![hobby-en](https://user-images.githubusercontent.com/77663720/222413346-9e0c7485-73b6-4dd5-a857-80cf3ac655c9.png)
- ![hobby-sv](https://user-images.githubusercontent.com/77663720/222413359-917a8336-736b-48fc-9b9a-fe06208c3a93.png)

#### After clicking the link:
![sports-hobby-clicked_link](https://user-images.githubusercontent.com/77663720/222414148-02889995-7e6f-4457-ae2e-bdfe06ae4b12.png)

### Sport event detail page:

#### Page with the link:
 - ![sports-event](https://user-images.githubusercontent.com/77663720/222413864-a5edbe8b-702a-4ef9-8d9c-8095d7c4e192.png)

#### Translations (fi/en/sv):
- ![event-fi](https://user-images.githubusercontent.com/77663720/222413376-cd776f67-6620-4cc0-9c0b-9bd8b9b790f1.png)
- ![event-en](https://user-images.githubusercontent.com/77663720/222413387-f9bc84c0-135a-45da-b775-680710dd7aac.png)
- ![event-sv](https://user-images.githubusercontent.com/77663720/222413397-bcf5ac55-fbf5-4545-9218-1ff5059f0e52.png)

#### After clicking the link:
![sports-event-clicked_link](https://user-images.githubusercontent.com/77663720/222414206-c3e17d39-1ac8-42fe-a29b-ac92cb3686e7.png)

## Additional notes


[LIIKUNTA-412]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ