### PR TITLE
Fix Apollo cache

### DIFF
--- a/apps/events-helsinki/src/domain/clients/eventsApolloClient.ts
+++ b/apps/events-helsinki/src/domain/clients/eventsApolloClient.ts
@@ -19,7 +19,9 @@ export default function initializeEventsApolloClient(
 export function useEventsApolloClient(args: {
   handleError?: (error: unknown) => void;
 }): ApolloClient<NormalizedCacheObject> {
-  return React.useMemo(() => initializeEventsApolloClient(args), [args]);
+  // NOTE: Critical: The Apollo cache should never be cleared!
+  // Carefully test the cache after any changes done here.
+  return React.useMemo(() => initializeEventsApolloClient(args), []);
 }
 
 export const eventsApolloClient = initializeEventsApolloClient();

--- a/apps/hobbies-helsinki/src/domain/clients/hobbiesApolloClient.ts
+++ b/apps/hobbies-helsinki/src/domain/clients/hobbiesApolloClient.ts
@@ -19,7 +19,9 @@ export default function initializeHobbiesApolloClient(
 export function useHobbiesApolloClient(args: {
   handleError?: (error: unknown) => void;
 }): ApolloClient<NormalizedCacheObject> {
-  return React.useMemo(() => initializeHobbiesApolloClient(args), [args]);
+  // NOTE: Critical: The Apollo cache should never be cleared!
+  // Carefully test the cache after any changes done here.
+  return React.useMemo(() => initializeHobbiesApolloClient(args), []);
 }
 
 export const hobbiesApolloClient = initializeHobbiesApolloClient();

--- a/apps/sports-helsinki/src/domain/clients/sportsApolloClient.ts
+++ b/apps/sports-helsinki/src/domain/clients/sportsApolloClient.ts
@@ -19,7 +19,9 @@ export default function initializeSportsApolloClient(
 export function useSportsApolloClient(args: {
   handleError?: (error: unknown) => void;
 }): ApolloClient<NormalizedCacheObject> {
-  return React.useMemo(() => initializeSportsApolloClient(args), [args]);
+  // NOTE: Critical: The Apollo cache should never be cleared!
+  // Carefully test the cache after any changes done here.
+  return React.useMemo(() => initializeSportsApolloClient(args), []);
 }
 
 export const sportsApolloClient = initializeSportsApolloClient();

--- a/packages/components/src/components/errorPages/ErrorPage.tsx
+++ b/packages/components/src/components/errorPages/ErrorPage.tsx
@@ -35,7 +35,7 @@ const HARDCODED_LANGUAGES = [
   {
     __typename: 'Language',
     id: 'TGFuZ3VhZ2U6ZW4=',
-    locale: 'en_US',
+    locale: 'en',
     name: 'English',
     code: 'EN' as LanguageCodeEnum,
     slug: 'en',
@@ -43,7 +43,7 @@ const HARDCODED_LANGUAGES = [
   {
     __typename: 'Language',
     id: 'TGFuZ3VhZ2U6c3Y=',
-    locale: 'sv_SE',
+    locale: 'sv',
     name: 'Svenska',
     code: 'SV' as LanguageCodeEnum,
     slug: 'sv',


### PR DESCRIPTION
LIIKUNTA-439 HH-297.

Critical fix to the Apollo-client cache that didn't persist.

Steps to test: 

1. Make a search (in Events / Hobbies / Sports, venues or events)
2. Click a result card to navigate to the details page
3. Click back arrow or browser back button
→ The browser should not make a new query but scroll to the card that was clicked earlier, but instead it makes a new query

----

LIIKUNTA-432

Fixed the locations selected module in the article page. 
Needed also to update the CMS content related to the languages (Wordpress PolyLang):
1. https://liikunta.hkih.stage.geniem.io/wp-admin/admin.php?page=mlang
2. https://liikunta2.content.api.hel.fi/wp-admin/admin.php?page=mlang