### PR TITLE
feat: other hour object to venue info

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueInfo/VenueInfo.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueInfo/VenueInfo.tsx
@@ -17,10 +17,11 @@ import styles from './venueInfo.module.scss';
 
 const OpeningHoursInfo = ({ venue: { connections } }: { venue: Venue }) => {
   const { t } = useVenueTranslation();
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const connectionOpeningHoursSectionsContents: any[] = connections
-    ?.filter((item) => item?.sectionType === 'OPENING_HOURS')
+    ?.filter(
+      (item) => item?.sectionType === 'OPENING_HOURS' || 'OPENING_HOUR_OBJECT'
+    )
     ?.map((item) => item?.name);
   const connectionOpeningHoursSectionsLines =
     connectionOpeningHoursSectionsContents.join('\n\n').split('\n');


### PR DESCRIPTION
## Description

Each Opening Hour Object is a separate connection so there is a space between them

<img width="391" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/16116141/9645a9d2-1160-45e9-9201-314ca28b47c9">


## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
