### PR TITLE
TH-1302 | feat(events): support previous version URLs

### DIFF
--- a/apps/events-helsinki/i18nRoutes.config.js
+++ b/apps/events-helsinki/i18nRoutes.config.js
@@ -1,4 +1,4 @@
-const i18nRoutes = {
+const i18nRoutesCurrentVersion = {
   '/search': [
     { source: '/haku', locale: 'fi' },
     { source: '/sok', locale: 'sv' },
@@ -28,5 +28,20 @@ const i18nRoutes = {
     { source: '/kunskap', locale: 'sv' },
   ],
 };
+
+const i18nRoutesPreviousVersions = {
+  '/fi': [{ source: '/home', locale: 'fi' }],
+  '/sv': [{ source: '/home', locale: 'sv' }],
+  '/en': [{ source: '/home', locale: 'en' }],
+  '/fi/haku': [{ source: '/events', locale: 'fi' }],
+  '/sv/sok': [{ source: '/events', locale: 'sv' }],
+  '/en/search': [{ source: '/events', locale: 'en' }],
+};
+
+const i18nRoutes = Object.assign(
+  {},
+  i18nRoutesPreviousVersions,
+  i18nRoutesCurrentVersion
+);
 
 module.exports = i18nRoutes;

--- a/apps/events-helsinki/i18nRoutes.config.js
+++ b/apps/events-helsinki/i18nRoutes.config.js
@@ -19,14 +19,6 @@ const i18nRoutesCurrentVersion = {
     { source: '/sivut/:slug*', locale: 'fi' },
     { source: '/sidor/:slug*', locale: 'sv' },
   ],
-  '/accessibility': [
-    { source: '/saavutetavuusseloste', locale: 'fi' },
-    { source: '/tillgäntglighetsutlåtande', locale: 'sv' },
-  ],
-  '/about': [
-    { source: '/tietoa', locale: 'fi' },
-    { source: '/kunskap', locale: 'sv' },
-  ],
 };
 
 const i18nRoutesPreviousVersions = {

--- a/apps/events-helsinki/i18nRoutes.config.js
+++ b/apps/events-helsinki/i18nRoutes.config.js
@@ -1,4 +1,4 @@
-const i18nRoutesCurrentVersion = {
+const i18nRoutes = {
   '/search': [
     { source: '/haku', locale: 'fi' },
     { source: '/sok', locale: 'sv' },
@@ -20,20 +20,5 @@ const i18nRoutesCurrentVersion = {
     { source: '/sidor/:slug*', locale: 'sv' },
   ],
 };
-
-const i18nRoutesPreviousVersions = {
-  '/fi': [{ source: '/home', locale: 'fi' }],
-  '/sv': [{ source: '/home', locale: 'sv' }],
-  '/en': [{ source: '/home', locale: 'en' }],
-  '/fi/haku': [{ source: '/events', locale: 'fi' }],
-  '/sv/sok': [{ source: '/events', locale: 'sv' }],
-  '/en/search': [{ source: '/events', locale: 'en' }],
-};
-
-const i18nRoutes = Object.assign(
-  {},
-  i18nRoutesPreviousVersions,
-  i18nRoutesCurrentVersion
-);
 
 module.exports = i18nRoutes;

--- a/apps/events-helsinki/next.config.js
+++ b/apps/events-helsinki/next.config.js
@@ -6,6 +6,7 @@ const { withSentryConfig } = require('@sentry/nextjs');
 const pc = require('picocolors');
 const packageJson = require('./package.json');
 const i18nRoutes = require('./i18nRoutes.config');
+const redirectRoutes = require('./redirectRoutes.config');
 const { i18n } = require('./next-i18next.config');
 
 // const enableCSP = true;
@@ -143,6 +144,16 @@ const nextConfig = {
         destination,
         source: `/${locale}${source}`,
         locale: false,
+      }))
+    );
+  },
+  async redirects() {
+    return Object.entries(redirectRoutes).flatMap(([destination, sources]) =>
+      sources.map(({ source, locale }) => ({
+        destination,
+        source: `/${locale}${source}`,
+        locale: false,
+        permanent: true,
       }))
     );
   },

