### PR TITLE
fix: show venue info in mobile

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -116,7 +116,7 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
                 </div>
                 <h1 className={styles.title}>{venue.name}</h1>
                 <div className={styles.additionalInfo}>
-                  <Visible above="s" className={styles.location}>
+                  <div className={styles.location}>
                     <ul className={styles.headerInfoLines}>
                       {infoLines.map((infoLine) => (
                         <li
@@ -127,7 +127,7 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
                         </li>
                       ))}
                     </ul>
-                  </Visible>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Description
Show all info in mobile hero view same as in desktop

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
