### PR TITLE
fix: improve logic of buy button in hero

### DIFF
--- a/apps/events-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/events-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -1,7 +1,6 @@
 import {
   useLocale,
   getDateRangeStr,
-  buttonStyles,
   IconButton,
   InfoWithIcon,
   SkeletonLoader,
@@ -31,7 +30,6 @@ import {
   PageSection,
   useConfig,
 } from 'react-helsinki-headless-cms';
-import AppConfig from '../../app/AppConfig';
 
 import EventKeywords from '../eventKeywords/EventKeywords';
 import EventName from '../eventName/EventName';
@@ -70,10 +68,6 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
 
   const goBack = ({ returnPath, remainingQueryString = '' }: ReturnParams) => {
     router.push(`${returnPath}${remainingQueryString}`);
-  };
-
-  const goToBuyTicketsPage = () => {
-    window.open(offerInfoUrl);
   };
 
   const startTime =
@@ -161,28 +155,17 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
                       </InfoWithIcon>
                     </div>
                   )}
-                  {showBuyButton && (
-                    <div className={styles.buyButtonWrapper}>
-                      <Button
-                        aria-label={t('hero.ariaLabelBuyTickets')}
-                        onClick={goToBuyTicketsPage}
-                        iconRight={<IconLinkExternal aria-hidden />}
-                        variant="success"
-                      >
-                        {t('hero.buttonBuyTickets') as string}
-                      </Button>
-                    </div>
-                  )}
-                  {registrationUrl && (
+                  {(showBuyButton || registrationUrl) && (
                     <div className={styles.registrationButtonWrapper}>
                       <Button
-                        theme={AppConfig.defaultButtonTheme}
-                        variant={AppConfig.defaultButtonVariant}
-                        className={buttonStyles.buttonCoatBlue}
-                        aria-label={t('hero.ariaLabelEnrol')}
-                        onClick={() => window.open(registrationUrl)}
+                        variant="success"
+                        aria-label={t('hero.ariaLabelBuyTickets')}
+                        onClick={() =>
+                          window.open(registrationUrl || offerInfoUrl)
+                        }
+                        iconRight={<IconLinkExternal aria-hidden />}
                       >
-                        {t('hero.buttonEnrol') as string}
+                        {t('hero.buttonBuyTickets') as string}
                       </Button>
                     </div>
                   )}

--- a/apps/events-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/apps/events-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -179,12 +179,12 @@ it('Register button should be visible and clickable', async () => {
   render(<EventHero event={mockEvent} />);
 
   expect(
-    screen.getByText(translations.event.hero.buttonEnrol)
+    screen.getByText(translations.event.hero.buttonBuyTickets)
   ).toBeInTheDocument();
 
   await userEvent.click(
     screen.getByRole('button', {
-      name: translations.event.hero.ariaLabelEnrol,
+      name: translations.event.hero.ariaLabelBuyTickets,
     })
   );
 

--- a/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -174,19 +174,6 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
                       </Button>
                     </div>
                   )}
-                  {registrationUrl && (
-                    <div className={styles.registrationButtonWrapper}>
-                      <Button
-                        theme={AppConfig.defaultButtonTheme}
-                        variant={AppConfig.defaultButtonVariant}
-                        className={buttonStyles.buttonCoatBlue}
-                        aria-label={t('hero.ariaLabelEnrol')}
-                        onClick={() => window.open(registrationUrl)}
-                      >
-                        {t('hero.buttonEnrol') as string}
-                      </Button>
-                    </div>
-                  )}
                 </div>
                 {showKeywords && (
                   <div className={styles.categoryWrapper}>

--- a/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -44,6 +44,7 @@ export interface Props {
   superEvent?: SuperEventResponse;
 }
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 const EventHero: React.FC<Props> = ({ event, superEvent }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
@@ -70,10 +71,6 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
 
   const goBack = ({ returnPath, remainingQueryString = '' }: ReturnParams) => {
     router.push(`${returnPath}${remainingQueryString}`);
-  };
-
-  const goToBuyTicketsPage = () => {
-    window.open(offerInfoUrl);
   };
 
   const startTime =
@@ -161,15 +158,19 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
                       </InfoWithIcon>
                     </div>
                   )}
-                  {showBuyButton && (
-                    <div className={styles.buyButtonWrapper}>
+                  {(showBuyButton || registrationUrl) && (
+                    <div className={styles.registrationButtonWrapper}>
                       <Button
-                        aria-label={t('hero.ariaLabelBuyTickets')}
-                        onClick={goToBuyTicketsPage}
+                        theme={AppConfig.defaultButtonTheme}
+                        variant={AppConfig.defaultButtonVariant}
+                        className={buttonStyles.buttonCoatBlue}
+                        aria-label={t('hero.ariaLabelEnrol')}
+                        onClick={() =>
+                          window.open(registrationUrl || offerInfoUrl)
+                        }
                         iconRight={<IconLinkExternal aria-hidden />}
-                        variant="success"
                       >
-                        {t('hero.buttonBuyTickets') as string}
+                        {t('hero.buttonEnrol') as string}
                       </Button>
                     </div>
                   )}

--- a/apps/hobbies-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -121,7 +121,9 @@ it('should render this week tag', () => {
   ).toBeInTheDocument();
 });
 
-it('should hide buy button for free events', () => {
+// buy and enrol buttons are combined together, the difference is in the redirect url
+
+it('should hide buy/enrol button for free events', () => {
   const mockEvent = getFakeEvent({
     offers: [fakeOffer({ isFree: true }) as OfferFieldsFragment],
   });
@@ -129,12 +131,12 @@ it('should hide buy button for free events', () => {
 
   expect(
     screen.queryByRole('button', {
-      name: new RegExp(translations.event.hero.buttonBuyTickets, 'i'),
+      name: new RegExp(translations.event.hero.buttonEnrol, 'i'),
     })
   ).not.toBeInTheDocument();
 });
 
-it('should show buy button', async () => {
+it('should show buy/enrol button', async () => {
   global.open = jest.fn();
   const infoUrl = 'https://test.url';
   const mockEvent = getFakeEvent({
@@ -149,16 +151,9 @@ it('should show buy button', async () => {
 
   render(<EventHero event={mockEvent} />);
 
-  // shouldn't be rendred when externalLinks are not present
-  expect(
-    screen.queryByRole('button', {
-      name: new RegExp(translations.event.hero.buttonEnrol, 'i'),
-    })
-  ).not.toBeInTheDocument();
-
   await userEvent.click(
     screen.getByRole('button', {
-      name: new RegExp(translations.event.hero.buttonBuyTickets, 'i'),
+      name: translations.event.hero.ariaLabelEnrol,
     })
   );
   expect(global.open).toHaveBeenCalledWith(infoUrl);

--- a/apps/sports-helsinki/src/domain/event/eventHero/EventHero.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventHero/EventHero.tsx
@@ -72,10 +72,6 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
     router.push(`${returnPath}${remainingQueryString}`);
   };
 
-  const goToBuyTicketsPage = () => {
-    window.open(offerInfoUrl);
-  };
-
   const startTime =
     superEvent?.status === 'pending'
       ? ''
@@ -161,26 +157,15 @@ const EventHero: React.FC<Props> = ({ event, superEvent }) => {
                       </InfoWithIcon>
                     </div>
                   )}
-                  {showBuyButton && (
-                    <div className={styles.buyButtonWrapper}>
-                      <Button
-                        aria-label={t('hero.ariaLabelBuyTickets')}
-                        onClick={goToBuyTicketsPage}
-                        iconRight={<IconLinkExternal aria-hidden />}
-                        variant="success"
-                      >
-                        {t('hero.buttonBuyTickets') as string}
-                      </Button>
-                    </div>
-                  )}
-                  {registrationUrl && (
+                  {(showBuyButton || registrationUrl) && (
                     <div className={styles.registrationButtonWrapper}>
                       <Button
-                        theme={AppConfig.defaultButtonTheme}
-                        variant={AppConfig.defaultButtonVariant}
-                        className={buttonStyles.buttonCoatBlue}
+                        variant="success"
                         aria-label={t('hero.ariaLabelEnrol')}
-                        onClick={() => window.open(registrationUrl)}
+                        onClick={() =>
+                          window.open(registrationUrl || offerInfoUrl)
+                        }
+                        iconRight={<IconLinkExternal aria-hidden />}
                       >
                         {t('hero.buttonEnrol') as string}
                       </Button>

--- a/apps/sports-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -123,7 +123,9 @@ it('should render this week tag', () => {
   ).toBeInTheDocument();
 });
 
-it('should hide buy button for free events', () => {
+// buy and enrol buttons are combined together, the difference is in the redirect url
+
+it('should hide buy/enrol button for free events', () => {
   const mockEvent = getFakeEvent({
     offers: [fakeOffer({ isFree: true }) as OfferFieldsFragment],
   });
@@ -131,12 +133,12 @@ it('should hide buy button for free events', () => {
 
   expect(
     screen.queryByRole('button', {
-      name: new RegExp(translations.event.hero.buttonBuyTickets, 'i'),
+      name: new RegExp(translations.event.hero.buttonEnrol, 'i'),
     })
   ).not.toBeInTheDocument();
 });
 
-it('should show buy button', async () => {
+it('should show buy/enrol button', async () => {
   global.open = jest.fn();
   const infoUrl = 'https://test.url';
   const mockEvent = getFakeEvent({
@@ -151,16 +153,9 @@ it('should show buy button', async () => {
 
   render(<EventHero event={mockEvent} />);
 
-  // shouldn't be rendred when externalLinks are not present
-  expect(
-    screen.queryByRole('button', {
-      name: new RegExp(translations.event.hero.buttonEnrol, 'i'),
-    })
-  ).not.toBeInTheDocument();
-
   await userEvent.click(
     screen.getByRole('button', {
-      name: new RegExp(translations.event.hero.buttonBuyTickets, 'i'),
+      name: translations.event.hero.ariaLabelEnrol,
     })
   );
   expect(global.open).toHaveBeenCalledWith(infoUrl);


### PR DESCRIPTION
## Description
- Remove one of the buttons (combine functionality of Buy tickets and Enroll to one button)
- Fix colors (hobbies - coat, sports and events - success)
- Fix text (hobbies and sports - Enrol, events - Buy tickets)
- Redirect url (always prioritize registrationUrl)
- add external link icon

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