--- a/apps/events-helsinki/redirectRoutes.config.js
+++ b/apps/events-helsinki/redirectRoutes.config.js
@@ -1,0 +1,10 @@
+const redirectRoutes = {
+  '/fi': [{ source: '/home', locale: 'fi' }],
+  '/sv': [{ source: '/home', locale: 'sv' }],
+  '/en': [{ source: '/home', locale: 'en' }],
+  '/fi/haku': [{ source: '/events', locale: 'fi' }],
+  '/sv/sok': [{ source: '/events', locale: 'sv' }],
+  '/en/search': [{ source: '/events', locale: 'en' }],
+};
+
+module.exports = redirectRoutes;

--- a/apps/events-helsinki/src/__tests__/redirectRoutes.test.tsx
+++ b/apps/events-helsinki/src/__tests__/redirectRoutes.test.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import router from 'next/router';
+import { render, waitFor, screen, userEvent } from '@/test-utils';
+
+// Skip until there is a fix for this NextJS bug https://github.com/vercel/next.js/discussions/26426
+describe.skip('NextJS redirects', () => {
+  it.each([
+    ['/fi/home', '/fi'],
+    ['/sv/home', '/sv'],
+    ['/en/home', '/en'],
+    ['/fi/events', '/fi/haku'],
+    ['/sv/events', '/sv/sok'],
+    ['/en/events', '/en/search'],
+  ])(
+    'should redirect the requests of the old app-version path (%s) to the new path (%s)',
+    async (redirectFrom, redirectTo) => {
+      render(
+        <Link href={redirectFrom}>
+          <a>
+            from {redirectFrom} to {redirectTo}
+          </a>
+        </Link>
+      );
+      const link = screen.getByRole('link');
+      userEvent.click(link);
+      await waitFor(() => {
+        expect(router.asPath).toBe(redirectTo);
+      });
+    }
+  );
+});
+
+// eslint-disable-next-line jest/no-export
+export {};

--- a/apps/hobbies-helsinki/i18nRoutes.config.js
+++ b/apps/hobbies-helsinki/i18nRoutes.config.js
@@ -19,14 +19,6 @@ const i18nRoutes = {
     { source: '/sivut/:slug*', locale: 'fi' },
     { source: '/sidor/:slug*', locale: 'sv' },
   ],
-  '/accessibility': [
-    { source: '/saavutetavuusseloste', locale: 'fi' },
-    { source: '/tillgäntglighetsutlåtande', locale: 'sv' },
-  ],
-  '/about': [
-    { source: '/tietoa', locale: 'fi' },
-    { source: '/kunskap', locale: 'sv' },
-  ],
 };
 
 module.exports = i18nRoutes;

--- a/apps/sports-helsinki/i18nRoutes.config.js
+++ b/apps/sports-helsinki/i18nRoutes.config.js
@@ -27,14 +27,6 @@ const i18nRoutes = {
     { source: '/sivut/:slug*', locale: 'fi' },
     { source: '/sidor/:slug*', locale: 'sv' },
   ],
-  '/accessibility': [
-    { source: '/saavutetavuusseloste', locale: 'fi' },
-    { source: '/tillgäntglighetsutlåtande', locale: 'sv' },
-  ],
-  '/about': [
-    { source: '/tietoa', locale: 'fi' },
-    { source: '/kunskap', locale: 'sv' },
-  ],
 };
 
 module.exports = i18nRoutes;


### PR DESCRIPTION
## Description

### feat(events): rewrite /\<language\>/(home|events) URLS to current URLs 

