### PR TITLE
Fix the Nextjs ISR to update pages after revalidation time passes

### DIFF
--- a/apps/events-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/events-helsinki/src/domain/app/AppConfig.ts
@@ -84,7 +84,7 @@ class AppConfig {
 
   static get defaultRevalidate() {
     const envValue = process.env.NEXT_PUBLIC_DEFAULT_ISR_REVALIDATE_SECONDS;
-    const value = envValue ? parseEnvValue(envValue) : 10;
+    const value = envValue ? parseEnvValue(envValue) : 60;
 
     if (typeof value !== 'number') {
       throw Error(

--- a/apps/events-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
+++ b/apps/events-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
@@ -90,7 +90,7 @@ it.each([
   {
     field: 'defaultRevalidate',
     envName: 'NEXT_PUBLIC_DEFAULT_ISR_REVALIDATE_SECONDS',
-    defaultValue: 10,
+    defaultValue: 60,
   },
 ])('provides number config $field', ({ field, envName, defaultValue }) => {
   // When exists, provides it

--- a/apps/events-helsinki/src/domain/app/getEventsStaticProps.ts
+++ b/apps/events-helsinki/src/domain/app/getEventsStaticProps.ts
@@ -90,23 +90,15 @@ async function getGlobalCMSData({
 }: GetGlobalCMSDataParams): Promise<ReturnedGlobalCMSData> {
   const language = getLanguageOrDefault(context.locale);
   const headerNavigationMenuName = DEFAULT_HEADER_MENU_NAME[language];
+  const fetchPolicy = 'network-only'; // Always fetch new, but update the cache.
   const { data: headerMenuData } = await client.query({
     query: MenuDocument,
     variables: {
       id: headerNavigationMenuName,
       // idType: 'URI'
     },
+    fetchPolicy,
   });
-  client.writeQuery({
-    query: MenuDocument,
-    variables: {
-      id: headerNavigationMenuName,
-    },
-    data: {
-      ...headerMenuData,
-    },
-  });
-
   const footerNavigationMenuName = DEFAULT_FOOTER_MENU_NAME[language];
   const { data: footerMenuData } = await client.query({
     query: MenuDocument,
@@ -114,26 +106,12 @@ async function getGlobalCMSData({
       id: footerNavigationMenuName,
       // idType: 'URI'
     },
+    fetchPolicy,
   });
-  client.writeQuery({
-    query: MenuDocument,
-    variables: {
-      id: footerNavigationMenuName,
-    },
-    data: {
-      ...footerMenuData,
-    },
-  });
-
   const { data: languagesData } = await client.query({
     query: LanguagesDocument,
+    fetchPolicy,
   });
-
-  client.writeQuery({
-    query: LanguagesDocument,
-    data: { ...languagesData },
-  });
-
   const languages = getSupportedLanguages(languagesData?.languages, context);
 
   return {

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -100,7 +100,7 @@ export async function getStaticPaths() {
   }));
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -143,7 +143,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
             breadcrumbs,
             collections: getCollections(article.modules ?? []),
           },
-          revalidate: 60,
+          revalidate: AppConfig.defaultRevalidate,
         };
       } catch (e) {
         // eslint-disable-next-line no-console
@@ -154,6 +154,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
               statusCode: 500,
             },
           },
+          revalidate: 1,
         };
       }
     }
@@ -173,6 +174,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       ),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.fetchPolicy: 'no-cache',
   });
 
   const currentArticle = articleData.post;

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -94,7 +94,7 @@ export async function getStaticPaths() {
     .filter((entry) => entry.params.slug && entry.params.slug.length);
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -136,7 +136,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
             breadcrumbs,
             collections: getCollections(page.modules ?? []),
           },
-          revalidate: 60,
+          revalidate: AppConfig.defaultRevalidate,
         };
       } catch (e) {
         return {
@@ -145,7 +145,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
               statusCode: 400,
             },
           },
-          revalidate: 10,
+          revalidate: 1,
         };
       }
     }
@@ -163,6 +163,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.fetchPolicy: 'no-cache',
   });
 
   const currentPage = pageData.page;

