### PR TITLE
fix: long text sidebar layout bug

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueInfo/venueInfo.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueInfo/venueInfo.module.scss
@@ -67,7 +67,6 @@ a.link {
   margin: 0;
   padding: 0;
   list-style-type: none;
-  white-space: pre;
   line-height: $lineheight-l;
   font-size: $fontsize-body-l;
   & > li:not(:last-child) {


### PR DESCRIPTION
## Description
Too long text in sidebar breaks the layout. Fixed

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