Rewrite URLs in order to support previous version URLs:
 - /fi/home -> /fi
 - /sv/home -> /sv
 - /en/home -> /en
 - /fi/events -> /fi/haku
 - /sv/events -> /sv/sok
 - /en/events -> /en/search

refs TH-1302
 
### chore: remove accessibility and about rewrite routes as unnecessary 

The /accessibility and /about rewrite routes are unnecessary as the
pages are available at:
 - accessibility page:
   - /fi/sivut/saavutettavuusseloste
   - /en/pages/accessibility-statement
   - /sv/sidor/tillganglighetsutlatande
 - about page:
   - /fi/sivut/tietoa-palvelusta
   - /en/pages/about
   - /sv/sidor/om-tjansten

refs TH-1302
 
### refactor: use redirects instead of rewrites when processing old URLs 

TH-1302

## Issues

### Closes

**[TH-1302](https://helsinkisolutionoffice.atlassian.net/browse/TH-1302)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### https://tapahtumat-pr249.dev.hel.ninja/fi/home
![fi-home](https://user-images.githubusercontent.com/77663720/223147615-c8d4d73c-e42f-4329-9109-11359f6c7ed3.png)

### https://tapahtumat-pr249.dev.hel.ninja/sv/home
![sv-home](https://user-images.githubusercontent.com/77663720/223147645-2fa70d44-e7c7-41d5-b81d-64073621496f.png)

### https://tapahtumat-pr249.dev.hel.ninja/en/home
![en-home](https://user-images.githubusercontent.com/77663720/223147667-a03944c4-77d6-4456-8c5e-b5a90ea69b0c.png)

### https://tapahtumat-pr249.dev.hel.ninja/fi/events
![fi-events](https://user-images.githubusercontent.com/77663720/223147697-01d4ee02-b35c-4316-94ca-d280e366c98e.png)

### https://tapahtumat-pr249.dev.hel.ninja/sv/events
![sv-events](https://user-images.githubusercontent.com/77663720/223147707-55d215ed-1c81-428d-a1a3-da848b070bd4.png)

### https://tapahtumat-pr249.dev.hel.ninja/en/events
![en-events](https://user-images.githubusercontent.com/77663720/223147725-d6d1f1bd-6878-47db-b057-7da4c2590cc8.png)

### https://tapahtumat-pr249.dev.hel.ninja/fi/events?categories=food%2Cdance
![fi-events-with_query_params](https://user-images.githubusercontent.com/77663720/223148705-e5665c3b-41a9-4127-baf3-9979b2e667a5.png)

### https://tapahtumat-pr249.dev.hel.ninja/sv/events?categories=food%2Cdance
![sv-events-with_query_params](https://user-images.githubusercontent.com/77663720/223148732-e6e8d8f0-b891-4a37-bbe3-7350e4490b2f.png)

### https://tapahtumat-pr249.dev.hel.ninja/en/events?categories=food%2Cdance
![en-events-with_query_params](https://user-images.githubusercontent.com/77663720/223148755-08cf0560-a6c8-42e8-a0ed-2a9ea750efa1.png)

### https://tapahtumat-pr249.dev.hel.ninja/fi/events/helsinki:agdadusgui
![fi-events-detail_page](https://user-images.githubusercontent.com/77663720/223148784-3c86bf4f-89d3-4b51-91e2-edde039dcce3.png)

### https://tapahtumat-pr249.dev.hel.ninja/sv/events/helsinki:agdadusgui
![sv-events-detail_page](https://user-images.githubusercontent.com/77663720/223148857-cd5c7fef-f7fd-46a3-b5ac-cf9535305737.png)

### https://tapahtumat-pr249.dev.hel.ninja/en/events/helsinki:agdadusgui
![en-events-detail_page](https://user-images.githubusercontent.com/77663720/223148873-7cfb2a3d-1a02-40ab-bade-159ffb412afb.png)

## Additional notes


[TH-1302]: https://helsinkisolutionoffice.atlassian.net/browse/TH-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