### PR TITLE
Disable the Apollo-cache for CMS queries of the front page

### DIFF
--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -186,7 +186,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       ),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
-    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.fetchPolicy: 'no-cache',
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
   const currentArticle = articleData.post;

--- a/apps/events-helsinki/src/pages/index.tsx
+++ b/apps/events-helsinki/src/pages/index.tsx
@@ -80,6 +80,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
           id: 'root',
           languageCode: getQlLanguage(language),
         },
+        fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
       });
 
       const { data: pageData } = await apolloClient.query<
@@ -91,6 +92,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
           template: TemplateEnum.FrontPage,
           language: getQlLanguage(language).toLocaleLowerCase(),
         },
+        fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
       });
       if (!pageData || !landingPageData) {
         return {

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -169,7 +169,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
-    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.fetchPolicy: 'no-cache',
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
   const currentPage = pageData.page;

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -182,7 +182,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
-    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
   const currentArticle = articleData.post;

--- a/apps/hobbies-helsinki/src/pages/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/index.tsx
@@ -79,6 +79,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
           id: 'root',
           languageCode: getQlLanguage(language),
         },
+        fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
       });
 
       const { data: pageData } = await apolloClient.query<
@@ -90,6 +91,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
           template: TemplateEnum.FrontPage,
           language: getQlLanguage(language).toLocaleLowerCase(),
         },
+        fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
       });
       if (!pageData || !landingPageData) {
         return {

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -168,7 +168,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
-    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
   const currentPage = pageData.page;

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -183,7 +183,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
-    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.fetchPolicy: 'no-cache',
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
   const currentArticle = articleData.post;

--- a/apps/sports-helsinki/src/pages/index.tsx
+++ b/apps/sports-helsinki/src/pages/index.tsx
@@ -81,6 +81,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
           id: 'root',
           languageCode: getQlLanguage(language),
         },
+        fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
       });
 
       const { data: pageData } = await apolloClient.query<
@@ -92,6 +93,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
           template: TemplateEnum.FrontPage,
           language: getQlLanguage(language).toLocaleLowerCase(),
         },
+        fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
       });
       if (!pageData || !landingPageData) {
         return {

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -169,7 +169,7 @@ const getProps = async (context: GetStaticPropsContext) => {
       id: _getURIQueryParameter(context.params?.slug as string[], language),
       // `idType: PageIdType.Uri // idType is`fixed in query, so added automatically
     },
-    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but some reason why it updates only once.
+    fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
   const currentPage = pageData.page;


### PR DESCRIPTION
TH-1310.

The same fix was earlier done to the dynamic CMS pages, but it was still not added to the persistent CMS pages. It seems, that because of this, the production pods could not update the front page.