### PR TITLE
chore: release-please creating invalid release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,8 +10,8 @@ on:
   # manual triggered
   workflow_dispatch:
     inputs:
-      prlabel:
-        description: 'PR label, force update for release-please PR's. Do not use spaces!'
+      label:
+        description: 'PR label, force update for release-please PRs. Do not use spaces!'
         required: false
         type: string
 
@@ -27,8 +27,8 @@ jobs:
         run: |
           if [ -n "${{ github.event.release.tag_name }}" ]; then
             LABEL="--label ${{ github.event.release.tag_name }}"
-          elif [ -n "${{ inputs.prlabel }}" ]; then
-            LABEL="--label ${{ inputs.prlabel }}"
+          elif [ -n "${{ inputs.label }}" ]; then
+            LABEL="--label ${{ inputs.label }}"
           fi
           echo $LABEL
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,17 +4,35 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+  # rerun after release creation to fix manifest -file merge issue
+  release:
+    types: [published]
+  # manual triggered
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'PR label, force update for release-please PR's. Do not use spaces!'
+        required: false
+        type: string
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          command: manifest
-          monorepo-tags: true
+      - name: Install release-please client
+        run: npm i release-please -g
+      # extra label will be set on open release-please PR's to ensure PR re-generation (manifest -file merge issue)
+      # extra label includes the released component tag or manual triggered label name
+      - name: Create release pr
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            LABEL="--label ${{ github.event.release.tag_name }}"
+          elif [ -n "${{ inputs.label }}" ]; then
+            LABEL="--label ${{ inputs.label }}"
+          fi
+          echo $LABEL
+
+          release-please release-pr --token=${{ secrets.GITHUB_TOKEN }} --repo-url=$GITHUB_REPOSITORY $LABEL
+      # create release
+      - name: Create github release
+        run: release-please github-release --token=${{ secrets.GITHUB_TOKEN }} --repo-url=$GITHUB_REPOSITORY

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ on:
   # manual triggered
   workflow_dispatch:
     inputs:
-      label:
+      prlabel:
         description: 'PR label, force update for release-please PR's. Do not use spaces!'
         required: false
         type: string
@@ -27,8 +27,8 @@ jobs:
         run: |
           if [ -n "${{ github.event.release.tag_name }}" ]; then
             LABEL="--label ${{ github.event.release.tag_name }}"
-          elif [ -n "${{ inputs.label }}" ]; then
-            LABEL="--label ${{ inputs.label }}"
+          elif [ -n "${{ inputs.prlabel }}" ]; then
+            LABEL="--label ${{ inputs.prlabel }}"
           fi
           echo $LABEL
 

--- a/README.md
+++ b/README.md
@@ -414,14 +414,16 @@ When adding a new app, add it to both the [release-please-config.json](./release
 
 If you were expecting a new release PR to be created or old one to be updated, but nothing happened, there's probably one of the older release PR's in pending state or action didn't run.
 
-1. Check if the release action ran for the last merge to main. If it didn't, re-run the action manually.
+1. Check if the release action ran for the last merge to main. If it didn't, run the action manually with a label.
 2. Check if there's any open release PR. If there is, the work is now included on this one (this is the normal scenario).
 3. If you do not see any open release PR related to the work, check if any of the closed PR's are labeled with `autorelease: pending` - ie. someone might have closed a release PR manually. Change the closed PR's label to `autorelease: tagged`. Then go and re-run the last merge workflow to trigger the release action - a new release PR should now appear.
 4. Finally check the output of the release action. Sometimes the bot can't parse the commit message and there is a notification about this in the action log. If this happens, it won't include the work in the commit either. You can fix this by changing the commit message to follow the [Conventional Commits](https://www.conventionalcommits.org/) format and rerun the action.
 
 **Important!** If you have closed a release PR manually, you need to change the label of closed release PR to `autorelease: tagged`. Otherwise, the release action will not create a new release PR.
 
-Sometimes there might be a merge conflict in release PR - this should resolve itself on the next push to main. But you can also resolve it manually, by updating the [release-please-manifest.json](./.release-please-manifest.json) file.
+**Important!** Extra label will force release-please to re-generate PR's. This is done when action is run manually with prlabel -option
+
+Sometimes there might be a merge conflict in release PR - this should resolve itself on the next push to main. It is possible run release-please action manually with label, it should recreate the PR's. You can also resolve it manually, by updating the [release-please-manifest.json](./.release-please-manifest.json) file.
 
 There's also a CLI for debugging and manually running releases available for release-please: [release-please-cli](https://github.com/googleapis/release-please/blob/main/docs/cli.md)
 


### PR DESCRIPTION
## Description
* Use release-please client instead of release-please-action
* rerun release-please action after release to fix manifest -file merge issues

## Issues

### Closes

**[DEVOPS-519](https://helsinkisolutionoffice.atlassian.net/browse/DEVOPS-519):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[DEVOPS-519]: https://helsinkisolutionoffice.atlassian.net/browse/DEVOPS-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