### PR TITLE
Fix undefined image url testing

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -71,7 +71,7 @@
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "3.1.4",
-    "react-helsinki-headless-cms": "1.0.0-alpha123",
+    "react-helsinki-headless-cms": "1.0.0-alpha124-canary-37220c9",
     "react-i18next": "12.2.0",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -71,7 +71,7 @@
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "3.1.4",
-    "react-helsinki-headless-cms": "1.0.0-alpha123",
+    "react-helsinki-headless-cms": "1.0.0-alpha124-canary-37220c9",
     "react-i18next": "12.2.0",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "3.1.4",
-    "react-helsinki-headless-cms": "1.0.0-alpha123",
+    "react-helsinki-headless-cms": "1.0.0-alpha124-canary-37220c9",
     "react-i18next": "12.2.0",
     "react-leaflet": "4.2.0",
     "react-scroll": "^1.8.7",

--- a/apps/sports-helsinki/src/domain/event/queryUtils.ts
+++ b/apps/sports-helsinki/src/domain/event/queryUtils.ts
@@ -293,7 +293,9 @@ export const useSimilarVenuesQuery = ({
         const venueSourceIds = venueIds.map((venueId) =>
           getVenueSourceId(venueId)
         );
-        getVenuesByIds({ variables: { ids: venueSourceIds } });
+        if (venueSourceIds.length) {
+          getVenuesByIds({ variables: { ids: venueSourceIds } });
+        }
       }
     }
   }, [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -70,7 +70,7 @@
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "3.1.4",
-    "react-helsinki-headless-cms": "1.0.0-alpha123",
+    "react-helsinki-headless-cms": "1.0.0-alpha124-canary-37220c9",
     "react-i18next": "12.2.0",
     "react-leaflet": "4.2.0",
     "react-toastify": "^9.0.3",

--- a/packages/components/src/components/footer/Footer.tsx
+++ b/packages/components/src/components/footer/Footer.tsx
@@ -1,11 +1,12 @@
 import { Footer, Link } from 'hds-react';
 import type { FunctionComponent } from 'react';
 import React from 'react';
+import type { Menu } from 'react-helsinki-headless-cms';
 import { useMenuQuery } from 'react-helsinki-headless-cms/apollo';
 import { DEFAULT_FOOTER_MENU_NAME } from '../../constants';
 import useFooterTranslation from '../../hooks/useFooterTranslation';
 import useLocale from '../../hooks/useLocale';
-import type { Menu } from '../../types';
+
 import { resetFocusId } from '../resetFocus/ResetFocus';
 import styles from './footer.module.scss';
 
@@ -46,15 +47,18 @@ const FooterSection: FunctionComponent<FooterSectionProps> = ({
         copyrightHolder={t('footer:copyright')}
         copyrightText={t('footer:allRightsReserved')}
       >
-        {footerMenu?.menuItems?.nodes?.map((navigationItem) => (
-          <Footer.Item
-            className={styles.footerLink}
-            key={navigationItem?.id}
-            as={Link}
-            href={navigationItem?.path || ''}
-            label={navigationItem?.label}
-          />
-        ))}
+        {footerMenu?.menuItems?.nodes?.map(
+          // FIXME: HCRC-build sometimes fails - this type should not be needed.
+          (navigationItem: Menu['menuItems']['nodes'][number]) => (
+            <Footer.Item
+              className={styles.footerLink}
+              key={navigationItem?.id}
+              as={Link}
+              href={navigationItem?.path || ''}
+              label={navigationItem?.label}
+            />
+          )
+        )}
       </Footer.Base>
     </Footer>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13842,7 +13842,7 @@ __metadata:
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:3.1.4"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha123"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha124-canary-37220c9"
     react-i18next: "npm:12.2.0"
     react-leaflet: "npm:4.2.0"
     react-toastify: "npm:^9.0.3"
@@ -14101,7 +14101,7 @@ __metadata:
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:3.1.4"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha123"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha124-canary-37220c9"
     react-i18next: "npm:12.2.0"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"
@@ -16279,7 +16279,7 @@ __metadata:
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:3.1.4"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha123"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha124-canary-37220c9"
     react-i18next: "npm:12.2.0"
     react-scroll: "npm:^1.8.7"
     react-toastify: "npm:^9.0.3"
@@ -23980,9 +23980,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha123":
-  version: 1.0.0-alpha123
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha123"
+"react-helsinki-headless-cms@npm:1.0.0-alpha124-canary-37220c9":
+  version: 1.0.0-alpha124-canary-37220c9
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha124-canary-37220c9"
   dependencies:
     hds-design-tokens: "npm:^2.3.0"
     html-react-parser: "npm:^1.4.8"
@@ -23996,7 +23996,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: c1b5e66f1709be74d04d37655e861d64aa6f5df879cc11e160bd7b7ed8644d01d197b5f6860099a8e0cceb6305738e500469ecec0531013d376fdfaa02f2348d
+  checksum: e0fe0f93ad0233d5c76f7fb088b1d551cff0491e1f2d464c805e9dc5d0da9c89e5b544c29dfc06a4720f29fc9f60ea0eae01a6ee074645bb66422e34a88ee478
   languageName: node
   linkType: hard
 
@@ -26336,7 +26336,7 @@ __metadata:
     react-datepicker: "npm:^4.8.0"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:3.1.4"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha123"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha124-canary-37220c9"
     react-i18next: "npm:12.2.0"
     react-leaflet: "npm:4.2.0"
     react-scroll: "npm:^1.8.7"


### PR DESCRIPTION
LIIKUNTA-434. 

Installed a new version of HCRC-lib. In that new version, the library won't no longer test an undefined image url, which made the browser to hang and wait for a response that would always be a 404. Instead of that, the library now rejects the promise immediately and starts looking for a fallback image.

NOTE: dependency to https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/98