### PR TITLE
Improvements and fixes to the common error page

### DIFF
--- a/apps/events-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/events-helsinki/src/domain/event/EventPageContainer.tsx
@@ -13,6 +13,7 @@ import type {
   SuperEventResponse,
   EventFieldsFragment,
 } from 'events-helsinki-components';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { useState } from 'react';
@@ -26,7 +27,10 @@ import EventContent from './eventContent/EventContent';
 import EventHero from './eventHero/EventHero';
 import styles from './eventPage.module.scss';
 import EventPageMeta from './eventPageMeta/EventPageMeta';
-import SimilarEvents from './similarEvents/SimilarEvents';
+
+const SimilarEvents = dynamic(() => import('./similarEvents/SimilarEvents'), {
+  ssr: false,
+});
 
 export interface EventPageContainerProps {
   loading: boolean;

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -84,8 +84,15 @@ const NextCmsArticle: NextPage<{
 };
 
 export async function getStaticPaths() {
-  // NOTE: It might not be a good thing to use ApolloClient here,
-  // since then the build process depends on external service.
+  // Do not prerender any static pages when in preview environment
+  // (faster builds, but slower initial page load)
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
+  }
+
   const articlePageInfos = await getAllArticles(eventsApolloClient);
   const paths = articlePageInfos.map((pageInfo) => ({
     params: { slug: cmsHelper.getSlugFromUri(pageInfo.uri) },
@@ -93,7 +100,7 @@ export async function getStaticPaths() {
   }));
   return {
     paths,
-    fallback: true, // can also be true or 'blocking'
+    fallback: true,
   };
 }
 

--- a/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
+++ b/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
@@ -51,7 +51,7 @@ export default Event;
 export async function getStaticPaths() {
   return {
     paths: [],
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -71,7 +71,6 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     if (!eventData) {
       return {
         notFound: true,
-        revalidate: true,
       };
     }
     const event = eventData?.eventDetails;
@@ -81,8 +80,6 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         event,
         loading,
         ...(await serverSideTranslationsWithCommon(language, [
-          'common',
-          'home',
           'search',
           'event',
         ])),

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -75,8 +75,15 @@ const NextCmsPage: NextPage<{
 };
 
 export async function getStaticPaths() {
-  // NOTE: It might not be a good thing to use ApolloClient here,
-  // since then the build process depends on external service.
+  // Do not prerender any static pages when in preview environment
+  // (faster builds, but slower initial page load)
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
+  }
+
   const pagePageInfos = await getAllPages(eventsApolloClient);
   const paths = pagePageInfos
     .map((pageInfo) => ({
@@ -87,7 +94,7 @@ export async function getStaticPaths() {
     .filter((entry) => entry.params.slug && entry.params.slug.length);
   return {
     paths,
-    fallback: true, // can also be true or 'blocking'
+    fallback: true,
   };
 }
 

--- a/apps/hobbies-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/EventPageContainer.tsx
@@ -2,7 +2,6 @@ import { useLazyQuery } from '@apollo/client';
 import {
   LoadingSpinner,
   useLocale,
-  isClient,
   addParamsToQueryString,
   getEventIdFromUrl,
   isEventClosed,
@@ -13,6 +12,7 @@ import type {
   SuperEventResponse,
   EventFields,
 } from 'events-helsinki-components';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { useState } from 'react';
@@ -26,7 +26,10 @@ import EventContent from './eventContent/EventContent';
 import EventHero from './eventHero/EventHero';
 import styles from './eventPage.module.scss';
 import EventPageMeta from './eventPageMeta/EventPageMeta';
-import SimilarEvents from './similarEvents/SimilarEvents';
+
+const SimilarEvents = dynamic(() => import('./similarEvents/SimilarEvents'), {
+  ssr: false,
+});
 
 export interface EventPageContainerProps {
   loading: boolean;
@@ -111,7 +114,7 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
                 </>
               )}
               {/* Hide similar event on SSR to make initial load faster */}
-              {isClient && showSimilarEvents && !eventClosed && (
+              {showSimilarEvents && !eventClosed && (
                 <SimilarEvents
                   event={event}
                   onEventsLoaded={handleSimilarEventsLoaded}

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -83,8 +83,15 @@ const NextCmsArticle: NextPage<{
 };
 
 export async function getStaticPaths() {
-  // NOTE: It might not be a good thing to use ApolloClient here,
-  // since then the build process depends on external service.
+  // Do not prerender any static pages when in preview environment
+  // (faster builds, but slower initial page load)
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
+  }
+
   const articlePageInfos = await getAllArticles(hobbiesApolloClient);
   const paths = articlePageInfos.map((pageInfo) => ({
     params: { slug: cmsHelper.getSlugFromUri(pageInfo.uri) },
@@ -92,7 +99,7 @@ export async function getStaticPaths() {
   }));
   return {
     paths,
-    fallback: true, // can also be true or 'blocking'
+    fallback: true,
   };
 }
 

--- a/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -51,7 +51,7 @@ export default Event;
 export async function getStaticPaths() {
   return {
     paths: [],
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -80,8 +80,6 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         event,
         loading,
         ...(await serverSideTranslationsWithCommon(language, [
-          'common',
-          'home',
           'search',
           'event',
         ])),

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -74,8 +74,15 @@ const NextCmsPage: NextPage<{
 };
 
 export async function getStaticPaths() {
-  // NOTE: It might not be a good thing to use ApolloClient here,
-  // since then the build process depends on external service.
+  // Do not prerender any static pages when in preview environment
+  // (faster builds, but slower initial page load)
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
+  }
+
   const pagePageInfos = await getAllPages(hobbiesApolloClient);
   const paths = pagePageInfos
     .map((pageInfo) => ({
@@ -86,7 +93,7 @@ export async function getStaticPaths() {
     .filter((entry) => entry.params.slug && entry.params.slug.length);
   return {
     paths,
-    fallback: true, // can also be true or 'blocking'
+    fallback: true,
   };
 }
 

--- a/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
@@ -13,6 +13,7 @@ import type {
   SuperEventResponse,
   EventFields,
 } from 'events-helsinki-components';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { useState } from 'react';
@@ -26,7 +27,10 @@ import EventContent from './eventContent/EventContent';
 import EventHero from './eventHero/EventHero';
 import styles from './eventPage.module.scss';
 import EventPageMeta from './eventPageMeta/EventPageMeta';
-import SimilarEvents from './similarEvents/SimilarEvents';
+
+const SimilarEvents = dynamic(() => import('./similarEvents/SimilarEvents'), {
+  ssr: false,
+});
 
 export interface EventPageContainerProps {
   loading: boolean;

--- a/apps/sports-helsinki/src/domain/venue/venueLocation/VenueLocation.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueLocation/VenueLocation.tsx
@@ -1,11 +1,11 @@
 import type { Venue } from 'events-helsinki-components';
 import {
   useCommonTranslation,
-  MapBox,
   InfoBlock,
   Text,
 } from 'events-helsinki-components';
 import { IconAngleDown } from 'hds-react';
+import dynamic from 'next/dynamic';
 import React from 'react';
 import {
   getGoogleDirectionsUrl,
@@ -14,6 +14,13 @@ import {
 } from '../utils/getVenueDirections';
 import getVenueIdParts from '../utils/getVenueIdParts';
 import styles from './venueLocation.module.scss';
+
+const MapBox = dynamic(
+  () => import('events-helsinki-components').then((mod) => mod.MapBox),
+  {
+    ssr: false,
+  }
+);
 
 const VenueLocation = ({ venue }: { venue: Venue }) => {
   const { t } = useCommonTranslation();

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -84,8 +84,15 @@ const NextCmsArticle: NextPage<{
 };
 
 export async function getStaticPaths() {
-  // NOTE: It might not be a good thing to use ApolloClient here,
-  // since then the build process depends on external service.
+  // Do not prerender any static pages when in preview environment
+  // (faster builds, but slower initial page load)
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
+  }
+
   const articlePageInfos = await getAllArticles(sportsApolloClient);
   const paths = articlePageInfos.map((pageInfo) => ({
     params: { slug: cmsHelper.getSlugFromUri(pageInfo.uri) },
@@ -93,7 +100,7 @@ export async function getStaticPaths() {
   }));
   return {
     paths,
-    fallback: true, // can also be true or 'blocking'
+    fallback: true,
   };
 }
 

--- a/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -27,7 +27,6 @@ const Event: NextPage<{
 }> = ({ event, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useCommonTranslation();
-
   return (
     <MatomoWrapper>
       <RHHCPage
@@ -53,7 +52,7 @@ export default Event;
 export async function getStaticPaths() {
   return {
     paths: [],
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -75,8 +75,15 @@ const NextCmsPage: NextPage<{
 };
 
 export async function getStaticPaths() {
-  // NOTE: It might not be a good thing to use ApolloClient here,
-  // since then the build process depends on external service.
+  // Do not prerender any static pages when in preview environment
+  // (faster builds, but slower initial page load)
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
+  }
+
   const pagePageInfos = await getAllPages(sportsApolloClient);
   const paths = pagePageInfos
     .map((pageInfo) => ({
@@ -87,7 +94,7 @@ export async function getStaticPaths() {
     .filter((entry) => entry.params.slug && entry.params.slug.length);
   return {
     paths,
-    fallback: true, // can also be true or 'blocking'
+    fallback: true,
   };
 }
 

--- a/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
@@ -51,7 +51,7 @@ export default Event;
 export async function getStaticPaths() {
   return {
     paths: [],
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 

--- a/packages/components/src/app/BaseApp.tsx
+++ b/packages/components/src/app/BaseApp.tsx
@@ -4,7 +4,6 @@ import {
 } from '@jonkoops/matomo-tracker-react';
 import 'nprogress/nprogress.css';
 
-import { LoadingSpinner } from 'hds-react';
 import type { SSRConfig } from 'next-i18next';
 import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -16,28 +15,9 @@ import ErrorFallback from '../components/errorPages/ErrorFallback';
 import EventsCookieConsent from '../components/eventsCookieConsent/EventsCookieConsent';
 import ResetFocus from '../components/resetFocus/ResetFocus';
 import { GeolocationProvider } from '../geolocation';
-import useCommonTranslation from '../hooks/useCommonTranslation';
 import { NavigationProvider } from '../navigationProvider';
 import type { NavigationProviderProps } from '../navigationProvider';
 import type { CmsRoutedAppHelper, HeadlessCMSHelper } from '../utils';
-
-function PageLoadingSpinner() {
-  return (
-    <div
-      style={{
-        width: '100vw',
-        height: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <LoadingSpinner />
-    </div>
-  );
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 
 export type Props = {
   children: React.ReactNode;
@@ -58,7 +38,6 @@ function BaseApp({
   routerHelper,
   matomoConfiguration,
 }: Props) {
-  const { t } = useCommonTranslation();
   // Unset hidden visibility that was applied to hide the first server render
   // that does not include styles from HDS. HDS applies styling by injecting
   // style tags into the head. This requires the existence of a document object.
@@ -77,6 +56,7 @@ function BaseApp({
 
   const matomoInstance = React.useMemo(
     () => createMatomoInstance(matomoConfiguration),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [createMatomoInstance]
   );
 
@@ -87,25 +67,23 @@ function BaseApp({
   return (
     <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
       <ErrorBoundary FallbackComponent={FallbackComponent}>
-        <React.Suspense fallback={<PageLoadingSpinner />}>
-          <MatomoProvider value={matomoInstance}>
-            <GeolocationProvider>
-              <NavigationProvider
-                headerMenu={headerMenu}
-                footerMenu={footerMenu}
-                languages={languages}
-              >
-                <ResetFocus />
-                {children}
-                <EventsCookieConsent
-                  allowLanguageSwitch={false}
-                  appName={appName}
-                />
-                <ToastContainer />
-              </NavigationProvider>
-            </GeolocationProvider>
-          </MatomoProvider>
-        </React.Suspense>
+        <MatomoProvider value={matomoInstance}>
+          <GeolocationProvider>
+            <NavigationProvider
+              headerMenu={headerMenu}
+              footerMenu={footerMenu}
+              languages={languages}
+            >
+              <ResetFocus />
+              {children}
+              <EventsCookieConsent
+                allowLanguageSwitch={false}
+                appName={appName}
+              />
+              <ToastContainer />
+            </NavigationProvider>
+          </GeolocationProvider>
+        </MatomoProvider>
       </ErrorBoundary>
     </CmsHelperProvider>
   );

--- a/packages/components/src/components/domain/event/eventLocation/EventLocation.tsx
+++ b/packages/components/src/components/domain/event/eventLocation/EventLocation.tsx
@@ -1,9 +1,14 @@
+import dynamic from 'next/dynamic';
 import React from 'react';
-import MapBox from '../../../../components/mapBox/MapBox';
+
 import useCommonTranslation from '../../../../hooks/useCommonTranslation';
 import useLocale from '../../../../hooks/useLocale';
 import type { AppLanguage, EventFields } from '../../../../types';
 import { getEventFields, getServiceMapUrl } from '../../../../utils/eventUtils';
+
+const MapBox = dynamic(() => import('../../../../components/mapBox/MapBox'), {
+  ssr: false,
+});
 
 interface Props {
   event: EventFields;

--- a/packages/components/src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx
+++ b/packages/components/src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx
@@ -19,14 +19,12 @@ const event = fakeEvent({
   name: { fi: eventName },
 }) as EventFields;
 
-it('should render 1 mapLink and 2 directionsLink', () => {
+it('should render 1 mapLink and 2 directionsLink', async () => {
   render(<EventLocation event={event} />);
 
-  expect(
-    screen.getByRole('link', {
-      name: /Avaa kartta. Avautuu uudessa välilehdessä. Avautuu toisella sivustolla./i,
-    })
-  ).toBeInTheDocument();
+  await screen.findByRole('link', {
+    name: /Avaa kartta. Avautuu uudessa välilehdessä. Avautuu toisella sivustolla./i,
+  });
   expect(
     screen.getByRole('link', { name: /reittiohjeet \(hsl\)/i })
   ).toBeInTheDocument();


### PR DESCRIPTION
HH-254. Improvements and fixes to https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/216. Related to the investigation mentioned in https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/216#pullrequestreview-1326463452.

1. Language change breaks the page
2. Suspense not working
3. Unhandled Runtime Error - Error: Text content does not match server-rendered HTML.
4. A graphql network issue
5. Several rehydration issues

---- 

As a comment to these issues: I saw only the rehydration issues. I couldn't reproduce any of the rest. The result might have been an empty white page or a debug error page from the NextJS, but it was always the same thing causing them: The rehydration issue, which was caused by the MapBox being rendered on server side, which then made a different kind of result when client rendered it.