--- a/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
@@ -85,7 +85,7 @@ class AppConfig {
 
   static get defaultRevalidate() {
     const envValue = process.env.NEXT_PUBLIC_DEFAULT_ISR_REVALIDATE_SECONDS;
-    const value = envValue ? parseEnvValue(envValue) : 10;
+    const value = envValue ? parseEnvValue(envValue) : 60;
 
     if (typeof value !== 'number') {
       throw Error(

--- a/apps/hobbies-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
@@ -90,7 +90,7 @@ it.each([
   {
     field: 'defaultRevalidate',
     envName: 'NEXT_PUBLIC_DEFAULT_ISR_REVALIDATE_SECONDS',
-    defaultValue: 10,
+    defaultValue: 60,
   },
 ])('provides number config $field', ({ field, envName, defaultValue }) => {
   // When exists, provides it

--- a/apps/hobbies-helsinki/src/domain/app/getHobbiesStaticProps.ts
+++ b/apps/hobbies-helsinki/src/domain/app/getHobbiesStaticProps.ts
@@ -91,23 +91,15 @@ async function getGlobalCMSData({
 }: GetGlobalCMSDataParams): Promise<ReturnedGlobalCMSData> {
   const language = getLanguageOrDefault(context.locale);
   const headerNavigationMenuName = DEFAULT_HEADER_MENU_NAME[language];
+  const fetchPolicy = 'network-only'; // Always fetch new, but update the cache.
   const { data: headerMenuData } = await client.query({
     query: MenuDocument,
     variables: {
       id: headerNavigationMenuName,
       // idType: 'URI'
     },
+    fetchPolicy,
   });
-  client.writeQuery({
-    query: MenuDocument,
-    variables: {
-      id: headerNavigationMenuName,
-    },
-    data: {
-      ...headerMenuData,
-    },
-  });
-
   const footerNavigationMenuName = DEFAULT_FOOTER_MENU_NAME[language];
   const { data: footerMenuData } = await client.query({
     query: MenuDocument,
@@ -115,26 +107,12 @@ async function getGlobalCMSData({
       id: footerNavigationMenuName,
       // idType: 'URI'
     },
+    fetchPolicy,
   });
-  client.writeQuery({
-    query: MenuDocument,
-    variables: {
-      id: footerNavigationMenuName,
-    },
-    data: {
-      ...footerMenuData,
-    },
-  });
-
   const { data: languagesData } = await client.query({
     query: LanguagesDocument,
+    fetchPolicy,
   });
-
-  client.writeQuery({
-    query: LanguagesDocument,
-    data: { ...languagesData },
-  });
-
   const languages = getSupportedLanguages(languagesData?.languages, context);
 
   return {

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -99,7 +99,7 @@ export async function getStaticPaths() {
   }));
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -142,7 +142,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
             breadcrumbs,
             collections: getCollections(article.modules ?? []),
           },
-          revalidate: 60,
+          revalidate: AppConfig.defaultRevalidate,
         };
       } catch (e) {
         // eslint-disable-next-line no-console
@@ -153,6 +153,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
               statusCode: 500,
             },
           },
+          revalidate: 1,
         };
       }
     }
@@ -170,6 +171,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.
   });
 
   const currentArticle = articleData.post;

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -93,7 +93,7 @@ export async function getStaticPaths() {
     .filter((entry) => entry.params.slug && entry.params.slug.length);
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -135,7 +135,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
             breadcrumbs,
             collections: getCollections(page.modules ?? []),
           },
-          revalidate: 60,
+          revalidate: AppConfig.defaultRevalidate,
         };
       } catch (e) {
         return {
@@ -144,6 +144,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
               statusCode: 500,
             },
           },
+          revalidate: 1,
         };
       }
     }
@@ -161,6 +162,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.
   });
 
   const currentPage = pageData.page;

