### PR TITLE
chore: release-please workflow trigger from github event do not work

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  # rerun after release creation to fix manifest -file merge issue
-  release:
-    types: [published]
   # manual triggered
   workflow_dispatch:
     inputs:
@@ -34,5 +31,8 @@ jobs:
 
           release-please release-pr --token=${{ secrets.GITHUB_TOKEN }} --repo-url=$GITHUB_REPOSITORY $LABEL
       # create release
+      # rerun release-pr after release creation to fix manifest -file merge issue
       - name: Create github release
-        run: release-please github-release --token=${{ secrets.GITHUB_TOKEN }} --repo-url=$GITHUB_REPOSITORY
+        run: |
+          release-please github-release --token=${{ secrets.GITHUB_TOKEN }} --repo-url=$GITHUB_REPOSITORY
+          release-please release-pr --token=${{ secrets.GITHUB_TOKEN }} --repo-url=$GITHUB_REPOSITORY

--- a/README.md
+++ b/README.md
@@ -425,6 +425,14 @@ If you were expecting a new release PR to be created or old one to be updated, b
 
 Sometimes there might be a merge conflict in release PR - this should resolve itself on the next push to main. It is possible run release-please action manually with label, it should recreate the PR's. You can also resolve it manually, by updating the [release-please-manifest.json](./.release-please-manifest.json) file.
 
+#### Fix merge conflicts by running release-please -action manually
+
+1. Open [release-please github action](https://github.com/City-of-Helsinki/events-helsinki-monorepo/actions/workflows/release-please.yml)
+2. Click **Run workflow**
+3. Check Branch is **main**
+4. Leave label field empty. New label is not needed to fix merge issues
+5. Click **Run workflow** -button
+
 There's also a CLI for debugging and manually running releases available for release-please: [release-please-cli](https://github.com/googleapis/release-please/blob/main/docs/cli.md)
 
 ## FAQ


### PR DESCRIPTION
## Description

It seems the workflow can’t be triggered on the release event. From documentation
> When you use the repository’s GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.


## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
