### PR TITLE
Fix image url exploit that fetched venue and event pages without id

### DIFF
--- a/apps/events-helsinki/src/domain/event/similarEvents/SimilarEvents.tsx
+++ b/apps/events-helsinki/src/domain/event/similarEvents/SimilarEvents.tsx
@@ -52,6 +52,7 @@ const SimilarEvents: React.FC<Props> = ({
         {...cardProps}
         url={url}
         direction="fixed-vertical"
+        imageUrl={cardProps.imageUrl ?? ''}
         customContent={
           EventCardContent && <EventCardContent event={events[i]} />
         }

--- a/apps/hobbies-helsinki/src/domain/event/similarEvents/SimilarEvents.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/similarEvents/SimilarEvents.tsx
@@ -58,6 +58,7 @@ const SimilarEvents: React.FC<Props> = ({
         {...cardProps}
         url={url}
         direction="fixed-vertical"
+        imageUrl={cardProps.imageUrl ?? ''}
         customContent={
           EventCardContent && <EventCardContent event={events[i]} />
         }

--- a/apps/sports-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/sports-helsinki/src/domain/event/queryUtils.ts
@@ -293,7 +293,9 @@ export const useSimilarVenuesQuery = ({
         const venueSourceIds = venueIds.map((venueId) =>
           getVenueSourceId(venueId)
         );
-        getVenuesByIds({ variables: { ids: venueSourceIds } });
+        if (venueSourceIds.length) {
+          getVenuesByIds({ variables: { ids: venueSourceIds } });
+        }
       }
     }
   }, [

--- a/apps/sports-helsinki/src/domain/event/useEventCards.tsx
+++ b/apps/sports-helsinki/src/domain/event/useEventCards.tsx
@@ -33,6 +33,7 @@ function useEventCards({ events, returnPath }: useEventCardsProps) {
           {...cardProps}
           url={url}
           direction="fixed-vertical"
+          imageUrl={cardProps.imageUrl ?? ''}
           customContent={
             EventCardContent && <EventCardContent event={events[i]} />
           }

--- a/apps/sports-helsinki/src/domain/venue/useVenueCards.tsx
+++ b/apps/sports-helsinki/src/domain/venue/useVenueCards.tsx
@@ -42,6 +42,7 @@ function useVenueCards({ venues, returnPath }: useVenueCardsProps) {
           {...cardProps}
           url={url}
           direction="fixed-vertical"
+          imageUrl={cardProps.imageUrl ?? ''}
           customContent={
             VenueCardContent && <VenueCardContent location={venues[i]} />
           }


### PR DESCRIPTION
LIIKUNTA-434.

The null as an image url somehow made a new request to the venue path without id. When the image url was set to and empty string instead, this was avoided.