--- a/apps/sports-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/sports-helsinki/src/domain/app/AppConfig.ts
@@ -85,7 +85,7 @@ class AppConfig {
 
   static get defaultRevalidate() {
     const envValue = process.env.NEXT_PUBLIC_DEFAULT_ISR_REVALIDATE_SECONDS;
-    const value = envValue ? parseEnvValue(envValue) : 10;
+    const value = envValue ? parseEnvValue(envValue) : 60;
 
     if (typeof value !== 'number') {
       throw Error(

--- a/apps/sports-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
+++ b/apps/sports-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
@@ -89,7 +89,7 @@ it.each([
   {
     field: 'defaultRevalidate',
     envName: 'NEXT_PUBLIC_DEFAULT_ISR_REVALIDATE_SECONDS',
-    defaultValue: 10,
+    defaultValue: 60,
   },
 ])('provides number config $field', ({ field, envName, defaultValue }) => {
   // When exists, provides it

--- a/apps/sports-helsinki/src/domain/app/getSportsStaticProps.ts
+++ b/apps/sports-helsinki/src/domain/app/getSportsStaticProps.ts
@@ -90,23 +90,15 @@ async function getGlobalCMSData({
 }: GetGlobalCMSDataParams): Promise<ReturnedGlobalCMSData> {
   const language = getLanguageOrDefault(context.locale);
   const headerNavigationMenuName = DEFAULT_HEADER_MENU_NAME[language];
+  const fetchPolicy = 'network-only'; // Always fetch new, but update the cache.
   const { data: headerMenuData } = await client.query({
     query: MenuDocument,
     variables: {
       id: headerNavigationMenuName,
       // idType: 'URI'
     },
+    fetchPolicy,
   });
-  client.writeQuery({
-    query: MenuDocument,
-    variables: {
-      id: headerNavigationMenuName,
-    },
-    data: {
-      ...headerMenuData,
-    },
-  });
-
   const footerNavigationMenuName = DEFAULT_FOOTER_MENU_NAME[language];
   const { data: footerMenuData } = await client.query({
     query: MenuDocument,
@@ -114,26 +106,12 @@ async function getGlobalCMSData({
       id: footerNavigationMenuName,
       // idType: 'URI'
     },
+    fetchPolicy,
   });
-  client.writeQuery({
-    query: MenuDocument,
-    variables: {
-      id: footerNavigationMenuName,
-    },
-    data: {
-      ...footerMenuData,
-    },
-  });
-
   const { data: languagesData } = await client.query({
     query: LanguagesDocument,
+    fetchPolicy,
   });
-
-  client.writeQuery({
-    query: LanguagesDocument,
-    data: { ...languagesData },
-  });
-
   const languages = getSupportedLanguages(languagesData?.languages, context);
 
   return {

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -100,7 +100,7 @@ export async function getStaticPaths() {
   }));
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -143,7 +143,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
             breadcrumbs,
             collections: getCollections(article.modules ?? []),
           },
-          revalidate: 60,
+          revalidate: AppConfig.defaultRevalidate,
         };
       } catch (e) {
         // eslint-disable-next-line no-console
@@ -154,6 +154,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
               statusCode: 500,
             },
           },
+          revalidate: 1,
         };
       }
     }
@@ -171,6 +172,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.fetchPolicy: 'no-cache',
   });
 
   const currentArticle = articleData.post;

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -94,7 +94,7 @@ export async function getStaticPaths() {
     .filter((entry) => entry.params.slug && entry.params.slug.length);
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 }
 
@@ -136,7 +136,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
             breadcrumbs,
             collections: getCollections(page.modules ?? []),
           },
-          revalidate: 60,
+          revalidate: AppConfig.defaultRevalidate,
         };
       } catch (e) {
         return {
@@ -145,6 +145,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
               statusCode: 500,
             },
           },
+          revalidate: 1,
         };
       }
     }
@@ -162,6 +163,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.
   });
 
   const currentPage = pageData.page;


### PR DESCRIPTION
LIIKUNTA-440.

The NextJS server-side rendering has called the getStaticProps
when the revalidation period has passed, just like it should, but the Apollo has responded to the queries that the getStaticProps has made for articles or pages with some items in the cache. Some reason why, not even the 'network-only' fetch policy works properly, because in the tests done, it updates the pages and articles only once. The default fetch policy for the Apollo Client is the "cache-first", but it has also has that same issue. However, the no-cache policy seems to work OK and the article and page items gets updated every time when the revalidation period expires and a new request is made.

This commit also makes the fallback rules more consistent: They are now always 'blocking', which seems to give less bouncing on browser navigations to the pages or articles that has not yet been cached by NextJS server-side. More about that rule here: https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-blocking.

Also, all the revalidation periods are now read from the AppConfig and are now consistent. If an error page is rendered, the revalidation period is 1 second. Otherwise, the default is now 60 seconds set in AppConfig. The value can still be overridden with an environment value.

While investigating the Apollo cache issues, it was also discovered that
the writeQuery-command in the get[App]StaticProps -file was needless, the fetch policy should always update it anyway and so it really seems to work in the tests done.