### PR TITLE
Dynamic pages to return null when document is not found

### DIFF
--- a/apps/events-helsinki/src/pages/404.tsx
+++ b/apps/events-helsinki/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   NotFound,
-  useCommonTranslation,
+  useAppEventsTranslation,
 } from 'events-helsinki-components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getEventsStaticProps from '../domain/app/getEventsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const FourOhFour: NextPage = () => {
-  const { t } = useCommonTranslation();
-  return <NotFound appName={t(`appEvents:appName`)} />;
+  const { t } = useAppEventsTranslation();
+  return <NotFound appName={t('appEvents:appName')} />;
 };
 export default FourOhFour;
 
@@ -19,7 +19,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     const language = getLanguageOrDefault(context.locale);
     return {
       props: {
-        ...(await serverSideTranslationsWithCommon(language, ['common'])),
+        ...(await serverSideTranslationsWithCommon(language)),
       },
     };
   });

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -56,6 +56,10 @@ const NextCmsArticle: NextPage<{
 
   const { footerMenu } = useContext(NavigationContext);
 
+  // FIXME: Return null to fix SSR rendering for notFound-page.
+  // This is needed only with fallback: true, but should not be needed at all.
+  if (!article) return null;
+
   return (
     <MatomoWrapper>
       <RHHCPage

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -9,6 +9,7 @@ import {
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
+  useAppEventsTranslation,
 } from 'events-helsinki-components';
 import type { AppLanguage } from 'events-helsinki-components';
 
@@ -50,7 +51,9 @@ const NextCmsArticle: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
 
-  const { t } = useCommonTranslation();
+  const { t: commonTranslation } = useCommonTranslation();
+  const { t: appTranslation } = useAppEventsTranslation();
+
   const { footerMenu } = useContext(NavigationContext);
 
   return (
@@ -64,7 +67,9 @@ const NextCmsArticle: NextPage<{
             breadcrumbs={
               breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
             }
-            shareLinks={<ShareLinks title={t('common:share.article')} />}
+            shareLinks={
+              <ShareLinks title={commonTranslation('common:share.article')} />
+            }
             collections={
               collections
                 ? cmsHelper.getDefaultCollections(
@@ -76,7 +81,10 @@ const NextCmsArticle: NextPage<{
           />
         }
         footer={
-          <FooterSection menu={footerMenu} appName={t('appEvents:appName')} />
+          <FooterSection
+            menu={footerMenu}
+            appName={appTranslation('appEvents:appName')}
+          />
         }
       />
     </MatomoWrapper>

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -7,7 +7,7 @@ import {
   NavigationContext,
   getAllPages,
   MatomoWrapper,
-  useCommonTranslation,
+  useAppEventsTranslation,
   getLanguageOrDefault,
   FooterSection,
 } from 'events-helsinki-components';
@@ -49,7 +49,8 @@ const NextCmsPage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t: appTranslation } = useAppEventsTranslation();
+
   return (
     <MatomoWrapper>
       <HCRCPage
@@ -67,7 +68,10 @@ const NextCmsPage: NextPage<{
           />
         }
         footer={
-          <FooterSection menu={footerMenu} appName={t('appEvents:appName')} />
+          <FooterSection
+            menu={footerMenu}
+            appName={appTranslation('appEvents:appName')}
+          />
         }
       />
     </MatomoWrapper>

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -51,6 +51,10 @@ const NextCmsPage: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
   const { t: appTranslation } = useAppEventsTranslation();
 
+  // FIXME: Return null to fix SSR rendering for notFound-page.
+  // This is needed only with fallback: true, but should not be needed at all.
+  if (!page) return null;
+
   return (
     <MatomoWrapper>
       <HCRCPage

--- a/apps/hobbies-helsinki/src/pages/404.tsx
+++ b/apps/hobbies-helsinki/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   NotFound,
-  useCommonTranslation,
+  useAppHobbiesTranslation,
 } from 'events-helsinki-components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getHobbiesStaticProps from '../domain/app/getHobbiesStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const FourOhFour: NextPage = () => {
-  const { t } = useCommonTranslation();
-  return <NotFound appName={t(`appHobbies:appName`)} />;
+  const { t } = useAppHobbiesTranslation();
+  return <NotFound appName={t('appHobbies:appName')} />;
 };
 export default FourOhFour;
 
@@ -19,7 +19,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     const language = getLanguageOrDefault(context.locale);
     return {
       props: {
-        ...(await serverSideTranslationsWithCommon(language, ['common'])),
+        ...(await serverSideTranslationsWithCommon(language)),
       },
     };
   });

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -54,6 +54,10 @@ const NextCmsArticle: NextPage<{
   const { t: appTranslation } = useAppHobbiesTranslation();
   const { footerMenu } = useContext(NavigationContext);
 
+  // FIXME: Return null to fix SSR rendering for notFound-page.
+  // This is needed only with fallback: true, but should not be needed at all.
+  if (!article) return null;
+
   return (
     <MatomoWrapper>
       <RHHCPage

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -9,6 +9,7 @@ import {
   MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
+  useAppHobbiesTranslation,
 } from 'events-helsinki-components';
 import type { AppLanguage } from 'events-helsinki-components';
 import type {
@@ -49,7 +50,8 @@ const NextCmsArticle: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
 
-  const { t } = useCommonTranslation();
+  const { t: commonTranslation } = useCommonTranslation();
+  const { t: appTranslation } = useAppHobbiesTranslation();
   const { footerMenu } = useContext(NavigationContext);
 
   return (
@@ -63,7 +65,9 @@ const NextCmsArticle: NextPage<{
             breadcrumbs={
               breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
             }
-            shareLinks={<ShareLinks title={t('common:share.article')} />}
+            shareLinks={
+              <ShareLinks title={commonTranslation('common:share.article')} />
+            }
             collections={
               collections
                 ? cmsHelper.getDefaultCollections(
@@ -75,7 +79,10 @@ const NextCmsArticle: NextPage<{
           />
         }
         footer={
-          <FooterSection menu={footerMenu} appName={t('appHobbies:appName')} />
+          <FooterSection
+            menu={footerMenu}
+            appName={appTranslation('appHobbies:appName')}
+          />
         }
       />
     </MatomoWrapper>

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -6,7 +6,7 @@ import {
   NavigationContext,
   getAllPages,
   MatomoWrapper,
-  useCommonTranslation,
+  useAppHobbiesTranslation,
   FooterSection,
   getLanguageOrDefault,
 } from 'events-helsinki-components';
@@ -49,7 +49,7 @@ const NextCmsPage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t: appTranslation } = useAppHobbiesTranslation();
   return (
     <MatomoWrapper>
       <HCRCPage
@@ -66,7 +66,10 @@ const NextCmsPage: NextPage<{
           />
         }
         footer={
-          <FooterSection menu={footerMenu} appName={t('appHobbies:appName')} />
+          <FooterSection
+            menu={footerMenu}
+            appName={appTranslation('appHobbies:appName')}
+          />
         }
       />
     </MatomoWrapper>

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -50,6 +50,11 @@ const NextCmsPage: NextPage<{
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
   const { t: appTranslation } = useAppHobbiesTranslation();
+
+  // FIXME: Return null to fix SSR rendering for notFound-page.
+  // This is needed only with fallback: true, but should not be needed at all.
+  if (!page) return null;
+
   return (
     <MatomoWrapper>
       <HCRCPage

--- a/apps/sports-helsinki/src/pages/404.tsx
+++ b/apps/sports-helsinki/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   NotFound,
-  useCommonTranslation,
+  useAppSportsTranslation,
 } from 'events-helsinki-components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getSportsStaticProps from '../domain/app/getSportsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const FourOhFour: NextPage = () => {
-  const { t } = useCommonTranslation();
-  return <NotFound appName={t(`appSports:appName`)} />;
+  const { t } = useAppSportsTranslation();
+  return <NotFound appName={t('appSports:appName')} />;
 };
 export default FourOhFour;
 
@@ -19,7 +19,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     const language = getLanguageOrDefault(context.locale);
     return {
       props: {
-        ...(await serverSideTranslationsWithCommon(language, ['common'])),
+        ...(await serverSideTranslationsWithCommon(language)),
       },
     };
   });

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -9,6 +9,7 @@ import {
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
+  useAppSportsTranslation,
 } from 'events-helsinki-components';
 import type { AppLanguage } from 'events-helsinki-components';
 import type {
@@ -49,7 +50,8 @@ const NextCmsArticle: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
 
-  const { t } = useCommonTranslation();
+  const { t: commonTranslation } = useCommonTranslation();
+  const { t: appTranslation } = useAppSportsTranslation();
   const { footerMenu } = useContext(NavigationContext);
 
   return (
@@ -64,7 +66,9 @@ const NextCmsArticle: NextPage<{
             breadcrumbs={
               breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
             }
-            shareLinks={<ShareLinks title={t('common:share.article')} />}
+            shareLinks={
+              <ShareLinks title={commonTranslation('common:share.article')} />
+            }
             collections={
               collections
                 ? cmsHelper.getDefaultCollections(
@@ -76,7 +80,10 @@ const NextCmsArticle: NextPage<{
           />
         }
         footer={
-          <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
+          <FooterSection
+            menu={footerMenu}
+            appName={appTranslation('appSports:appName')}
+          />
         }
       />
     </MatomoWrapper>

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -54,6 +54,10 @@ const NextCmsArticle: NextPage<{
   const { t: appTranslation } = useAppSportsTranslation();
   const { footerMenu } = useContext(NavigationContext);
 
+  // FIXME: Return null to fix SSR rendering for notFound-page.
+  // This is needed only with fallback: true, but should not be needed at all.
+  if (!article) return null;
+
   return (
     <MatomoWrapper>
       <RHHCPage

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -7,7 +7,7 @@ import {
   getAllPages,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
+  useAppSportsTranslation,
   FooterSection,
   getLanguageOrDefault,
 } from 'events-helsinki-components';
@@ -49,7 +49,7 @@ const NextCmsPage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t: appTranslation } = useAppSportsTranslation();
   return (
     <MatomoWrapper>
       <HCRCPage
@@ -67,7 +67,10 @@ const NextCmsPage: NextPage<{
           />
         }
         footer={
-          <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
+          <FooterSection
+            menu={footerMenu}
+            appName={appTranslation('appSports:appName')}
+          />
         }
       />
     </MatomoWrapper>

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -50,6 +50,11 @@ const NextCmsPage: NextPage<{
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
   const { t: appTranslation } = useAppSportsTranslation();
+
+  // FIXME: Return null to fix SSR rendering for notFound-page.
+  // This is needed only with fallback: true, but should not be needed at all.
+  if (!page) return null;
+
   return (
     <MatomoWrapper>
       <HCRCPage


### PR DESCRIPTION
LIIKUNTA-441. Fix hydration issues in dev mode when the `fallback: true`-option is on.

Return null to fix SSR rendering when the getStaticProps returns with notFound: true. This is null-checker fix is needed only with fallback: true -option on, but should not be needed at all. The fallback: 'blocking' hides the issue and makes it all work better.

Also, improve the translation library usage in 404-page and dynamic CMS pages.

Before, with `fallback: true`
![image](https://user-images.githubusercontent.com/389204/228140296-2dd44b50-f403-4621-b8fb-5366bea58432.png)
