### PR TITLE
fix: infinite loop with error page on Apollo client network errors

### DIFF
--- a/apps/events-helsinki/src/domain/app/getEventsStaticProps.ts
+++ b/apps/events-helsinki/src/domain/app/getEventsStaticProps.ts
@@ -28,8 +28,7 @@ export default async function getEventsStaticProps<P = Record<string, any>>(
   context: GetStaticPropsContext,
   tryToGetPageProps: (
     eventsContext: EventsContext
-  ) => Promise<GetStaticPropsResult<P>>,
-  handleError = true
+  ) => Promise<GetStaticPropsResult<P>>
 ) {
   const language = getLanguageOrDefault(context.locale);
   const apolloClient = initializeEventsApolloClient();
@@ -59,21 +58,18 @@ export default async function getEventsStaticProps<P = Record<string, any>>(
   } catch (e: unknown) {
     // Generic error handling
     staticGenerationLogger.error(`Error while generating a page: ${e}`, e);
-    if (handleError) {
-      if (isApolloError(e as Error)) {
-        return {
-          props: {
-            error: {
-              statusCode: 500,
-            },
+    if (isApolloError(e as Error)) {
+      return {
+        revalidate: 1,
+        props: {
+          error: {
+            statusCode: 500,
           },
-        };
-      }
-      throw e;
+        },
+      };
     }
+    throw e;
   }
-  // to avoid "Did you forget to add a `return`" -error
-  return { props: {} };
 }
 
 type GetGlobalCMSDataParams = {

--- a/apps/events-helsinki/src/pages/_error.tsx
+++ b/apps/events-helsinki/src/pages/_error.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+/**
+ * Due to translation problem: https://github.com/i18next/next-i18next/issues/1020
+ * let's redirect always to the pages/error.tsx page.
+ */
+const NextErrorPage = () => {
+  const router = useRouter();
+  React.useEffect(() => {
+    router.replace('/error');
+  }, [router]);
+  return null;
+};
+export default NextErrorPage;

--- a/apps/events-helsinki/src/pages/error.tsx
+++ b/apps/events-helsinki/src/pages/error.tsx
@@ -20,19 +20,12 @@ const Error: NextPage = () => {
 export default Error;
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-  return getEventsStaticProps(
-    context,
-    async () => {
-      const language = getLanguageOrDefault(context.locale);
-      return {
-        props: {
-          ...(await serverSideTranslationsWithCommon(language, [
-            'common',
-            'errors',
-          ])),
-        },
-      };
-    },
-    false
-  );
+  return getEventsStaticProps(context, async () => {
+    const language = getLanguageOrDefault(context.locale);
+    return {
+      props: {
+        ...(await serverSideTranslationsWithCommon(language)),
+      },
+    };
+  });
 }

--- a/apps/hobbies-helsinki/src/domain/app/getHobbiesStaticProps.ts
+++ b/apps/hobbies-helsinki/src/domain/app/getHobbiesStaticProps.ts
@@ -28,8 +28,7 @@ export default async function getHobbiesStaticProps<P = Record<string, any>>(
   context: GetStaticPropsContext,
   tryToGetPageProps: (
     hobbiesContext: HobbiesContext
-  ) => Promise<GetStaticPropsResult<P>>,
-  handleError = true
+  ) => Promise<GetStaticPropsResult<P>>
 ) {
   try {
     const language = getLanguageOrDefault(context.locale);
@@ -53,28 +52,25 @@ export default async function getHobbiesStaticProps<P = Record<string, any>>(
 
     return {
       // Apply revalidate, allow it to be overwritten
-      revalidate: handleError ? AppConfig.defaultRevalidate : Infinity,
+      revalidate: AppConfig.defaultRevalidate,
       ...result,
       props,
     };
   } catch (e: unknown) {
     // Generic error handling
     staticGenerationLogger.error(`Error while generating a page: ${e}`, e);
-    if (handleError) {
-      if (isApolloError(e as Error)) {
-        return {
-          props: {
-            error: {
-              statusCode: 500,
-            },
+    if (isApolloError(e as Error)) {
+      return {
+        revalidate: 1,
+        props: {
+          error: {
+            statusCode: 500,
           },
-        };
-      }
-      throw e;
+        },
+      };
     }
+    throw e;
   }
-  // to avoid "Did you forget to add a `return`" -error
-  return { props: {} };
 }
 
 type GetGlobalCMSDataParams = {

--- a/apps/hobbies-helsinki/src/pages/_app.tsx
+++ b/apps/hobbies-helsinki/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import 'nprogress/nprogress.css';
 import type { NavigationProviderProps } from 'events-helsinki-components';
 import { BaseApp, useCommonTranslation } from 'events-helsinki-components';
-import type { AppProps as NextAppProps } from 'next/app';
 import type { SSRConfig } from 'next-i18next';
 import { appWithTranslation } from 'next-i18next';
 import React from 'react';

--- a/apps/hobbies-helsinki/src/pages/_error.tsx
+++ b/apps/hobbies-helsinki/src/pages/_error.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+/**
+ * Due to translation problem: https://github.com/i18next/next-i18next/issues/1020
+ * let's redirect always to the pages/error.tsx page.
+ */
+const NextErrorPage = () => {
+  const router = useRouter();
+  React.useEffect(() => {
+    router.replace('/error');
+  }, [router]);
+  return null;
+};
+export default NextErrorPage;

--- a/apps/hobbies-helsinki/src/pages/error.tsx
+++ b/apps/hobbies-helsinki/src/pages/error.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   UnknownError,
-  useCommonTranslation,
+  useAppHobbiesTranslation,
 } from 'events-helsinki-components';
 
 import type { GetStaticPropsContext, NextPage } from 'next';
@@ -13,8 +13,8 @@ import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslati
  * Let's use this page instead. the `_error_tsx` routes also to this page
  */
 const Error: NextPage = () => {
-  const { t } = useCommonTranslation();
-  return <UnknownError appName={t(`appSports:appName`)} />;
+  const { t } = useAppHobbiesTranslation();
+  return <UnknownError appName={t(`appHobbies:appName`)} />;
 };
 export default Error;
 
@@ -22,10 +22,7 @@ export async function getServerSideProps(context: GetStaticPropsContext) {
   const language = getLanguageOrDefault(context.locale);
   return {
     props: {
-      ...(await serverSideTranslationsWithCommon(language, [
-        'common',
-        'errors',
-      ])),
+      ...(await serverSideTranslationsWithCommon(language)),
     },
   };
 }

--- a/apps/sports-helsinki/src/domain/app/getSportsStaticProps.ts
+++ b/apps/sports-helsinki/src/domain/app/getSportsStaticProps.ts
@@ -27,8 +27,7 @@ export default async function getSportsStaticProps<P = Record<string, unknown>>(
   context: GetStaticPropsContext,
   tryToGetPageProps: (
     sportsContext: SportsContext
-  ) => Promise<GetStaticPropsResult<P>>,
-  handleError = true
+  ) => Promise<GetStaticPropsResult<P>>
 ) {
   const language = getLanguageOrDefault(context.locale);
   const apolloClient = initializeSportsApolloClient();
@@ -58,21 +57,19 @@ export default async function getSportsStaticProps<P = Record<string, unknown>>(
   } catch (e: unknown) {
     // Generic error handling
     staticGenerationLogger.error(`Error while generating a page: ${e}`, e);
-    if (handleError) {
-      if (isApolloError(e as Error)) {
-        return {
-          props: {
-            error: {
-              statusCode: 500,
-            },
+
+    if (isApolloError(e as Error)) {
+      return {
+        revalidate: 1,
+        props: {
+          error: {
+            statusCode: 500,
           },
-        };
-      }
-      throw e;
+        },
+      };
     }
+    throw e;
   }
-  // to avoid "Did you forget to add a `return`" -error
-  return { props: {} };
 }
 
 type GetGlobalCMSDataParams = {

--- a/apps/sports-helsinki/src/pages/_error.tsx
+++ b/apps/sports-helsinki/src/pages/_error.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+/**
+ * Due to translation problem: https://github.com/i18next/next-i18next/issues/1020
+ * let's redirect always to the pages/error.tsx page.
+ */
+const NextErrorPage = () => {
+  const router = useRouter();
+  React.useEffect(() => {
+    router.replace('/error');
+  }, [router]);
+  return null;
+};
+export default NextErrorPage;

--- a/apps/sports-helsinki/src/pages/error.tsx
+++ b/apps/sports-helsinki/src/pages/error.tsx
@@ -20,19 +20,12 @@ const Error: NextPage = () => {
 export default Error;
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-  return getSportsStaticProps(
-    context,
-    async () => {
-      const language = getLanguageOrDefault(context.locale);
-      return {
-        props: {
-          ...(await serverSideTranslationsWithCommon(language, [
-            'common',
-            'errors',
-          ])),
-        },
-      };
-    },
-    false
-  );
+  return getSportsStaticProps(context, async () => {
+    const language = getLanguageOrDefault(context.locale);
+    return {
+      props: {
+        ...(await serverSideTranslationsWithCommon(language)),
+      },
+    };
+  });
 }

--- a/packages/components/src/components/errorPages/ErrorPage.tsx
+++ b/packages/components/src/components/errorPages/ErrorPage.tsx
@@ -1,16 +1,62 @@
 import { Button, IconCrossCircle } from 'hds-react';
 import { useRouter } from 'next/router';
-import React, { useContext } from 'react';
+import React from 'react';
+import type {
+  Language,
+  LanguageCodeEnum,
+  Menu,
+} from 'react-helsinki-headless-cms';
 import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import { MAIN_CONTENT_ID } from '../../constants';
 import useErrorsTranslation from '../../hooks/useErrorsTranslation';
 import useLocale from '../../hooks/useLocale';
-import NavigationContext from '../../navigationProvider/NavigationContext';
 import FooterSection from '../footer/Footer';
 import MatomoWrapper from '../matomoWrapper/MatomoWrapper';
-
 import Navigation from '../navigation/Navigation';
 import styles from './errorPage.module.scss';
+
+/**
+ * This is just a mock of list of Languages.
+ * The react-helsinki-headless-cms needs typeof `Language[]` in a list of lanugages,
+ * and at least the current language must present in the list.
+ * The error page should not fetch langauges by using the Apollo client,
+ * because the network error in the Apollo client is
+ * usually the reason to show the error page.
+ */
+const HARDCODED_LANGUAGES = [
+  {
+    __typename: 'Language',
+    id: 'TGFuZ3VhZ2U6Zmk=',
+    locale: 'fi',
+    name: 'Suomi',
+    code: 'FI' as LanguageCodeEnum,
+    slug: 'fi',
+  },
+  {
+    __typename: 'Language',
+    id: 'TGFuZ3VhZ2U6ZW4=',
+    locale: 'en_US',
+    name: 'English',
+    code: 'EN' as LanguageCodeEnum,
+    slug: 'en',
+  },
+  {
+    __typename: 'Language',
+    id: 'TGFuZ3VhZ2U6c3Y=',
+    locale: 'sv_SE',
+    name: 'Svenska',
+    code: 'SV' as LanguageCodeEnum,
+    slug: 'sv',
+  },
+] as Language[];
+
+/** This is just a mock of footer menu to prevent
+ * Apollo client to query it on error page.
+ * The error page should not fetch the menu by using the Apollo client,
+ * because the network error in the Apollo client is
+ * usually the reason to show the error page.
+ * */
+const HARDCODED_FOOTER_MENU = { menuItems: { nodes: [] } } as unknown as Menu;
 
 export type ErrorPageProps = {
   headerText: string;
@@ -23,7 +69,6 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
   descriptionText,
   appName,
 }) => {
-  const { footerMenu } = useContext(NavigationContext);
   const { t } = useErrorsTranslation();
   const router = useRouter();
   const locale = useLocale();
@@ -36,7 +81,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
     <MatomoWrapper>
       <RHHCPage
         className="pageLayout"
-        navigation={<Navigation />}
+        navigation={<Navigation languages={HARDCODED_LANGUAGES} />}
         content={
           <div className={styles.errorPageWrapper}>
             <main id={MAIN_CONTENT_ID}>
@@ -51,7 +96,9 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
             </main>
           </div>
         }
-        footer={<FooterSection menu={footerMenu} appName={appName} />}
+        footer={
+          <FooterSection menu={HARDCODED_FOOTER_MENU} appName={appName} />
+        }
       />
     </MatomoWrapper>
   );

--- a/packages/components/src/components/navigation/Navigation.tsx
+++ b/packages/components/src/components/navigation/Navigation.tsx
@@ -18,21 +18,29 @@ type NavigationProps = {
   languages?: Language[];
 };
 
-export default function Navigation({ page }: NavigationProps) {
+export default function Navigation({
+  page,
+  menu,
+  languages: forcedLanguages, // FIXME: This is here only to skip the Apollo query and so the issues in the Error page
+}: NavigationProps) {
   const { headerMenu, languages } = useContext(NavigationContext);
   const router = useRouter();
   const locale = useLocale();
   const cmsHelper = useCmsHelper();
   const routerHelper = useCmsRoutedAppHelper();
   const currentPage = router.pathname;
-  const languagesQuery = useLanguagesQuery({ skip: !!languages });
+  const languagesQuery = useLanguagesQuery({
+    skip: !!languages || !!forcedLanguages,
+  });
   const languageOptions =
-    languages ?? languagesQuery.data?.languages?.filter(isLanguage);
+    forcedLanguages ??
+    languages ??
+    languagesQuery.data?.languages?.filter(isLanguage);
 
   return (
     <RHHCNavigation
       languages={languageOptions}
-      menu={headerMenu}
+      menu={menu ?? headerMenu}
       className={styles.topNavigation}
       onTitleClick={() => {
         router.push('/');


### PR DESCRIPTION
HH-254.

Recovered the `_error.tsx` files to each app and their purpose is to
redirect to the Error-page. Like this we can use the i18n-library on error page
(This is all due the missing feature in NextJS). The error that is occurring
server side is then actually shown in client side.

Added a RetryLink for network errors handling.

"If your retried operation also results in errors, those errors are not passed
to your onError link to prevent an infinite loop of operations.
This means that an onError link can retry a particular operation only once."
- https://www.apollographql.com/docs/react/data/error-handling#retrying-operations

"To retry operations that encounter a network error,
we recommend adding a RetryLink to your link chain.
This link enables you to configure retry logic like
exponential backoff and total number of attempts."
- https://www.apollographql.com/docs/react/data/error-handling#on-network-errors