### PR TITLE
chore: enable turbotrace for apps

### DIFF
--- a/apps/events-helsinki/next.config.js
+++ b/apps/events-helsinki/next.config.js
@@ -176,11 +176,10 @@ const nextConfig = {
   output: 'standalone',
 
   experimental: {
-    /*    turbotrace: {
+    turbotrace: {
       contextDirectory: path.resolve(__dirname, '../..'),
       logDetail: true,
-    }, */
-    outputFileTracingRoot: path.resolve(__dirname, '../..'),
+    },
     // Prefer loading of ES Modules over CommonJS
     // @link {https://nextjs.org/blog/next-11-1#es-modules-support|Blog 11.1.0}
     // @link {https://github.com/vercel/next.js/discussions/27876|Discussion}

--- a/apps/hobbies-helsinki/next.config.js
+++ b/apps/hobbies-helsinki/next.config.js
@@ -176,11 +176,11 @@ const nextConfig = {
   output: 'standalone',
 
   experimental: {
-    /*    turbotrace: {
+    turbotrace: {
       contextDirectory: path.resolve(__dirname, '../..'),
       logDetail: true,
-    }, */
-    outputFileTracingRoot: path.resolve(__dirname, '../..'),
+    },
+    //    outputFileTracingRoot: path.resolve(__dirname, '../..'),
     // Prefer loading of ES Modules over CommonJS
     // @link {https://nextjs.org/blog/next-11-1#es-modules-support|Blog 11.1.0}
     // @link {https://github.com/vercel/next.js/discussions/27876|Discussion}

--- a/apps/sports-helsinki/next.config.js
+++ b/apps/sports-helsinki/next.config.js
@@ -176,11 +176,10 @@ const nextConfig = {
   output: 'standalone',
 
   experimental: {
-    /*    turbotrace: {
+    turbotrace: {
       contextDirectory: path.resolve(__dirname, '../..'),
       logDetail: true,
-    }, */
-    outputFileTracingRoot: path.resolve(__dirname, '../..'),
+    },
     // Prefer loading of ES Modules over CommonJS
     // @link {https://nextjs.org/blog/next-11-1#es-modules-support|Blog 11.1.0}
     // @link {https://github.com/vercel/next.js/discussions/27876|Discussion}


### PR DESCRIPTION
## Description
Turbotrace should make tracing of dependencies faster: https://nextjs.org/docs/advanced-features/output-file-tracing#experimental-turbotrace

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
