### PR TITLE
refactor: use redirects instead of rewrites when processing old URLs

### DIFF
--- a/apps/events-helsinki/i18nRoutes.config.js
+++ b/apps/events-helsinki/i18nRoutes.config.js
@@ -1,4 +1,4 @@
-const i18nRoutesCurrentVersion = {
+const i18nRoutes = {
   '/search': [
     { source: '/haku', locale: 'fi' },
     { source: '/sok', locale: 'sv' },
@@ -20,20 +20,5 @@ const i18nRoutesCurrentVersion = {
     { source: '/sidor/:slug*', locale: 'sv' },
   ],
 };
-
-const i18nRoutesPreviousVersions = {
-  '/fi': [{ source: '/home', locale: 'fi' }],
-  '/sv': [{ source: '/home', locale: 'sv' }],
-  '/en': [{ source: '/home', locale: 'en' }],
-  '/fi/haku': [{ source: '/events', locale: 'fi' }],
-  '/sv/sok': [{ source: '/events', locale: 'sv' }],
-  '/en/search': [{ source: '/events', locale: 'en' }],
-};
-
-const i18nRoutes = Object.assign(
-  {},
-  i18nRoutesPreviousVersions,
-  i18nRoutesCurrentVersion
-);
 
 module.exports = i18nRoutes;

--- a/apps/events-helsinki/next.config.js
+++ b/apps/events-helsinki/next.config.js
@@ -6,6 +6,7 @@ const { withSentryConfig } = require('@sentry/nextjs');
 const pc = require('picocolors');
 const packageJson = require('./package.json');
 const i18nRoutes = require('./i18nRoutes.config');
+const redirectRoutes = require('./redirectRoutes.config');
 const { i18n } = require('./next-i18next.config');
 
 // const enableCSP = true;
@@ -143,6 +144,16 @@ const nextConfig = {
         destination,
         source: `/${locale}${source}`,
         locale: false,
+      }))
+    );
+  },
+  async redirects() {
+    return Object.entries(redirectRoutes).flatMap(([destination, sources]) =>
+      sources.map(({ source, locale }) => ({
+        destination,
+        source: `/${locale}${source}`,
+        locale: false,
+        permanent: true,
       }))
     );
   },

--- a/apps/events-helsinki/redirectRoutes.config.js
+++ b/apps/events-helsinki/redirectRoutes.config.js
@@ -1,0 +1,10 @@
+const redirectRoutes = {
+  '/fi': [{ source: '/home', locale: 'fi' }],
+  '/sv': [{ source: '/home', locale: 'sv' }],
+  '/en': [{ source: '/home', locale: 'en' }],
+  '/fi/haku': [{ source: '/events', locale: 'fi' }],
+  '/sv/sok': [{ source: '/events', locale: 'sv' }],
+  '/en/search': [{ source: '/events', locale: 'en' }],
+};
+
+module.exports = redirectRoutes;

--- a/apps/events-helsinki/src/__tests__/redirectRoutes.test.tsx
+++ b/apps/events-helsinki/src/__tests__/redirectRoutes.test.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import router from 'next/router';
+import { render, waitFor, screen, userEvent } from '@/test-utils';
+
+// Skip until there is a fix for this NextJS bug https://github.com/vercel/next.js/discussions/26426
+describe.skip('NextJS redirects', () => {
+  it.each([
+    ['/fi/home', '/fi'],
+    ['/sv/home', '/sv'],
+    ['/en/home', '/en'],
+    ['/fi/events', '/fi/haku'],
+    ['/sv/events', '/sv/sok'],
+    ['/en/events', '/en/search'],
+  ])(
+    'should redirect the requests of the old app-version path (%s) to the new path (%s)',
+    async (redirectFrom, redirectTo) => {
+      render(
+        <Link href={redirectFrom}>
+          <a>
+            from {redirectFrom} to {redirectTo}
+          </a>
+        </Link>
+      );
+      const link = screen.getByRole('link');
+      userEvent.click(link);
+      await waitFor(() => {
+        expect(router.asPath).toBe(redirectTo);
+      });
+    }
+  );
+});
+
+// eslint-disable-next-line jest/no-export
+export {};


### PR DESCRIPTION
TH-1302. This pull requests modifies the `rewrites` -implementation of #249 so that it uses `redirects` instead, which is good for clients, because they can investigate that the URLs are permanently moved.

The used redirects table can be seen when the app is built with a `--debug` -flag (`yarn build --debug`):

```
Redirects

┌ source: /:path+/
├ destination: /:path+
└ permanent: true

┌ source: /fi/home
├ destination: /fi
└ permanent: true

┌ source: /sv/home
├ destination: /sv
└ permanent: true

┌ source: /en/home
├ destination: /en
└ permanent: true

┌ source: /fi/events
├ destination: /fi/haku
└ permanent: true

┌ source: /sv/events
├ destination: /sv/sok
└ permanent: true

┌ source: /en/events
├ destination: /en/search
└ permanent: true
 

Headers

┌ source: /:nextInternalLocale(default|fi|sv|en)/:path((?!api).*)*
└ headers:
  └ Cross-Origin-Opener-Policy: same-origin
  ├ Cross-Origin-Embedder-Policy: same-origin
 

Rewrites

┌ source: /fi/haku
└ destination: /search

┌ source: /sv/sok
└ destination: /search

┌ source: /fi/tapahtumat/:eventId
└ destination: /events/:eventId

┌ source: /sv/kurser/:eventId
└ destination: /events/:eventId

┌ source: /fi/artikkelit
└ destination: /articles

┌ source: /sv/artiklar
└ destination: /articles

┌ source: /fi/artikkelit/:slug*
└ destination: /articles/:slug*

┌ source: /sv/artiklar/:slug*
└ destination: /articles/:slug*

┌ source: /fi/sivut/:slug*
└ destination: /pages/:slug*

┌ source: /sv/sidor/:slug*
└ destination: /pages/:slug*
```

NOTE: Too bad the unit test was not supported for the redirects yet. The whole test could be removed if decided so, because it does not do anything at the moment.