### PR TITLE
Search page item type specific error messages

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
@@ -11,11 +11,17 @@ const ResultsInfoContainer: React.FC<{
   const { t } = useTranslation('search');
 
   if (resultsCount === 0) {
-    return <ResultsInfo bigText={t(`searchNotification.noResultsTitle`)} />;
+    return (
+      <ResultsInfo bigText={t(`searchNotification.noResultsTitleGeneral`)} />
+    );
   }
 
   if (resultsCount < 5) {
-    return <ResultsInfo bigText={t(`searchNotification.fewResultsTitle`)} />;
+    return (
+      <ResultsInfo
+        bigText={t(`searchNotification.fewResultsTitlenoResultsTitle`)}
+      />
+    );
   }
 
   return null;

--- a/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
@@ -17,11 +17,7 @@ const ResultsInfoContainer: React.FC<{
   }
 
   if (resultsCount < 5) {
-    return (
-      <ResultsInfo
-        bigText={t(`searchNotification.fewResultsTitlenoResultsTitle`)}
-      />
-    );
+    return <ResultsInfo bigText={t(`searchNotification.fewResultsTitle`)} />;
   }
 
   return null;

--- a/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
@@ -14,7 +14,7 @@ it('renders no events found text', async () => {
 
   expect(
     screen.getByText(
-      'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta'
+      'Valitsemillasi hakuehdoilla ei löytynyt yhtään tapahtumaa.'
     )
   ).toBeInTheDocument();
 });

--- a/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@/test-utils';
 import SearchResultsContainer from '../SearchResultsContainer';
 
 it.each<[number, string]>([
-  [0, 'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta'],
+  [0, 'Valitsemillasi hakuehdoilla ei löytynyt yhtään tapahtumaa.'],
   [1, 'Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.'],
   [4, 'Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.'],
 ])(

--- a/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/__snapshots__/ResultsInfo.test.tsx.snap
+++ b/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/__snapshots__/ResultsInfo.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`events with 0 results matches snapshot for no results 1`] = `
     <div
       class="bigText"
     >
-      Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta
+      Valitsemillasi hakuehdoilla ei löytynyt yhtään tapahtumaa.
     </div>
   </div>
 </div>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
@@ -11,7 +11,9 @@ const ResultsInfoContainer: React.FC<{
   const { t } = useTranslation('search');
 
   if (resultsCount === 0) {
-    return <ResultsInfo bigText={t(`searchNotification.noResultsTitle`)} />;
+    return (
+      <ResultsInfo bigText={t(`searchNotification.noResultsTitleCourse`)} />
+    );
   }
 
   if (resultsCount < 5) {

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
@@ -14,7 +14,7 @@ it('renders no events found text', async () => {
 
   expect(
     screen.getByText(
-      'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta'
+      'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta.'
     )
   ).toBeInTheDocument();
 });

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@/test-utils';
 import SearchResultsContainer from '../SearchResultsContainer';
 
 it.each<[number, string]>([
-  [0, 'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta'],
+  [0, 'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta.'],
   [1, 'Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.'],
   [4, 'Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.'],
 ])(

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/__snapshots__/ResultsInfo.test.tsx.snap
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/__snapshots__/ResultsInfo.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`events with 0 results matches snapshot for no results 1`] = `
     <div
       class="bigText"
     >
-      Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta
+      Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta.
     </div>
   </div>
 </div>

--- a/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -82,6 +82,7 @@ const EventSearchPage: React.FC<SearchPageProps> = ({
           >
             {eventsList && (
               <SearchResultsContainer
+                itemType={eventType}
                 eventsCount={eventsList.meta.count}
                 loading={isLoadingEvents}
                 eventList={

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
@@ -9,11 +9,15 @@ import styles from './resultsInfo.module.scss';
 const ResultsInfoContainer: React.FC<{
   resultsCount: number;
   itemType?: EventTypeId | 'Venue';
-}> = ({ resultsCount }) => {
+}> = ({ resultsCount, itemType }) => {
   const { t } = useTranslation('search');
 
   if (resultsCount === 0) {
-    return <ResultsInfo bigText={t(`searchNotification.noResultsTitle`)} />;
+    return (
+      <ResultsInfo
+        bigText={t(`searchNotification.noResultsTitle${itemType || ''}`)}
+      />
+    );
   }
 
   if (resultsCount < 5) {

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/ResultsInfo.tsx
@@ -1,3 +1,4 @@
+import type { EventTypeId } from '@events-helsinki/components';
 import { IconSearch } from 'hds-react';
 
 import { useTranslation } from 'next-i18next';
@@ -7,6 +8,7 @@ import styles from './resultsInfo.module.scss';
 
 const ResultsInfoContainer: React.FC<{
   resultsCount: number;
+  itemType?: EventTypeId | 'Venue';
 }> = ({ resultsCount }) => {
   const { t } = useTranslation('search');
 

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/SearchResultsContainer.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/SearchResultsContainer.tsx
@@ -1,3 +1,4 @@
+import type { EventTypeId } from '@events-helsinki/components';
 import { useSearchTranslation } from '@events-helsinki/components';
 import React from 'react';
 import { ContentContainer, PageSection } from 'react-helsinki-headless-cms';
@@ -9,6 +10,7 @@ interface Props {
   eventsCount: number;
   eventList: React.ReactElement;
   orderBySelectComponent?: React.ReactElement;
+  itemType?: EventTypeId | 'Venue';
 }
 
 const SearchResultsContainer: React.FC<Props> = ({
@@ -16,6 +18,7 @@ const SearchResultsContainer: React.FC<Props> = ({
   eventsCount,
   eventList,
   orderBySelectComponent,
+  itemType,
 }) => {
   const { t } = useSearchTranslation();
 
@@ -35,7 +38,12 @@ const SearchResultsContainer: React.FC<Props> = ({
           </div>
         )}
         {!!eventsCount && eventList}
-        {!loading && <ResultsInfoContainer resultsCount={eventsCount} />}
+        {!loading && (
+          <ResultsInfoContainer
+            itemType={itemType}
+            resultsCount={eventsCount}
+          />
+        )}
       </ContentContainer>
     </PageSection>
   );

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
@@ -1,7 +1,23 @@
+import { EventTypeId } from '@events-helsinki/components';
 import * as React from 'react';
 
 import { render, screen } from '@/test-utils';
 import ResultsInfo from '../ResultsInfo';
+
+it.each<['Venue' | EventTypeId | undefined, string]>([
+  ['Venue', 'Valitsemillasi hakuehdoilla ei löytynyt yhtään paikkaa.'],
+  [
+    EventTypeId.General,
+    'Valitsemillasi hakuehdoilla ei löytynyt yhtään tapahtumaa.',
+  ],
+  [
+    EventTypeId.Course,
+    'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta.',
+  ],
+])('renders no events found text', (itemType, infoText) => {
+  render(<ResultsInfo itemType={itemType} resultsCount={0} />);
+  expect(screen.getByText(infoText)).toBeInTheDocument();
+});
 
 it('events with 0 results matches snapshot for no results', () => {
   const { container } = render(
@@ -9,14 +25,6 @@ it('events with 0 results matches snapshot for no results', () => {
   );
 
   expect(container).toMatchSnapshot();
-});
-
-it('renders no events found text', async () => {
-  render(<ResultsInfo itemType="Venue" resultsCount={0} />);
-
-  expect(
-    screen.getByText('Valitsemillasi hakuehdoilla ei löytynyt yhtään paikkaa.')
-  ).toBeInTheDocument();
 });
 
 it.each([1, 4])(

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx
@@ -4,18 +4,18 @@ import { render, screen } from '@/test-utils';
 import ResultsInfo from '../ResultsInfo';
 
 it('events with 0 results matches snapshot for no results', () => {
-  const { container } = render(<ResultsInfo resultsCount={0} />);
+  const { container } = render(
+    <ResultsInfo itemType="Venue" resultsCount={0} />
+  );
 
   expect(container).toMatchSnapshot();
 });
 
 it('renders no events found text', async () => {
-  render(<ResultsInfo resultsCount={0} />);
+  render(<ResultsInfo itemType="Venue" resultsCount={0} />);
 
   expect(
-    screen.getByText(
-      'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta'
-    )
+    screen.getByText('Valitsemillasi hakuehdoilla ei löytynyt yhtään paikkaa.')
   ).toBeInTheDocument();
 });
 

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@/test-utils';
 import SearchResultsContainer from '../SearchResultsContainer';
 
 it.each<[number, string]>([
-  [0, 'Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta'],
+  [0, 'Valitsemillasi hakuehdoilla ei löytynyt yhtään paikkaa.'],
   [1, 'Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.'],
   [4, 'Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.'],
 ])(
@@ -12,6 +12,7 @@ it.each<[number, string]>([
   (eventsCount, infoText) => {
     render(
       <SearchResultsContainer
+        itemType="Venue"
         eventList={<div />}
         eventsCount={eventsCount}
         loading={false}

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/__snapshots__/ResultsInfo.test.tsx.snap
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/__tests__/__snapshots__/ResultsInfo.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`events with 0 results matches snapshot for no results 1`] = `
     <div
       class="bigText"
     >
-      Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta
+      Valitsemillasi hakuehdoilla ei löytynyt yhtään paikkaa.
     </div>
   </div>
 </div>

--- a/apps/sports-helsinki/src/domain/search/venueSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/venueSearch/SearchPage.tsx
@@ -99,6 +99,7 @@ const VenueSearchPage: React.FC<SearchPageProps> = ({
           >
             {venuesList && (
               <SearchResultsContainer
+                itemType="Venue"
                 eventsCount={count}
                 loading={isLoadingVenues}
                 eventList={

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -51,13 +51,10 @@
   "textFoundEvents": "{{count}} search results",
   "buttonLoadMore": "Show more ({{count}})",
   "searchNotification": {
-    "noResultsTitle": "Sorry, no search results were found for the search criteria you selected.",
-    "noResultsTitleVenue": "Sorry, no venues were found for the search criteria you selected",
-    "noResultsTitleGeneral": "Sorry, no events were found for the search criteria you selected",
-    "noResultsTitleCourse": "Sorry, no hobbies were found for the search criteria you selected",
-    "noResultsText": "No search results were found for the search criteria you selected. Try to change search terms or change to event search.",
+    "noResultsTitleVenue": "No places were found with the selected search criteria.",
+    "noResultsTitleGeneral": "No events were found for the search criteria you selected.",
+    "noResultsTitleCourse": "No hobbies were found for the search criteria you selected.",
     "fewResultsTitle": "Your search terms returned only a few results.",
-    "fewResultsText": "Your search terms returned only a few results. Try to change search terms or change to event search.",
     "changeLanguageText": "Please change your search terms or display results in Finnish. You could also switch to an Events search.",
     "buttons": {
       "labelSearchOtherEventType": "Switch to an Events search",

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -52,6 +52,9 @@
   "buttonLoadMore": "Show more ({{count}})",
   "searchNotification": {
     "noResultsTitle": "Sorry, no search results were found for the search criteria you selected.",
+    "noResultsTitleVenue": "Sorry, no venues were found for the search criteria you selected",
+    "noResultsTitleGeneral": "Sorry, no events were found for the search criteria you selected",
+    "noResultsTitleCourse": "Sorry, no hobbies were found for the search criteria you selected",
     "noResultsText": "No search results were found for the search criteria you selected. Try to change search terms or change to event search.",
     "fewResultsTitle": "Your search terms returned only a few results.",
     "fewResultsText": "Your search terms returned only a few results. Try to change search terms or change to event search.",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -6,13 +6,10 @@
   "errorLoadMore": "Tapahtumien lataaminen epäonnistui",
   "buttonLoadMore": "Näytä lisää ({{count}})",
   "searchNotification": {
-    "noResultsTitle": "Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta",
-    "noResultsTitleVenue": "Ei löytynyt yhtään paikkoja",
-    "noResultsTitleGeneral": "Ei löytynyt yhtään tapahtumia",
-    "noResultsTitleCourse": "Ei löytynyt yhtään harrastuksia",
-    "noResultsText": "Valitsemillasi hakuehdoilla ei löytynyt harrastuksia. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",
+    "noResultsTitleVenue": "Valitsemillasi hakuehdoilla ei löytynyt yhtään paikkaa.",
+    "noResultsTitleGeneral": "Valitsemillasi hakuehdoilla ei löytynyt yhtään tapahtumaa.",
+    "noResultsTitleCourse": "Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta.",
     "fewResultsTitle": "Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.",
-    "fewResultsText": "Valitsemillasi hakuehdoilla löytyi vain vähän harrastuksia. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",
     "changeLanguageText": "Kokeile muuttaa hakuehtoja tai etsi suomen kielellä.",
     "buttons": {
       "labelSearchOtherEventType": "Siirry hakemaan tapahtumia",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -7,6 +7,9 @@
   "buttonLoadMore": "Näytä lisää ({{count}})",
   "searchNotification": {
     "noResultsTitle": "Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta",
+    "noResultsTitleVenue": "Ei löytynyt yhtään paikkoja",
+    "noResultsTitleGeneral": "Ei löytynyt yhtään tapahtumia",
+    "noResultsTitleCourse": "Ei löytynyt yhtään harrastuksia",
     "noResultsText": "Valitsemillasi hakuehdoilla ei löytynyt harrastuksia. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",
     "fewResultsTitle": "Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia.",
     "fewResultsText": "Valitsemillasi hakuehdoilla löytyi vain vähän harrastuksia. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -54,10 +54,10 @@
   "betaResultsNotificationText": "Vi arbetar med att vidareutveckla webbsidan. För tillfället innehåller tjänsten enbart hobbyer för barn och unga.",
   "buttonLoadMore": "Visa fler ({{count}})",
   "searchNotification": {
-    "noResultsTitle": "Tyvärr hittades inga resultat för de sökkriterier du valt.",
-    "noResultsText": "Tyvärr hittades inga resultat för de sökkriterier du valt. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",
-    "fewResultsTitle": "Med de sökvillkor du valde hittades bara några få resultat.",
-    "fewResultsText": "Med de sökvillkor du valde hittades bara några få resultat. Kokeile muuttaa hakuehtoja tai siirry tapahtumien hakuun.",
+    "noResultsTitleVenue": "Med de valda sökkriterierna hittades ingen plats.",
+    "noResultsTitleGeneral": "Med de valda sökkriterierna hittades inget evenemang.",
+    "noResultsTitleCourse": "Med de valda sökkriterierna hittades ingen hobby.",
+    "fewResultsTitle": "Med de valda sökkriterierna hittades endast få sökresultat.",
     "changeLanguageText": "Ändra sökvillkoren eller visa resultaten på finska. Du kan också välja att söka bland evenemang. Tillsvidare finns alla svenska hobbyer inte ännu på hemsidan.",
     "buttons": {
       "labelSearchOtherEventType": "Sök evenemang",


### PR DESCRIPTION
## Description
When no search results found, in all 3 apps should be shown specific to search item type error message (venue, event, course)

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
