### PR TITLE
Fix the footer that had no appname translation defined correctly

### DIFF
--- a/apps/hobbies-helsinki/src/pages/404.tsx
+++ b/apps/hobbies-helsinki/src/pages/404.tsx
@@ -10,7 +10,7 @@ import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslati
 
 const FourOhFour: NextPage = () => {
   const { t } = useCommonTranslation();
-  return <NotFound appName={t(`appSports:appName`)} />;
+  return <NotFound appName={t(`appHobbies:appName`)} />;
 };
 export default FourOhFour;
 


### PR DESCRIPTION
HH-147 Footer had no appname translation defined correctly. 