### PR TITLE
Add app routing and theme contexts

### DIFF
--- a/apps/events-helsinki/config/jest/TestProviders.tsx
+++ b/apps/events-helsinki/config/jest/TestProviders.tsx
@@ -3,6 +3,7 @@ import { useApolloClient } from '@apollo/client';
 import type { MockedResponse } from '@apollo/client/testing';
 import { MockedProvider } from '@apollo/client/testing';
 import {
+  AppRoutingProvider,
   CmsHelperProvider,
   DEFAULT_LANGUAGE,
   NavigationContext,
@@ -25,6 +26,7 @@ import { ROUTES } from '../../src/constants';
 import cmsHelper from '../../src/domain/app/headlessCmsHelper';
 import routerHelper from '../../src/domain/app/routerHelper';
 import { initI18n as i18n } from './initI18n';
+import { appRoutingUrlMocks } from './mockDataUtils';
 
 const CMS_API_DOMAIN = 'tapahtumat.cms.test.domain.com';
 
@@ -47,23 +49,26 @@ function ErrorFallback({ error }: { error: Error }) {
 
 function TestProviders({ mocks, children, router }: Props) {
   return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    <I18nextProvider i18n={i18n}>
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <RHHCConfigProviderWithMockedApolloClient router={router}>
-          <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
-            <NavigationContext.Provider value={{}}>
-              <RouterContext.Provider value={{ ...router, ...mockRouter }}>
-                <ErrorBoundary FallbackComponent={ErrorFallback}>
-                  {children}
-                </ErrorBoundary>
-              </RouterContext.Provider>
-            </NavigationContext.Provider>
-          </CmsHelperProvider>
-        </RHHCConfigProviderWithMockedApolloClient>
-      </MockedProvider>
-    </I18nextProvider>
+    <AppRoutingProvider {...appRoutingUrlMocks}>
+      <I18nextProvider i18n={i18n}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <RHHCConfigProviderWithMockedApolloClient router={router}>
+            <CmsHelperProvider
+              cmsHelper={cmsHelper}
+              routerHelper={routerHelper}
+            >
+              <NavigationContext.Provider value={{}}>
+                <RouterContext.Provider value={{ ...router, ...mockRouter }}>
+                  <ErrorBoundary FallbackComponent={ErrorFallback}>
+                    {children}
+                  </ErrorBoundary>
+                </RouterContext.Provider>
+              </NavigationContext.Provider>
+            </CmsHelperProvider>
+          </RHHCConfigProviderWithMockedApolloClient>
+        </MockedProvider>
+      </I18nextProvider>
+    </AppRoutingProvider>
   );
 }
 

--- a/apps/events-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/events-helsinki/config/jest/mockDataUtils.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
+  AppLanguage,
   Audience,
   BannerPage,
   CmsImage,
   EventDetails,
+  EventFields,
   EventListResponse,
   ExternalLink,
   Image,
@@ -22,8 +24,10 @@ import type {
   StaticPage,
 } from '@events-helsinki/components';
 import { EXTLINK, EventTypeId } from '@events-helsinki/components';
+import type { AppRoutingContextProps } from '@events-helsinki/components/routingUrlProvider/AppRoutingContext';
 import { faker } from '@faker-js/faker';
 import merge from 'lodash/merge';
+import type { NextRouter } from 'next/router';
 
 export const fakeEvents = (
   count = 1,
@@ -357,4 +361,45 @@ const generateNodeArray = <T extends (...args: any) => any>(
   length: number
 ): ReturnType<T>[] => {
   return Array.from({ length }).map((_, i) => fakeFunc(i));
+};
+
+export const appRoutingUrlMocks: AppRoutingContextProps = {
+  getEventListLinkUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
+        `/tapahtumat/${event.id}?returnPath=/haku`
+    ),
+  getOrganizationSearchUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
+        `/haku?publisher=${event.publisher}&searchType=${event.typeId}`
+    ),
+  getPlainEventUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _locale: AppLanguage) => `/tapahtumat/${event.id}`
+    ),
+  getCardUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _locale: AppLanguage) => `/tapahtumat/${event.id}`
+    ),
+  getEventUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
+        `/tapahtumat/${event.id}`
+    ),
+  getKeywordOnClickHandler: jest
+    .fn()
+    .mockImplementation(
+      (
+        _router: NextRouter,
+        _locale: AppLanguage,
+        _type: 'text' | 'isFree' | 'dateType',
+        _value?: string | undefined
+      ) => jest.fn()
+    ),
 };

--- a/apps/events-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/events-helsinki/src/domain/event/EventPageContainer.tsx
@@ -18,16 +18,8 @@ import React, { useState } from 'react';
 import { Link } from 'react-helsinki-headless-cms';
 
 import { ROUTES } from '../../constants';
-import AppConfig from '../app/AppConfig';
 import routerHelper from '../app/routerHelper';
 import ErrorHero from '../error/ErrorHero';
-import {
-  getCardUrl,
-  getEventListLinkUrl,
-  getKeywordOnClickHandler,
-  getOrganizationSearchUrl,
-  getPlainEventUrl,
-} from '../search/eventSearch/utils';
 
 import styles from './eventPage.module.scss';
 import useSimilarEventsQueryVariables from './useSimilarEventsQueryVariables';
@@ -80,27 +72,14 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
               {/* Wait for data to be accessible before updating metadata */}
               <EventPageMeta event={event} />
               {eventClosed ? (
-                <EventClosedHero
-                  onClick={moveToHomePage}
-                  theme={AppConfig.defaultButtonTheme}
-                  variant={AppConfig.defaultButtonVariant}
-                />
+                <EventClosedHero onClick={moveToHomePage} />
               ) : (
                 <>
-                  <EventHero
-                    event={event}
-                    superEvent={superEvent}
-                    theme={AppConfig.defaultButtonTheme}
-                    variant={AppConfig.defaultButtonVariant}
-                    getKeywordOnClickHandler={getKeywordOnClickHandler}
-                  />
+                  <EventHero event={event} superEvent={superEvent} />
                   <EventContent
                     event={event}
                     superEvent={superEvent}
                     hasSimilarEvents={hasSimilarEvents}
-                    getEventListLinkUrl={getEventListLinkUrl}
-                    getOrganizationSearchUrl={getOrganizationSearchUrl}
-                    getPlainEventUrl={getPlainEventUrl}
                   />
                 </>
               )}
@@ -109,9 +88,6 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
                 <SimilarEvents
                   event={event}
                   onEventsLoaded={handleSimilarEventsLoaded}
-                  getCardUrl={(event, locale) =>
-                    getCardUrl(event, locale, router.asPath)
-                  }
                   eventFilters={similarEventsFilters ?? {}}
                 />
               )}

--- a/apps/events-helsinki/src/domain/event/eventDetails/EventDetails.tsx
+++ b/apps/events-helsinki/src/domain/event/eventDetails/EventDetails.tsx
@@ -68,7 +68,6 @@ const EventDetails: React.FC<EventDetailsProps> = (props) => {
           showIsFree
           showKeywordsCount
           withActions={false}
-          getKeywordOnClickHandler={getKeywordOnClickHandler}
         />
       </div>
     </div>

--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -186,7 +186,6 @@ const SearchPage: React.FC<{
                     showEnrolmentStatusInCardDetails={
                       AppConfig.showEnrolmentStatusInCardDetails
                     }
-                    getKeywordOnClickHandler={getKeywordOnClickHandler}
                   />
                 }
                 orderBySelectComponent={<EventsOrderBySelect />}

--- a/apps/events-helsinki/src/pages/_app.tsx
+++ b/apps/events-helsinki/src/pages/_app.tsx
@@ -20,6 +20,14 @@ import AppConfig from '../domain/app/AppConfig';
 import EventsApolloProvider from '../domain/app/EventsApolloProvider';
 import cmsHelper from '../domain/app/headlessCmsHelper';
 import routerHelper from '../domain/app/routerHelper';
+import {
+  getCardUrl,
+  getEventListLinkUrl,
+  getEventUrl,
+  getKeywordOnClickHandler,
+  getOrganizationSearchUrl,
+  getPlainEventUrl,
+} from '../domain/search/eventSearch/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AppProps<P = any> = {
@@ -50,6 +58,14 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
           )}
           withConsent={pathname !== ROUTES.COOKIE_CONSENT}
           asPath={asPath}
+          defaultButtonTheme={AppConfig.defaultButtonTheme}
+          defaultButtonVariant={AppConfig.defaultButtonVariant}
+          getCardUrl={getCardUrl}
+          getEventUrl={getEventUrl}
+          getEventListLinkUrl={getEventListLinkUrl}
+          getOrganizationSearchUrl={getOrganizationSearchUrl}
+          getPlainEventUrl={getPlainEventUrl}
+          getKeywordOnClickHandler={getKeywordOnClickHandler}
           {...pageProps}
         >
           <Component {...pageProps} />

--- a/apps/hobbies-helsinki/config/jest/TestProviders.tsx
+++ b/apps/hobbies-helsinki/config/jest/TestProviders.tsx
@@ -3,6 +3,7 @@ import { useApolloClient } from '@apollo/client';
 import type { MockedResponse } from '@apollo/client/testing';
 import { MockedProvider } from '@apollo/client/testing';
 import {
+  AppRoutingProvider,
   CmsHelperProvider,
   DEFAULT_LANGUAGE,
   NavigationContext,
@@ -26,6 +27,7 @@ import { ROUTES } from '../../src/constants';
 import cmsHelper from '../../src/domain/app/headlessCmsHelper';
 import routerHelper from '../../src/domain/app/routerHelper';
 import { initI18n as i18n } from './initI18n';
+import { appRoutingUrlMocks } from './mockDataUtils';
 
 const CMS_API_DOMAIN = 'harrastukset.cms.test.domain.com';
 
@@ -47,23 +49,26 @@ function ErrorFallback({ error }: { error: Error }) {
 
 function TestProviders({ mocks, children, router }: Props) {
   return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    <I18nextProvider i18n={i18n}>
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <RHHCConfigProviderWithMockedApolloClient router={router}>
-          <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
-            <NavigationContext.Provider value={{}}>
-              <RouterContext.Provider value={{ ...router, ...mockRouter }}>
-                <ErrorBoundary FallbackComponent={ErrorFallback}>
-                  {children}
-                </ErrorBoundary>
-              </RouterContext.Provider>
-            </NavigationContext.Provider>
-          </CmsHelperProvider>
-        </RHHCConfigProviderWithMockedApolloClient>
-      </MockedProvider>
-    </I18nextProvider>
+    <AppRoutingProvider {...appRoutingUrlMocks}>
+      <I18nextProvider i18n={i18n}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <RHHCConfigProviderWithMockedApolloClient router={router}>
+            <CmsHelperProvider
+              cmsHelper={cmsHelper}
+              routerHelper={routerHelper}
+            >
+              <NavigationContext.Provider value={{}}>
+                <RouterContext.Provider value={{ ...router, ...mockRouter }}>
+                  <ErrorBoundary FallbackComponent={ErrorFallback}>
+                    {children}
+                  </ErrorBoundary>
+                </RouterContext.Provider>
+              </NavigationContext.Provider>
+            </CmsHelperProvider>
+          </RHHCConfigProviderWithMockedApolloClient>
+        </MockedProvider>
+      </I18nextProvider>
+    </AppRoutingProvider>
   );
 }
 

--- a/apps/hobbies-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/hobbies-helsinki/config/jest/mockDataUtils.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
+  AppLanguage,
   Audience,
   BannerPage,
   CmsImage,
   EventDetails,
+  EventFields,
   EventListResponse,
   ExternalLink,
   Image,
@@ -22,8 +24,10 @@ import type {
   StaticPage,
 } from '@events-helsinki/components';
 import { EXTLINK, EventTypeId } from '@events-helsinki/components';
+import type { AppRoutingContextProps } from '@events-helsinki/components/routingUrlProvider/AppRoutingContext';
 import { faker } from '@faker-js/faker';
 import merge from 'lodash/merge';
+import type { NextRouter } from 'next/router';
 
 export const fakeEvents = (
   count = 1,
@@ -357,4 +361,46 @@ const generateNodeArray = <T extends (...args: any) => any>(
   length: number
 ): ReturnType<T>[] => {
   return Array.from({ length }).map((_, i) => fakeFunc(i));
+};
+
+export const appRoutingUrlMocks: AppRoutingContextProps = {
+  getEventListLinkUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
+        `/kurssit/${event.id}`
+    ),
+  getOrganizationSearchUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
+        `/haku?publisher=${event.publisher}&searchType=${event.typeId}`
+    ),
+  getPlainEventUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _locale: AppLanguage) => `/kurssit/${event.id}`
+    ),
+  getCardUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _locale: 'fi' | 'en' | 'sv') =>
+        `/kurssit/${event.id}`
+    ),
+  getEventUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: 'fi' | 'en' | 'sv') =>
+        `/kurssit/${event.id}`
+    ),
+  getKeywordOnClickHandler: jest
+    .fn()
+    .mockImplementation(
+      (
+        _router: NextRouter,
+        _locale: 'fi' | 'en' | 'sv',
+        _type: 'text' | 'isFree' | 'dateType',
+        _value?: string | undefined
+      ) => jest.fn()
+    ),
 };

--- a/apps/hobbies-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/EventPageContainer.tsx
@@ -18,16 +18,8 @@ import React, { useState } from 'react';
 import { Link } from 'react-helsinki-headless-cms';
 
 import { ROUTES } from '../../constants';
-import AppConfig from '../app/AppConfig';
 import routerHelper from '../app/routerHelper';
 import ErrorHero from '../error/ErrorHero';
-import {
-  getCardUrl,
-  getEventListLinkUrl,
-  getKeywordOnClickHandler,
-  getOrganizationSearchUrl,
-  getPlainEventUrl,
-} from '../search/eventSearch/utils';
 
 import styles from './eventPage.module.scss';
 import useSimilarEventsQueryVariables from './useSimilarEventsQueryVariables';
@@ -80,27 +72,14 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
               {/* Wait for data to be accessible before updating metadata */}
               <EventPageMeta event={event} />
               {eventClosed ? (
-                <EventClosedHero
-                  onClick={moveToHomePage}
-                  theme={AppConfig.defaultButtonTheme}
-                  variant={AppConfig.defaultButtonVariant}
-                />
+                <EventClosedHero onClick={moveToHomePage} />
               ) : (
                 <>
-                  <EventHero
-                    event={event}
-                    superEvent={superEvent}
-                    theme={AppConfig.defaultButtonTheme}
-                    variant={AppConfig.defaultButtonVariant}
-                    getKeywordOnClickHandler={getKeywordOnClickHandler}
-                  />
+                  <EventHero event={event} superEvent={superEvent} />
                   <EventContent
                     event={event}
                     superEvent={superEvent}
                     hasSimilarEvents={hasSimilarEvents}
-                    getEventListLinkUrl={getEventListLinkUrl}
-                    getOrganizationSearchUrl={getOrganizationSearchUrl}
-                    getPlainEventUrl={getPlainEventUrl}
                   />
                 </>
               )}
@@ -109,9 +88,6 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
                 <SimilarEvents
                   event={event}
                   onEventsLoaded={handleSimilarEventsLoaded}
-                  getCardUrl={(event, locale) =>
-                    getCardUrl(event, locale, router.asPath)
-                  }
                   eventFilters={similarEventsFilters ?? {}}
                 />
               )}

--- a/apps/hobbies-helsinki/src/domain/event/eventDetails/EventDetails.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventDetails/EventDetails.tsx
@@ -69,7 +69,6 @@ const EventDetails: React.FC<EventDetailsProps> = (props) => {
           showIsFree
           showKeywordsCount
           withActions={false}
-          getKeywordOnClickHandler={getKeywordOnClickHandler}
         />
       </div>
     </div>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -181,7 +181,6 @@ const SearchPage: React.FC<{
                     showEnrolmentStatusInCardDetails={
                       AppConfig.showEnrolmentStatusInCardDetails
                     }
-                    getKeywordOnClickHandler={getKeywordOnClickHandler}
                   />
                 }
               />

--- a/apps/hobbies-helsinki/src/pages/_app.tsx
+++ b/apps/hobbies-helsinki/src/pages/_app.tsx
@@ -19,6 +19,14 @@ import AppConfig from '../domain/app/AppConfig';
 import cmsHelper from '../domain/app/headlessCmsHelper';
 import HobbiesApolloProvider from '../domain/app/HobbiesApolloProvider';
 import routerHelper from '../domain/app/routerHelper';
+import {
+  getCardUrl,
+  getEventListLinkUrl,
+  getEventUrl,
+  getKeywordOnClickHandler,
+  getOrganizationSearchUrl,
+  getPlainEventUrl,
+} from '../domain/search/eventSearch/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AppProps<P = any> = {
@@ -50,6 +58,14 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
           )}
           withConsent={pathname !== ROUTES.COOKIE_CONSENT}
           asPath={asPath}
+          defaultButtonTheme={AppConfig.defaultButtonTheme}
+          defaultButtonVariant={AppConfig.defaultButtonVariant}
+          getCardUrl={getCardUrl}
+          getEventUrl={getEventUrl}
+          getEventListLinkUrl={getEventListLinkUrl}
+          getOrganizationSearchUrl={getOrganizationSearchUrl}
+          getPlainEventUrl={getPlainEventUrl}
+          getKeywordOnClickHandler={getKeywordOnClickHandler}
           {...pageProps}
         >
           <Component {...pageProps} />

--- a/apps/sports-helsinki/config/jest/TestProviders.tsx
+++ b/apps/sports-helsinki/config/jest/TestProviders.tsx
@@ -3,6 +3,7 @@ import { useApolloClient } from '@apollo/client';
 import { MockedProvider } from '@apollo/client/testing';
 import type { MockedResponse } from '@apollo/client/testing';
 import {
+  AppRoutingProvider,
   CmsHelperProvider,
   DEFAULT_LANGUAGE,
   NavigationContext,
@@ -25,6 +26,7 @@ import { ROUTES } from '../../src/constants';
 import cmsHelper from '../../src/domain/app/headlessCmsHelper';
 import routerHelper from '../../src/domain/app/routerHelper';
 import { initI18n as i18n } from './initI18n';
+import { appRoutingUrlMocks } from './mockDataUtils';
 
 const CMS_API_DOMAIN = 'liikunta.cms.test.domain.com';
 
@@ -47,23 +49,26 @@ function ErrorFallback({ error }: { error: Error }) {
 
 function TestProviders({ mocks, children, router }: Props) {
   return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    <I18nextProvider i18n={i18n}>
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <RHHCConfigProviderWithMockedApolloClient router={router}>
-          <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
-            <NavigationContext.Provider value={{}}>
-              <RouterContext.Provider value={{ ...router, ...mockRouter }}>
-                <ErrorBoundary FallbackComponent={ErrorFallback}>
-                  {children}
-                </ErrorBoundary>
-              </RouterContext.Provider>
-            </NavigationContext.Provider>
-          </CmsHelperProvider>
-        </RHHCConfigProviderWithMockedApolloClient>
-      </MockedProvider>
-    </I18nextProvider>
+    <AppRoutingProvider {...appRoutingUrlMocks}>
+      <I18nextProvider i18n={i18n}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <RHHCConfigProviderWithMockedApolloClient router={router}>
+            <CmsHelperProvider
+              cmsHelper={cmsHelper}
+              routerHelper={routerHelper}
+            >
+              <NavigationContext.Provider value={{}}>
+                <RouterContext.Provider value={{ ...router, ...mockRouter }}>
+                  <ErrorBoundary FallbackComponent={ErrorFallback}>
+                    {children}
+                  </ErrorBoundary>
+                </RouterContext.Provider>
+              </NavigationContext.Provider>
+            </CmsHelperProvider>
+          </RHHCConfigProviderWithMockedApolloClient>
+        </MockedProvider>
+      </I18nextProvider>
+    </AppRoutingProvider>
   );
 }
 

--- a/apps/sports-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/sports-helsinki/config/jest/mockDataUtils.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
+  AppLanguage,
   Audience,
   BannerPage,
   CmsImage,
   EventDetails,
+  EventFields,
   EventListResponse,
   ExternalLink,
   Image,
@@ -26,8 +28,10 @@ import type {
   Venue,
 } from '@events-helsinki/components';
 import { EXTLINK, EventTypeId } from '@events-helsinki/components';
+import type { AppRoutingContextProps } from '@events-helsinki/components/routingUrlProvider/AppRoutingContext';
 import { faker } from '@faker-js/faker';
 import merge from 'lodash/merge';
+import type { NextRouter } from 'next/router';
 
 export const fakeEvents = (
   count = 1,
@@ -460,4 +464,46 @@ export const fakeVenue = (overrides?: Partial<Venue>): Venue => {
     },
     overrides
   );
+};
+
+export const appRoutingUrlMocks: AppRoutingContextProps = {
+  getEventListLinkUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
+        `/kurssit/${event.id}`
+    ),
+  getOrganizationSearchUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
+        `/haku?publisher=${event.publisher}&searchType=${event.typeId}`
+    ),
+  getPlainEventUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _locale: AppLanguage) => `/kurssit/${event.id}`
+    ),
+  getCardUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _locale: 'fi' | 'en' | 'sv') =>
+        `/kurssit/${event.id}`
+    ),
+  getEventUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: 'fi' | 'en' | 'sv') =>
+        `/kurssit/${event.id}`
+    ),
+  getKeywordOnClickHandler: jest
+    .fn()
+    .mockImplementation(
+      (
+        _router: NextRouter,
+        _locale: 'fi' | 'en' | 'sv',
+        _type: 'text' | 'isFree' | 'dateType',
+        _value?: string | undefined
+      ) => jest.fn()
+    ),
 };

--- a/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
@@ -20,15 +20,6 @@ import { Link } from 'react-helsinki-headless-cms';
 import { ROUTES } from '../../constants';
 import routerHelper from '../app/routerHelper';
 import ErrorHero from '../error/ErrorHero';
-import {
-  getCardUrl,
-  getEventListLinkUrl,
-  getKeywordOnClickHandler,
-  getOrganizationSearchUrl,
-  getPlainEventUrl,
-} from '../search/eventSearch/utils';
-import AppConfig from './../app/AppConfig';
-
 import styles from './eventPage.module.scss';
 import useSimilarEventsQueryVariables from './useSimilarEventsQueryVariables';
 
@@ -80,27 +71,14 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
               {/* Wait for data to be accessible before updating metadata */}
               <EventPageMeta event={event} />
               {eventClosed ? (
-                <EventClosedHero
-                  onClick={moveToHomePage}
-                  theme={AppConfig.defaultButtonTheme}
-                  variant={AppConfig.defaultButtonVariant}
-                />
+                <EventClosedHero onClick={moveToHomePage} />
               ) : (
                 <>
-                  <EventHero
-                    event={event}
-                    superEvent={superEvent}
-                    theme={AppConfig.defaultButtonTheme}
-                    variant={AppConfig.defaultButtonVariant}
-                    getKeywordOnClickHandler={getKeywordOnClickHandler}
-                  />
+                  <EventHero event={event} superEvent={superEvent} />
                   <EventContent
                     event={event}
                     superEvent={superEvent}
                     hasSimilarEvents={hasSimilarEvents}
-                    getEventListLinkUrl={getEventListLinkUrl}
-                    getOrganizationSearchUrl={getOrganizationSearchUrl}
-                    getPlainEventUrl={getPlainEventUrl}
                   />
                 </>
               )}
@@ -109,9 +87,6 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
                 <SimilarEvents
                   event={event}
                   onEventsLoaded={handleSimilarEventsLoaded}
-                  getCardUrl={(event, locale) =>
-                    getCardUrl(event, locale, router.asPath)
-                  }
                   eventFilters={similarEventsFilters ?? {}}
                 />
               )}

--- a/apps/sports-helsinki/src/domain/event/eventDetails/EventDetails.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventDetails/EventDetails.tsx
@@ -68,7 +68,6 @@ const EventDetails: React.FC<EventDetailsProps> = (props) => {
           showIsFree
           showKeywordsCount
           withActions={false}
-          getKeywordOnClickHandler={getKeywordOnClickHandler}
         />
       </div>
     </div>

--- a/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -117,7 +117,6 @@ const EventSearchPage: React.FC<SearchPageProps> = ({
                     showEnrolmentStatusInCardDetails={
                       AppConfig.showEnrolmentStatusInCardDetails
                     }
-                    getKeywordOnClickHandler={getKeywordOnClickHandler}
                   />
                 }
                 orderBySelectComponent={

--- a/apps/sports-helsinki/src/pages/_app.tsx
+++ b/apps/sports-helsinki/src/pages/_app.tsx
@@ -20,6 +20,14 @@ import AppConfig from '../domain/app/AppConfig';
 import cmsHelper from '../domain/app/headlessCmsHelper';
 import routerHelper from '../domain/app/routerHelper';
 import SportsApolloProvider from '../domain/app/SportsApolloProvider';
+import {
+  getCardUrl,
+  getEventListLinkUrl,
+  getEventUrl,
+  getKeywordOnClickHandler,
+  getOrganizationSearchUrl,
+  getPlainEventUrl,
+} from '../domain/search/eventSearch/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AppProps<P = any> = {
@@ -50,6 +58,14 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
           )}
           withConsent={pathname !== ROUTES.COOKIE_CONSENT}
           asPath={asPath}
+          defaultButtonTheme={AppConfig.defaultButtonTheme}
+          defaultButtonVariant={AppConfig.defaultButtonVariant}
+          getCardUrl={getCardUrl}
+          getEventUrl={getEventUrl}
+          getEventListLinkUrl={getEventListLinkUrl}
+          getOrganizationSearchUrl={getOrganizationSearchUrl}
+          getPlainEventUrl={getPlainEventUrl}
+          getKeywordOnClickHandler={getKeywordOnClickHandler}
           {...pageProps}
         >
           <Component {...pageProps} />

--- a/packages/components/config/tests/app-test-providers.tsx
+++ b/packages/components/config/tests/app-test-providers.tsx
@@ -15,7 +15,8 @@ import {
 } from 'react-helsinki-headless-cms';
 import type { Config as RHHCConfig } from 'react-helsinki-headless-cms';
 import { I18nextTestStubProvider } from '@/test-utils/I18nextTestStubProvider';
-import { DEFAULT_LANGUAGE } from '../../src';
+import { AppRoutingProvider, DEFAULT_LANGUAGE } from '../../src';
+import { appRoutingUrlMocks } from './mockDataUtils';
 const cmsApiDomain = 'tapahtumat.cms.test.domain.com';
 
 const mockRouter: Partial<NextRouter> = {
@@ -37,17 +38,19 @@ function ErrorFallback({ error }: { error: Error }) {
 
 function TestProviders({ mocks, children, router }: Props) {
   return (
-    <I18nextTestStubProvider>
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <RHHCConfigProviderWithMockedApolloClient router={router}>
-          <RouterContext.Provider value={{ ...router, ...mockRouter }}>
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
-              {children}
-            </ErrorBoundary>
-          </RouterContext.Provider>
-        </RHHCConfigProviderWithMockedApolloClient>
-      </MockedProvider>
-    </I18nextTestStubProvider>
+    <AppRoutingProvider {...appRoutingUrlMocks}>
+      <I18nextTestStubProvider>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <RHHCConfigProviderWithMockedApolloClient router={router}>
+            <RouterContext.Provider value={{ ...router, ...mockRouter }}>
+              <ErrorBoundary FallbackComponent={ErrorFallback}>
+                {children}
+              </ErrorBoundary>
+            </RouterContext.Provider>
+          </RHHCConfigProviderWithMockedApolloClient>
+        </MockedProvider>
+      </I18nextTestStubProvider>
+    </AppRoutingProvider>
   );
 }
 

--- a/packages/components/config/tests/mockDataUtils.ts
+++ b/packages/components/config/tests/mockDataUtils.ts
@@ -3,30 +3,31 @@ import { faker } from '@faker-js/faker';
 import merge from 'lodash/merge';
 import type { NextRouter } from 'next/router';
 import { EXTLINK } from '../../src/constants';
+import type { AppRoutingContextProps } from '../../src/routingUrlProvider/AppRoutingContext';
 import { EventTypeId } from '../../src/types';
 import type {
   EventFields,
   AppLanguage,
-  type Audience,
-  type BannerPage,
-  type CmsImage,
-  type EventDetails,
-  type EventListResponse,
-  type ExternalLink,
-  type Image,
-  type InLanguage,
-  type Keyword,
-  type KeywordListResponse,
-  type LocalizedCmsImage,
-  type LocalizedCmsKeywords,
-  type LocalizedObject,
-  type Neighborhood,
-  type NeighborhoodListResponse,
-  type Offer,
-  type OrganizationDetails,
-  type Place,
-  type PlaceListResponse,
-  type StaticPage,
+  Audience,
+  BannerPage,
+  CmsImage,
+  EventDetails,
+  EventListResponse,
+  ExternalLink,
+  Image,
+  InLanguage,
+  Keyword,
+  KeywordListResponse,
+  LocalizedCmsImage,
+  LocalizedCmsKeywords,
+  LocalizedObject,
+  Neighborhood,
+  NeighborhoodListResponse,
+  Offer,
+  OrganizationDetails,
+  Place,
+  PlaceListResponse,
+  StaticPage,
 } from '../../src/types';
 
 export const fakeEvents = (
@@ -363,12 +364,12 @@ const generateNodeArray = <T extends (...args: any) => any>(
   return Array.from({ length }).map((_, i) => fakeFunc(i));
 };
 
-export const commonAppUrlGetterMocks = {
+export const appRoutingUrlMocks: AppRoutingContextProps = {
   getEventListLinkUrl: jest
     .fn()
     .mockImplementation(
       (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
-        `/kurssit/${event.id}?returnPath=/haku`
+        `/kurssit/${event.id}`
     ),
   getOrganizationSearchUrl: jest
     .fn()
@@ -380,5 +381,27 @@ export const commonAppUrlGetterMocks = {
     .fn()
     .mockImplementation(
       (event: EventFields, _locale: AppLanguage) => `/kurssit/${event.id}`
+    ),
+  getCardUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _locale: 'fi' | 'en' | 'sv') =>
+        `/kurssit/${event.id}`
+    ),
+  getEventUrl: jest
+    .fn()
+    .mockImplementation(
+      (event: EventFields, _router: NextRouter, _locale: 'fi' | 'en' | 'sv') =>
+        `/kurssit/${event.id}`
+    ),
+  getKeywordOnClickHandler: jest
+    .fn()
+    .mockImplementation(
+      (
+        _router: NextRouter,
+        _locale: 'fi' | 'en' | 'sv',
+        _type: 'text' | 'isFree' | 'dateType',
+        _value?: string | undefined
+      ) => jest.fn()
     ),
 };

--- a/packages/components/src/app/BaseApp.tsx
+++ b/packages/components/src/app/BaseApp.tsx
@@ -21,6 +21,12 @@ import ResetFocus from '../components/resetFocus/ResetFocus';
 import { GeolocationProvider } from '../geolocation';
 import { NavigationProvider } from '../navigationProvider';
 import type { NavigationProviderProps } from '../navigationProvider';
+import {
+  AppRoutingProvider,
+  type AppRoutingProviderProps,
+} from '../routingUrlProvider';
+import type { AppThemeProviderProps } from '../themeProvider';
+import { AppThemeProvider } from '../themeProvider';
 import type { CmsRoutedAppHelper, HeadlessCMSHelper } from '../utils';
 
 export type Props = {
@@ -34,6 +40,8 @@ export type Props = {
   asPath: string;
   withConsent: boolean;
 } & NavigationProviderProps &
+  AppRoutingProviderProps &
+  AppThemeProviderProps &
   SSRConfig;
 
 const DynamicToastContainer = dynamic(
@@ -65,6 +73,14 @@ function BaseApp({
   askemFeedbackConfiguration,
   asPath,
   withConsent,
+  defaultButtonTheme,
+  defaultButtonVariant,
+  getCardUrl,
+  getEventUrl,
+  getEventListLinkUrl,
+  getOrganizationSearchUrl,
+  getPlainEventUrl,
+  getKeywordOnClickHandler,
 }: Props) {
   const { getAllConsents } = useCookies();
 
@@ -118,30 +134,44 @@ function BaseApp({
   );
 
   return (
-    <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
-      <MatomoProvider value={matomoInstance}>
-        <AskemProvider value={askemFeedbackInstance}>
-          <GeolocationProvider>
-            <NavigationProvider
-              headerMenu={headerMenu}
-              footerMenu={footerMenu}
-              languages={languages}
-            >
-              <ResetFocus />
-              {children}
-              {withConsent && (
-                <EventsCookieConsent
-                  onConsentGiven={handleConsentGiven}
-                  allowLanguageSwitch={false}
-                  appName={appName}
-                />
-              )}
-              <DynamicToastContainer />
-            </NavigationProvider>
-          </GeolocationProvider>
-        </AskemProvider>
-      </MatomoProvider>
-    </CmsHelperProvider>
+    <AppThemeProvider
+      defaultButtonTheme={defaultButtonTheme}
+      defaultButtonVariant={defaultButtonVariant}
+    >
+      <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
+        <AppRoutingProvider
+          getCardUrl={getCardUrl}
+          getEventUrl={getEventUrl}
+          getEventListLinkUrl={getEventListLinkUrl}
+          getOrganizationSearchUrl={getOrganizationSearchUrl}
+          getPlainEventUrl={getPlainEventUrl}
+          getKeywordOnClickHandler={getKeywordOnClickHandler}
+        >
+          <MatomoProvider value={matomoInstance}>
+            <AskemProvider value={askemFeedbackInstance}>
+              <GeolocationProvider>
+                <NavigationProvider
+                  headerMenu={headerMenu}
+                  footerMenu={footerMenu}
+                  languages={languages}
+                >
+                  <ResetFocus />
+                  {children}
+                  {withConsent && (
+                    <EventsCookieConsent
+                      onConsentGiven={handleConsentGiven}
+                      allowLanguageSwitch={false}
+                      appName={appName}
+                    />
+                  )}
+                  <DynamicToastContainer />
+                </NavigationProvider>
+              </GeolocationProvider>
+            </AskemProvider>
+          </MatomoProvider>
+        </AppRoutingProvider>
+      </CmsHelperProvider>
+    </AppThemeProvider>
   );
 }
 

--- a/packages/components/src/components/domain/event/eventContent/EventContent.tsx
+++ b/packages/components/src/components/domain/event/eventContent/EventContent.tsx
@@ -15,11 +15,6 @@ import type {
   EventFields,
   SuperEventResponse,
 } from '../../../../types/event-types';
-import type {
-  GetEventListLinkUrlType,
-  GetOrganizationSearchUrlType,
-  GetPlainEventUrlType,
-} from '../../../../types/types';
 import { getEventFields } from '../../../../utils/eventUtils';
 import EventInfo from '../eventInfo/EventInfo';
 import EventLocation from '../eventLocation/EventLocation';
@@ -29,18 +24,12 @@ interface Props {
   event: EventFields;
   superEvent?: SuperEventResponse;
   hasSimilarEvents?: boolean;
-  getEventListLinkUrl: GetEventListLinkUrlType;
-  getOrganizationSearchUrl: GetOrganizationSearchUrlType;
-  getPlainEventUrl: GetPlainEventUrlType;
 }
 
 const EventContent: React.FC<Props> = ({
   event,
   superEvent,
   hasSimilarEvents,
-  getEventListLinkUrl,
-  getOrganizationSearchUrl,
-  getPlainEventUrl,
 }) => {
   const { t } = useTranslation(['common', 'event']);
   const locale = useLocale();
@@ -99,13 +88,7 @@ const EventContent: React.FC<Props> = ({
             {!isInternetEvent && <EventLocation event={event} />}
           </div>
           <div>
-            <EventInfo
-              event={event}
-              superEvent={superEvent}
-              getEventListLinkUrl={getEventListLinkUrl}
-              getOrganizationSearchUrl={getOrganizationSearchUrl}
-              getPlainEventUrl={getPlainEventUrl}
-            />
+            <EventInfo event={event} superEvent={superEvent} />
           </div>
         </div>
       </ContentContainer>

--- a/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 
 import { configure, render, screen, waitFor } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
-import {
-  commonAppUrlGetterMocks,
-  fakeEvent,
-  fakeImage,
-} from '@/test-utils/mockDataUtils';
+import { fakeEvent, fakeImage } from '@/test-utils/mockDataUtils';
 import type { EventFieldsFragment } from 'types/generated/graphql';
 import EventContent from '../EventContent';
 
@@ -40,7 +36,7 @@ const event = fakeEvent({
 }) as EventFieldsFragment;
 
 it('should render event content fields', async () => {
-  render(<EventContent event={event} {...commonAppUrlGetterMocks} />);
+  render(<EventContent event={event} />);
 
   await waitFor(() => {
     expect(
@@ -111,7 +107,6 @@ it('should hide map if internet event', () => {
           location: { ...event.location, id: 'helsinki:internet' },
         } as EventFieldsFragment
       }
-      {...commonAppUrlGetterMocks}
     />
   );
   expect(screen.queryByText(/sijainti/i)).not.toBeInTheDocument();
@@ -126,7 +121,6 @@ it('should show location extra info when available', () => {
           locationExtraInfo: { fi: 'Sisään takaovesta' },
         } as EventFieldsFragment
       }
-      {...commonAppUrlGetterMocks}
     />
   );
   expect(screen.getByText(/Paikan lisätiedot/i)).toBeInTheDocument();
@@ -134,6 +128,6 @@ it('should show location extra info when available', () => {
 });
 
 it('should not show location extra info title when location extra info not available', () => {
-  render(<EventContent event={event} {...commonAppUrlGetterMocks} />);
+  render(<EventContent event={event} />);
   expect(screen.queryByText(/Paikan lisätiedot/i)).not.toBeInTheDocument();
 });

--- a/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/browser';
 import { saveAs } from 'file-saver';
-import type { CommonButtonProps } from 'hds-react';
 import {
   Button,
   IconAngleRight,
@@ -22,11 +21,8 @@ import InfoWithIcon from '../../../../components/infoWithIcon/InfoWithIcon';
 import Visible from '../../../../components/visible/Visible';
 import useLocale from '../../../../hooks/useLocale';
 import useTabFocusStyle from '../../../../hooks/useTabFocusStyle';
-import type {
-  GetEventListLinkUrlType,
-  GetOrganizationSearchUrlType,
-  GetPlainEventUrlType,
-} from '../../../../types';
+import { useAppRoutingContext } from '../../../../routingUrlProvider';
+import { useAppThemeContext } from '../../../../themeProvider';
 import type {
   EventFields,
   KeywordOption,
@@ -50,18 +46,9 @@ import OtherEventTimes from './OtherEventTimes';
 export type EventInfoProps = {
   event: EventFields;
   superEvent?: SuperEventResponse;
-  getEventListLinkUrl: GetEventListLinkUrlType;
-  getOrganizationSearchUrl: GetOrganizationSearchUrlType;
-  getPlainEventUrl: GetPlainEventUrlType;
 };
 
-const EventInfo: React.FC<EventInfoProps> = ({
-  event,
-  superEvent,
-  getEventListLinkUrl,
-  getOrganizationSearchUrl,
-  getPlainEventUrl,
-}) => {
+const EventInfo: React.FC<EventInfoProps> = ({ event, superEvent }) => {
   const locale = useLocale();
   const eventInfoContainer = React.useRef<HTMLDivElement | null>(null);
   useTabFocusStyle({
@@ -91,18 +78,10 @@ const EventInfo: React.FC<EventInfoProps> = ({
   return (
     <div className={styles.eventInfo} ref={eventInfoContainer}>
       <div className={styles.contentWrapper}>
-        <DateInfo event={event} getPlainEventUrl={getPlainEventUrl} />
-        <SuperEvent
-          superEvent={superEvent}
-          getEventListLinkUrl={getEventListLinkUrl}
-        />
-        <SubEvents event={event} getEventListLinkUrl={getEventListLinkUrl} />
-        {!isMiddleLevelEvent && (
-          <OtherEventTimes
-            event={event}
-            getEventListLinkUrl={getEventListLinkUrl}
-          />
-        )}
+        <DateInfo event={event} />
+        <SuperEvent superEvent={superEvent} />
+        <SubEvents event={event} />
+        {!isMiddleLevelEvent && <OtherEventTimes event={event} />}
         <LocationInfo event={event} />
         {(!!audience.length || !!audienceMinAge || !!audienceMaxAge) && (
           <Audience
@@ -114,10 +93,7 @@ const EventInfo: React.FC<EventInfoProps> = ({
         {!!languages.length && <Languages languages={languages} />}
         {showOtherInfo && <OtherInfo event={event} />}
         <Directions event={event} />
-        <OrganizationInfo
-          event={event}
-          getOrganizationSearchUrl={getOrganizationSearchUrl}
-        />
+        <OrganizationInfo event={event} />
         <PriceInfo event={event} />
       </div>
     </div>
@@ -126,12 +102,11 @@ const EventInfo: React.FC<EventInfoProps> = ({
 
 const DateInfo: React.FC<{
   event: EventFields;
-  getPlainEventUrl: GetPlainEventUrlType;
-}> = ({ event, getPlainEventUrl }) => {
+}> = ({ event }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
   const locale = useLocale();
-
+  const { getPlainEventUrl } = useAppRoutingContext();
   const {
     addressLocality,
     district,
@@ -349,10 +324,10 @@ const Directions: React.FC<{
 
 const PriceInfo: React.FC<{
   event: EventFields;
-  theme?: CommonButtonProps['theme'];
-  variant?: CommonButtonProps['variant'];
-}> = ({ event, theme, variant }) => {
+}> = ({ event }) => {
   const { t } = useTranslation('event');
+  const { defaultButtonTheme: theme, defaultButtonVariant: variant } =
+    useAppThemeContext();
   const locale = useLocale();
   const eventPriceText = getEventPrice(event, locale, t('info.offers.isFree'));
   const { offerInfoUrl } = getEventFields(event, locale);

--- a/packages/components/src/components/domain/event/eventInfo/EventsHierarchy.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/EventsHierarchy.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import InfoWithIcon from '../../../../components/infoWithIcon/InfoWithIcon';
 import SkeletonLoader from '../../../../components/skeletonLoader/SkeletonLoader';
 import LoadingSpinner from '../../../../components/spinner/LoadingSpinner';
-import type { GetEventListLinkUrlType } from '../../../../types';
 import type {
   EventFields,
   SuperEventResponse,
@@ -25,8 +24,7 @@ export const superEventTestId = 'super-event';
 
 const SubEvents: React.FC<{
   event: EventFields;
-  getEventListLinkUrl: GetEventListLinkUrlType;
-}> = ({ event, getEventListLinkUrl }) => {
+}> = ({ event }) => {
   const { t } = useTranslation('event');
   const [isListOpen, setIsListOpen] = React.useState(false);
 
@@ -95,19 +93,13 @@ const SubEvents: React.FC<{
     <div className={styles.eventList}>
       <InfoWithIcon icon={titleIcon} title={title}>
         {isLowestLevelEvent || isMiddleLevelEvent ? (
-          <EventList
-            id={subEventsListTestId}
-            events={shownEvents}
-            showDate
-            getEventListLinkUrl={getEventListLinkUrl}
-          />
+          <EventList id={subEventsListTestId} events={shownEvents} showDate />
         ) : (
           <EventList
             id={subEventsListTestId}
             events={shownEvents}
             showName
             showDate
-            getEventListLinkUrl={getEventListLinkUrl}
           />
         )}
         {events.length > EVENTS_LIST_LIMIT && (
@@ -133,8 +125,7 @@ const SubEvents: React.FC<{
 
 const SuperEvent: React.FC<{
   superEvent: SuperEventResponse | undefined;
-  getEventListLinkUrl: GetEventListLinkUrlType;
-}> = ({ superEvent, getEventListLinkUrl }) => {
+}> = ({ superEvent }) => {
   const { t } = useTranslation('event');
 
   if (!superEvent?.data) return null;
@@ -147,12 +138,7 @@ const SuperEvent: React.FC<{
         icon={<IconLayers aria-hidden />}
         title={t('superEvent.title')}
       >
-        <EventList
-          id={superEventTestId}
-          showName
-          events={[superEvent.data]}
-          getEventListLinkUrl={getEventListLinkUrl}
-        />
+        <EventList id={superEventTestId} showName events={[superEvent.data]} />
       </InfoWithIcon>
     </div>
   );

--- a/packages/components/src/components/domain/event/eventInfo/OrganizationInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/OrganizationInfo.tsx
@@ -6,23 +6,20 @@ import { SecondaryLink } from 'react-helsinki-headless-cms';
 import InfoWithIcon from '../../../../components/infoWithIcon/InfoWithIcon';
 import LoadingSpinner from '../../../../components/spinner/LoadingSpinner';
 import useLocale from '../../../../hooks/useLocale';
+import { useAppRoutingContext } from '../../../../routingUrlProvider';
 import type { EventFields } from '../../../../types/event-types';
 import { useOrganizationDetailsQuery } from '../../../../types/generated/graphql';
-import type { GetOrganizationSearchUrlType } from '../../../../types/types';
 import { getEventFields } from '../../../../utils/eventUtils';
 import { translateValue } from '../../../../utils/translateUtils';
 import styles from './eventInfo.module.scss';
 
 interface Props {
   event: EventFields;
-  getOrganizationSearchUrl: GetOrganizationSearchUrlType;
 }
 
-const OrganizationInfo: React.FC<Props> = ({
-  event,
-  getOrganizationSearchUrl,
-}) => {
+const OrganizationInfo: React.FC<Props> = ({ event }) => {
   const { t } = useTranslation('event');
+  const { getOrganizationSearchUrl } = useAppRoutingContext();
   const locale = useLocale();
   const router = useRouter();
   const { provider, publisher } = getEventFields(event, locale);

--- a/packages/components/src/components/domain/event/eventInfo/OtherEventTimes.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/OtherEventTimes.tsx
@@ -6,7 +6,6 @@ import SkeletonLoader from '../../../../components/skeletonLoader/SkeletonLoader
 import LoadingSpinner from '../../../../components/spinner/LoadingSpinner';
 import useEventTranslation from '../../../../hooks/useEventTranslation';
 import type { EventFields } from '../../../../types/event-types';
-import type { GetEventListLinkUrlType } from '../../../../types/types';
 import { useOtherEventTimes } from '../queryUtils';
 import EventList from './eventList/EventList';
 import styles from './eventList/eventList.module.scss';
@@ -17,8 +16,7 @@ export const otherEventTimesListTestId = 'other-event-times-list';
 
 const OtherEventTimes: React.FC<{
   event: EventFields;
-  getEventListLinkUrl: GetEventListLinkUrlType;
-}> = ({ event, getEventListLinkUrl }) => {
+}> = ({ event }) => {
   const { t } = useEventTranslation();
   const [isListOpen, setIsListOpen] = React.useState(false);
 
@@ -54,7 +52,6 @@ const OtherEventTimes: React.FC<{
           id={otherEventTimesListTestId}
           events={shownEvents}
           showDate
-          getEventListLinkUrl={getEventListLinkUrl}
         />
         {events.length > EVENTS_LIST_LIMIT && (
           <button

--- a/packages/components/src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx
@@ -12,7 +12,7 @@ import {
   within,
 } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
-import { commonAppUrlGetterMocks, fakeEvent } from '@/test-utils/mockDataUtils';
+import { fakeEvent } from '@/test-utils/mockDataUtils';
 import type {
   EventFields,
   SuperEventResponse,
@@ -54,7 +54,7 @@ const getDateRangeStrProps = (event: EventDetails) => ({
 });
 
 it('should render event info fields', async () => {
-  render(<EventInfo event={event} {...commonAppUrlGetterMocks} />, { mocks });
+  render(<EventInfo event={event} />, { mocks });
   await actWait();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -108,7 +108,7 @@ it('should hide the organizer section when the organizer name is not given', asy
     ...event,
     provider: null,
   };
-  render(<EventInfo event={mockEvent} {...commonAppUrlGetterMocks} />, {
+  render(<EventInfo event={mockEvent} />, {
     mocks,
   });
   await actWait();
@@ -136,7 +136,7 @@ it('should hide other info section', () => {
       telephone: null,
     },
   } as EventFields;
-  render(<EventInfo event={mockEvent} {...commonAppUrlGetterMocks} />, {
+  render(<EventInfo event={mockEvent} />, {
     mocks,
   });
 
@@ -167,7 +167,7 @@ it('should hide other info section registration url from external links', () => 
       telephone: null,
     },
   } as EventFields;
-  render(<EventInfo event={mockEvent} {...commonAppUrlGetterMocks} />, {
+  render(<EventInfo event={mockEvent} />, {
     mocks,
   });
 
@@ -191,7 +191,7 @@ it('should hide the map link from location info if location is internet', () => 
       telephone: null,
     },
   } as EventFields;
-  render(<EventInfo event={mockEvent} {...commonAppUrlGetterMocks} />, {
+  render(<EventInfo event={mockEvent} />, {
     mocks,
   });
 
@@ -204,7 +204,7 @@ it('should hide the map link from location info if location is internet', () => 
 
 it('should open ticket buy page', async () => {
   global.open = jest.fn();
-  render(<EventInfo event={event} {...commonAppUrlGetterMocks} />, { mocks });
+  render(<EventInfo event={event} />, { mocks });
 
   // Event info fields
   await userEvent.click(
@@ -221,7 +221,7 @@ it('should open ticket buy page', async () => {
 // eslint-disable-next-line jest/no-disabled-tests
 it.skip('should create ics file succesfully', async () => {
   const saveAsSpy = jest.spyOn(FileSaver, 'saveAs');
-  render(<EventInfo event={event} {...commonAppUrlGetterMocks} />, { mocks });
+  render(<EventInfo event={event} />, { mocks });
 
   // Event info fields
   await userEvent.click(
@@ -238,15 +238,9 @@ it.skip('should create ics file succesfully', async () => {
 // eslint-disable-next-line jest/no-disabled-tests
 it.skip('should create ics file succesfully when end time is not defined', async () => {
   const saveAsSpy = jest.spyOn(FileSaver, 'saveAs');
-  render(
-    <EventInfo
-      event={{ ...event, endTime: null }}
-      {...commonAppUrlGetterMocks}
-    />,
-    {
-      mocks,
-    }
-  );
+  render(<EventInfo event={{ ...event, endTime: null }} />, {
+    mocks,
+  });
 
   // Event info fields
   await userEvent.click(
@@ -261,7 +255,7 @@ it.skip('should create ics file succesfully when end time is not defined', async
 });
 
 it('should hide audience age info on single event page', async () => {
-  render(<EventInfo event={event} {...commonAppUrlGetterMocks} />, {
+  render(<EventInfo event={event} />, {
     routes: [`/kurssit`],
   });
 
@@ -271,15 +265,9 @@ it('should hide audience age info on single event page', async () => {
 });
 
 it('should show formatted audience age info on single event page if max age is not specified', async () => {
-  render(
-    <EventInfo
-      event={{ ...event, audienceMaxAge: null }}
-      {...commonAppUrlGetterMocks}
-    />,
-    {
-      routes: [`/kurssit`],
-    }
-  );
+  render(<EventInfo event={{ ...event, audienceMaxAge: null }} />, {
+    routes: [`/kurssit`],
+  });
 
   await waitFor(() => {
     expect(screen.getByText(/5\+ -vuotiaat/i)).toBeInTheDocument();
@@ -290,7 +278,6 @@ it('should hide audience age info on single event page if min and max ages are n
   render(
     <EventInfo
       event={{ ...event, audienceMinAge: null, audienceMaxAge: null }}
-      {...commonAppUrlGetterMocks}
     />,
     {
       routes: [`/kurssit`],
@@ -316,10 +303,7 @@ describe('OrganizationInfo', () => {
     'should show correct provider link text on event/hobby detail page',
     async ({ eventTypeId, expectedLinkText }) => {
       render(
-        <EventInfo
-          event={{ ...event, typeId: eventTypeId } as EventFields}
-          {...commonAppUrlGetterMocks}
-        />,
+        <EventInfo event={{ ...event, typeId: eventTypeId } as EventFields} />,
         {
           mocks: mocksWithSubEvents,
           routes: ['/fi/kurssit/test'],
@@ -335,10 +319,7 @@ describe('OrganizationInfo', () => {
     'should show correct provider link on event/hobby detail page',
     async (eventTypeId) => {
       render(
-        <EventInfo
-          event={{ ...event, typeId: eventTypeId } as EventFields}
-          {...commonAppUrlGetterMocks}
-        />,
+        <EventInfo event={{ ...event, typeId: eventTypeId } as EventFields} />,
         {
           mocks,
           routes: ['/fi/kurssit/test'],
@@ -397,11 +378,7 @@ describe('superEvent', () => {
       status: 'resolved',
     } as SuperEventResponse;
     const { router } = render(
-      <EventInfo
-        event={event}
-        superEvent={superEventResponse}
-        {...commonAppUrlGetterMocks}
-      />,
+      <EventInfo event={event} superEvent={superEventResponse} />,
       {
         mocks: mocksWithSubEvents,
       }
@@ -423,7 +400,7 @@ describe('superEvent', () => {
   });
 
   it('should should not render super event title when super event is not given', async () => {
-    render(<EventInfo event={event} {...commonAppUrlGetterMocks} />, {
+    render(<EventInfo event={event} />, {
       mocks,
     });
     await actWait();
@@ -438,7 +415,7 @@ describe('superEvent', () => {
 
 describe('subEvents', () => {
   it('should render sub events title and content when sub events are given', async () => {
-    render(<EventInfo event={event} {...commonAppUrlGetterMocks} />, {
+    render(<EventInfo event={event} />, {
       mocks: mocksWithSubEvents,
     });
     await waitFor(() => {
@@ -452,12 +429,9 @@ describe('subEvents', () => {
   });
 
   it('should navigate to sub events page when it is clicked', async () => {
-    const { router } = render(
-      <EventInfo event={event} {...commonAppUrlGetterMocks} />,
-      {
-        mocks: mocksWithSubEvents,
-      }
-    );
+    const { router } = render(<EventInfo event={event} />, {
+      mocks: mocksWithSubEvents,
+    });
     const eventsList = await screen.findByTestId(subEventsListTestId);
     const subEvent = subEventsResponse.data[0];
     const dateStr = getDateRangeStr(getDateRangeStrProps(subEvent));
@@ -513,7 +487,6 @@ describe('subEvents', () => {
           ],
         })}
         superEvent={superEventResponseMock}
-        {...commonAppUrlGetterMocks}
       />,
       {
         mocks: [...mocks, middleAsSuperEventMock, superEventMock],

--- a/packages/components/src/components/domain/event/eventInfo/eventList/EventList.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/eventList/EventList.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import { Link } from 'react-helsinki-headless-cms';
 
 import useLocale from '../../../../../hooks/useLocale';
+import { useAppRoutingContext } from '../../../../../routingUrlProvider';
 import type { EventFields } from '../../../../../types/event-types';
-import type { GetEventListLinkUrlType } from '../../../../../types/types';
 import { getEventFields } from '../../../../../utils/eventUtils';
 import getDateRangeStr from '../../../../../utils/getDateRangeStr';
 import styles from './eventList.module.scss';
@@ -16,19 +16,12 @@ const EventList: React.FC<{
   showDate?: boolean;
   showName?: boolean;
   id: string;
-  getEventListLinkUrl: GetEventListLinkUrlType;
-}> = ({
-  events,
-  showDate = false,
-  showName = false,
-  id,
-  getEventListLinkUrl,
-}) => {
+}> = ({ events, showDate = false, showName = false, id }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
   const locale = useLocale();
   const router = useRouter();
-
+  const { getEventListLinkUrl } = useAppRoutingContext();
   return (
     <ul className={styles.timeList} data-testid={id}>
       {events.map((event) => {

--- a/packages/components/src/components/domain/event/similarEvents/SimilarEvents.tsx
+++ b/packages/components/src/components/domain/event/similarEvents/SimilarEvents.tsx
@@ -6,9 +6,9 @@ import {
   ContentContainer,
 } from 'react-helsinki-headless-cms';
 import useEventTranslation from '../../../../hooks/useEventTranslation';
+import { useAppRoutingContext } from '../../../../routingUrlProvider';
 import type { EventFields } from '../../../../types/event-types';
 import type { QueryEventListArgs } from '../../../../types/generated/graphql';
-import type { GetCardUrlType } from '../../../../types/types';
 import LoadingSpinner from '../../../spinner/LoadingSpinner';
 import { useSimilarEventsQuery } from '../queryUtils';
 import useEventCards from '../useEventCards';
@@ -18,7 +18,6 @@ export type SimilarEventsProps = {
   event: EventFields;
   type?: CollectionProps['type'];
   onEventsLoaded?: (eventsCount: number) => void;
-  getCardUrl: GetCardUrlType;
   eventFilters: QueryEventListArgs;
 };
 
@@ -30,10 +29,10 @@ const SimilarEvents: React.FC<SimilarEventsProps> = ({
   event,
   type = 'carousel',
   onEventsLoaded,
-  getCardUrl,
   eventFilters,
 }) => {
   const { t } = useEventTranslation();
+  const { getCardUrl } = useAppRoutingContext();
   const { data: events, loading } = useSimilarEventsQuery(event, eventFilters);
   const cards = useEventCards({
     events,

--- a/packages/components/src/components/eventCard/EventCard.tsx
+++ b/packages/components/src/components/eventCard/EventCard.tsx
@@ -22,11 +22,7 @@ import EventName from '../eventName/EventName';
 import styles from './eventCard.module.scss';
 import type { EventCardProps } from './types';
 
-const EventCard: React.FC<EventCardProps> = ({
-  event,
-  eventUrl,
-  getKeywordOnClickHandler,
-}) => {
+const EventCard: React.FC<EventCardProps> = ({ event, eventUrl }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useCommonTranslation();
   const router = useRouter();
@@ -93,7 +89,6 @@ const EventCard: React.FC<EventCardProps> = ({
                   event={event}
                   showIsFree={true}
                   showKeywords={false}
-                  getKeywordOnClickHandler={getKeywordOnClickHandler}
                 />
               </div>
             </div>
@@ -125,7 +120,6 @@ const EventCard: React.FC<EventCardProps> = ({
                 event={event}
                 showIsFree={true}
                 showKeywords={false}
-                getKeywordOnClickHandler={getKeywordOnClickHandler}
               />
             </div>
           </BackgroundImage>

--- a/packages/components/src/components/eventCard/LargeEventCard.tsx
+++ b/packages/components/src/components/eventCard/LargeEventCard.tsx
@@ -33,7 +33,6 @@ const LargeEventCard: React.FC<LargeEventCardProps> = ({
   event,
   eventUrl,
   showEnrolmentStatusInCardDetails = false,
-  getKeywordOnClickHandler,
 }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
@@ -120,7 +119,6 @@ const LargeEventCard: React.FC<LargeEventCardProps> = ({
                 event={event}
                 hideKeywordsOnMobile={true}
                 showIsFree={true}
-                getKeywordOnClickHandler={getKeywordOnClickHandler}
               />
             </div>
             <div className={styles.buttonWrapper}>
@@ -153,7 +151,6 @@ const LargeEventCard: React.FC<LargeEventCardProps> = ({
                 event={event}
                 hideKeywordsOnMobile={true}
                 showIsFree={true}
-                getKeywordOnClickHandler={getKeywordOnClickHandler}
               />
             </div>
           </BackgroundImage>

--- a/packages/components/src/components/eventCard/__tests__/EventCard.test.tsx
+++ b/packages/components/src/components/eventCard/__tests__/EventCard.test.tsx
@@ -44,13 +44,7 @@ afterAll(() => {
 });
 
 const renderComponent = () =>
-  render(
-    <EventCard
-      event={event}
-      eventUrl={`/tapahtumat/${event.id}`}
-      getKeywordOnClickHandler={jest.fn()}
-    />
-  );
+  render(<EventCard event={event} eventUrl={`/tapahtumat/${event.id}`} />);
 describe('event card', () => {
   // TODO: when HDS fixes the tag id -> uncomment
   // eslint-disable-next-line jest/no-commented-out-tests

--- a/packages/components/src/components/eventCard/__tests__/LargeEventCard.test.tsx
+++ b/packages/components/src/components/eventCard/__tests__/LargeEventCard.test.tsx
@@ -9,13 +9,7 @@ import type { EventFieldsFragment } from '../../../types';
 import LargeEventCard from '../LargeEventCard';
 
 const renderComponent = (event: EventFieldsFragment) =>
-  render(
-    <LargeEventCard
-      event={event}
-      eventUrl={`/tapahtumat/${event.id}`}
-      getKeywordOnClickHandler={jest.fn()}
-    />
-  );
+  render(<LargeEventCard event={event} eventUrl={`/tapahtumat/${event.id}`} />);
 
 beforeEach(() => {
   mockRouter.setCurrentUrl('/');

--- a/packages/components/src/components/eventCard/types.ts
+++ b/packages/components/src/components/eventCard/types.ts
@@ -1,9 +1,8 @@
-import type { EventFields, KeywordOnClickHandlerType } from '../../types';
+import type { EventFields } from '../../types';
 
 export type EventCardProps = {
   event: EventFields;
   eventUrl: string;
-  getKeywordOnClickHandler: KeywordOnClickHandlerType;
 };
 
 export type LargeEventCardProps = EventCardProps & {

--- a/packages/components/src/components/eventClosedHero/EventClosedHero.tsx
+++ b/packages/components/src/components/eventClosedHero/EventClosedHero.tsx
@@ -1,23 +1,18 @@
-import type { CommonButtonProps } from 'hds-react';
 import { Button } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
+import { useAppThemeContext } from '../../themeProvider';
 import styles from './eventClosedHero.module.scss';
 
 export type EventClosedHeroProps = {
   onClick: () => void;
-  theme?: CommonButtonProps['theme'];
-  variant?: CommonButtonProps['variant'];
 };
 
-const EventClosedHero: React.FC<EventClosedHeroProps> = ({
-  onClick,
-  theme,
-  variant,
-}) => {
+const EventClosedHero: React.FC<EventClosedHeroProps> = ({ onClick }) => {
   const { t } = useTranslation('event');
-
+  const { defaultButtonTheme: theme, defaultButtonVariant: variant } =
+    useAppThemeContext();
   return (
     <div className={styles.eventClosedHero}>
       <h1>{t('hero.titleEventClosed')}</h1>

--- a/packages/components/src/components/eventHero/EventHero.tsx
+++ b/packages/components/src/components/eventHero/EventHero.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import type { CommonButtonProps } from 'hds-react';
 import {
   Button,
   IconArrowLeft,
@@ -25,8 +24,8 @@ import IconButton from '../../components/iconButton/IconButton';
 import InfoWithIcon from '../../components/infoWithIcon/InfoWithIcon';
 import SkeletonLoader from '../../components/skeletonLoader/SkeletonLoader';
 import useLocale from '../../hooks/useLocale';
+import { useAppThemeContext } from '../../themeProvider';
 import type { EventFields, SuperEventResponse } from '../../types/event-types';
-import type { KeywordOnClickHandlerType } from '../../types/types';
 import { extractLatestReturnPath } from '../../utils/eventQueryString.util';
 import type { ReturnParams } from '../../utils/eventQueryString.util';
 import {
@@ -41,25 +40,18 @@ import styles from './eventHero.module.scss';
 export type EventHeroProps = {
   event: EventFields;
   superEvent?: SuperEventResponse;
-  getKeywordOnClickHandler: KeywordOnClickHandlerType;
-  theme?: CommonButtonProps['theme'];
-  variant?: CommonButtonProps['variant'];
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-const EventHero: React.FC<EventHeroProps> = ({
-  event,
-  superEvent,
-  getKeywordOnClickHandler,
-  theme,
-  variant,
-}) => {
+const EventHero: React.FC<EventHeroProps> = ({ event, superEvent }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
   const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
   const router = useRouter();
   const search = router.asPath.split('?')[1];
+  const { defaultButtonTheme: theme, defaultButtonVariant: variant } =
+    useAppThemeContext();
 
   const {
     endTime: eventEndTime,
@@ -187,12 +179,7 @@ const EventHero: React.FC<EventHeroProps> = ({
                 </div>
                 {showKeywords && (
                   <div className={styles.categoryWrapper}>
-                    <EventKeywords
-                      whiteOnly
-                      event={event}
-                      showIsFree={true}
-                      getKeywordOnClickHandler={getKeywordOnClickHandler}
-                    />
+                    <EventKeywords whiteOnly event={event} showIsFree={true} />
                   </div>
                 )}
               </div>

--- a/packages/components/src/components/eventHero/__tests__/EventHero.test.tsx
+++ b/packages/components/src/components/eventHero/__tests__/EventHero.test.tsx
@@ -20,7 +20,6 @@ import getDateRangeStr from '../../../utils/getDateRangeStr';
 import type { EventHeroProps } from '../EventHero';
 import EventHero from '../EventHero';
 
-const getKeywordOnClickHandlerMock = jest.fn();
 const name = 'Event name';
 const startTime = '2020-06-22T07:00:00.000000Z';
 const endTime = '2020-06-22T10:00:00.000000Z';
@@ -60,14 +59,9 @@ afterAll(() => {
 
 const renderComponent = (props?: Partial<EventHeroProps>) => {
   const event = getFakeEvent();
-  return render(
-    <EventHero
-      event={event}
-      getKeywordOnClickHandler={getKeywordOnClickHandlerMock}
-      {...props}
-    />,
-    { routes: [`/tapahtuma/${event.id}?returnPath=/haku`] }
-  );
+  return render(<EventHero event={event} {...props} />, {
+    routes: [`/tapahtuma/${event.id}?returnPath=/haku`],
+  });
 };
 
 it('should render event name, description and location', () => {
@@ -137,12 +131,7 @@ it('should hide buy/enrol button for free events', () => {
   const mockEvent = getFakeEvent({
     offers: [fakeOffer({ isFree: true }) as OfferFieldsFragment],
   });
-  render(
-    <EventHero
-      event={mockEvent}
-      getKeywordOnClickHandler={getKeywordOnClickHandlerMock}
-    />
-  );
+  render(<EventHero event={mockEvent} />);
 
   expect(
     screen.queryByRole('button', {
@@ -168,12 +157,7 @@ it.each([
     externalLinks: [],
   });
 
-  render(
-    <EventHero
-      event={mockEvent}
-      getKeywordOnClickHandler={getKeywordOnClickHandlerMock}
-    />
-  );
+  render(<EventHero event={mockEvent} />);
 
   await userEvent.click(
     screen.getByRole('button', {
@@ -209,12 +193,7 @@ it.each([
       ],
     });
 
-    render(
-      <EventHero
-        event={mockEvent}
-        getKeywordOnClickHandler={getKeywordOnClickHandlerMock}
-      />
-    );
+    render(<EventHero event={mockEvent} />);
 
     expect(screen.getByText(buttonLabel)).toBeInTheDocument();
 
@@ -238,7 +217,6 @@ it('should show event dates if super event is defined', () => {
     <EventHero
       event={mockEvent}
       superEvent={{ data: mockSuperEvent, status: 'resolved' }}
-      getKeywordOnClickHandler={getKeywordOnClickHandlerMock}
     />
   );
 

--- a/packages/components/src/components/eventKeywords/EventKeywords.tsx
+++ b/packages/components/src/components/eventKeywords/EventKeywords.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import KeywordTag from '../../components/keyword/KeywordTag';
 import { DATE_TYPES } from '../../constants';
 import { useLocale } from '../../hooks';
+import { useAppRoutingContext } from '../../routingUrlProvider';
 import type {
   EventFieldsFragment,
   KeywordOnClickHandlerType,
@@ -19,7 +20,6 @@ type EventKeywordsProps = {
   showKeywords?: boolean;
   showKeywordsCount?: boolean;
   withActions?: boolean;
-  getKeywordOnClickHandler: KeywordOnClickHandlerType;
 };
 const EventKeywords: React.FC<EventKeywordsProps> = ({
   blackOnMobile = false,
@@ -30,7 +30,6 @@ const EventKeywords: React.FC<EventKeywordsProps> = ({
   showKeywords = true,
   showKeywordsCount,
   withActions = true,
-  getKeywordOnClickHandler,
 }) => {
   const { t } = useTranslation('event');
   const locale = useLocale();
@@ -39,7 +38,7 @@ const EventKeywords: React.FC<EventKeywordsProps> = ({
     event,
     locale
   );
-
+  const { getKeywordOnClickHandler } = useAppRoutingContext();
   const handleClick = (
     type: Parameters<KeywordOnClickHandlerType>[2],
     value = ''

--- a/packages/components/src/components/eventKeywords/__tests__/EventKeywords.test.tsx
+++ b/packages/components/src/components/eventKeywords/__tests__/EventKeywords.test.tsx
@@ -5,7 +5,13 @@ import * as React from 'react';
 
 import { render, screen, userEvent } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
-import { fakeEvent, fakeKeyword, fakeOffer } from '@/test-utils/mockDataUtils';
+import {
+  appRoutingUrlMocks,
+  fakeEvent,
+  fakeKeyword,
+  fakeOffer,
+} from '@/test-utils/mockDataUtils';
+import { AppRoutingProvider } from '../../../routingUrlProvider';
 import type {
   AppLanguage,
   EventFieldsFragment,
@@ -45,12 +51,12 @@ afterAll(() => {
 
 it('should render keywords and handle click', async () => {
   const { router } = render(
-    <EventKeywords
-      event={event}
-      showIsFree={true}
-      showKeywords={true}
+    <AppRoutingProvider
+      {...appRoutingUrlMocks}
       getKeywordOnClickHandler={getKeywordOnClickHandler}
-    />
+    >
+      <EventKeywords event={event} showIsFree={true} showKeywords={true} />
+    </AppRoutingProvider>
   );
 
   keywordNames.forEach((keyword) => {
@@ -71,12 +77,12 @@ it('should render keywords and handle click', async () => {
 
 it('should not show keywords', () => {
   render(
-    <EventKeywords
-      event={event}
-      showIsFree={true}
-      showKeywords={false}
+    <AppRoutingProvider
+      {...appRoutingUrlMocks}
       getKeywordOnClickHandler={getKeywordOnClickHandler}
-    />
+    >
+      <EventKeywords event={event} showIsFree={true} showKeywords={false} />
+    </AppRoutingProvider>
   );
 
   keywordNames.forEach((keyword) => {
@@ -89,12 +95,12 @@ it('should not show keywords', () => {
 it('should render today tag and handle click', async () => {
   advanceTo('2020-06-22');
   const { router } = render(
-    <EventKeywords
-      event={event}
-      showIsFree={true}
-      showKeywords={false}
+    <AppRoutingProvider
+      {...appRoutingUrlMocks}
       getKeywordOnClickHandler={getKeywordOnClickHandler}
-    />
+    >
+      <EventKeywords event={event} showIsFree={true} showKeywords={false} />
+    </AppRoutingProvider>
   );
   await userEvent.click(
     screen.getByRole('link', {
@@ -111,12 +117,12 @@ it('should render today tag and handle click', async () => {
 it('should render this week tag and handle click', async () => {
   advanceTo('2020-06-23');
   const { router } = render(
-    <EventKeywords
-      event={event}
-      showIsFree={true}
-      showKeywords={false}
+    <AppRoutingProvider
+      {...appRoutingUrlMocks}
       getKeywordOnClickHandler={getKeywordOnClickHandler}
-    />
+    >
+      <EventKeywords event={event} showIsFree={true} showKeywords={false} />
+    </AppRoutingProvider>
   );
   await userEvent.click(
     screen.getByRole('link', {
@@ -136,12 +142,12 @@ it('should hide buy button for free events', () => {
     offers: [fakeOffer({ isFree: true }) as OfferFieldsFragment],
   };
   render(
-    <EventKeywords
-      event={mockEvent}
-      showIsFree={true}
-      showKeywords={false}
+    <AppRoutingProvider
+      {...appRoutingUrlMocks}
       getKeywordOnClickHandler={getKeywordOnClickHandler}
-    />
+    >
+      <EventKeywords event={mockEvent} showIsFree={true} showKeywords={false} />
+    </AppRoutingProvider>
   );
 
   expect(

--- a/packages/components/src/components/eventList/EventList.tsx
+++ b/packages/components/src/components/eventList/EventList.tsx
@@ -9,11 +9,7 @@ import LargeEventCard from '../../components/eventCard/LargeEventCard';
 
 import LoadingSpinner from '../../components/spinner/LoadingSpinner';
 import { useLocale } from '../../hooks';
-import type {
-  EventFields,
-  GetEventUrlType,
-  KeywordOnClickHandlerType,
-} from '../../types';
+import type { EventFields, GetEventUrlType } from '../../types';
 import styles from './eventList.module.scss';
 
 const eventCardsMap = {
@@ -31,7 +27,6 @@ type EventListProps = {
   showEnrolmentStatusInCardDetails: boolean;
   onLoadMore: () => void;
   getEventUrl: GetEventUrlType;
-  getKeywordOnClickHandler: KeywordOnClickHandlerType;
 };
 
 const EventList: React.FC<EventListProps> = ({
@@ -44,7 +39,6 @@ const EventList: React.FC<EventListProps> = ({
   onLoadMore,
   getEventUrl,
   showEnrolmentStatusInCardDetails = false,
-  getKeywordOnClickHandler,
 }) => {
   const { t } = useTranslation('search');
   const router = useRouter();
@@ -60,7 +54,6 @@ const EventList: React.FC<EventListProps> = ({
         event={event}
         eventUrl={eventUrl}
         showEnrolmentStatusInCardDetails={showEnrolmentStatusInCardDetails}
-        getKeywordOnClickHandler={getKeywordOnClickHandler}
       />
     );
   });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -13,4 +13,6 @@ export * from './types';
 export * from './utils';
 export * from './navigationProvider';
 export * from './cmsHelperProvider';
+export * from './routingUrlProvider';
+export * from './themeProvider';
 export * from './assets';

--- a/packages/components/src/routingUrlProvider/AppRoutingContext.tsx
+++ b/packages/components/src/routingUrlProvider/AppRoutingContext.tsx
@@ -1,0 +1,71 @@
+import type { NextRouter } from 'next/router';
+import React from 'react';
+import type { EventFieldsFragment } from '../types/generated/graphql';
+import type {
+  GetCardUrlType,
+  GetEventUrlType,
+  GetEventListLinkUrlType,
+  GetOrganizationSearchUrlType,
+  GetPlainEventUrlType,
+  KeywordOnClickHandlerType,
+  AppLanguage,
+} from '../types/types';
+
+export type AppRoutingContextProps = {
+  getCardUrl: GetCardUrlType;
+  getEventUrl: GetEventUrlType;
+  getEventListLinkUrl: GetEventListLinkUrlType;
+  getOrganizationSearchUrl: GetOrganizationSearchUrlType;
+  getPlainEventUrl: GetPlainEventUrlType;
+  getKeywordOnClickHandler: KeywordOnClickHandlerType;
+};
+
+const defaultRoutingContext: AppRoutingContextProps = {
+  getCardUrl: function (
+    _event: EventFieldsFragment,
+    _locale: AppLanguage
+  ): string {
+    throw new Error('Function not implemented.');
+  },
+  getEventUrl: function (
+    _event: EventFieldsFragment,
+    _router: NextRouter,
+    _locale: AppLanguage
+  ): string {
+    throw new Error('Function not implemented.');
+  },
+  getEventListLinkUrl: function (
+    _event: EventFieldsFragment,
+    _router: NextRouter,
+    _locale: AppLanguage
+  ): string {
+    throw new Error('Function not implemented.');
+  },
+  getOrganizationSearchUrl: function (
+    _event: EventFieldsFragment,
+    _router: NextRouter,
+    _locale: AppLanguage
+  ): string {
+    throw new Error('Function not implemented.');
+  },
+  getPlainEventUrl: function (
+    _event: EventFieldsFragment,
+    _locale: AppLanguage
+  ): string {
+    throw new Error('Function not implemented.');
+  },
+  getKeywordOnClickHandler: function (
+    _router: NextRouter,
+    _locale: AppLanguage,
+    _type: 'text' | 'dateType' | 'isFree',
+    _value?: string | undefined
+  ): () => void {
+    throw new Error('Function not implemented.');
+  },
+};
+
+const AppRoutingContext = React.createContext<AppRoutingContextProps>(
+  defaultRoutingContext
+);
+
+export default AppRoutingContext;

--- a/packages/components/src/routingUrlProvider/AppRoutingProvider.tsx
+++ b/packages/components/src/routingUrlProvider/AppRoutingProvider.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { AppRoutingContextProps } from './AppRoutingContext';
+import AppRoutingContext from './AppRoutingContext';
+
+export type AppRoutingProviderProps = AppRoutingContextProps & {
+  children: React.ReactNode;
+};
+
+export default function NavigationProvider({
+  getCardUrl,
+  getEventUrl,
+  getEventListLinkUrl,
+  getOrganizationSearchUrl,
+  getPlainEventUrl,
+  getKeywordOnClickHandler,
+  children,
+}: AppRoutingProviderProps) {
+  const context = {
+    getCardUrl,
+    getEventUrl,
+    getEventListLinkUrl,
+    getOrganizationSearchUrl,
+    getPlainEventUrl,
+    getKeywordOnClickHandler,
+  };
+  return (
+    <AppRoutingContext.Provider value={context}>
+      {children}
+    </AppRoutingContext.Provider>
+  );
+}

--- a/packages/components/src/routingUrlProvider/index.ts
+++ b/packages/components/src/routingUrlProvider/index.ts
@@ -1,0 +1,4 @@
+export { default as AppRoutingContext } from './AppRoutingContext';
+export type { AppRoutingProviderProps } from './AppRoutingProvider';
+export { default as AppRoutingProvider } from './AppRoutingProvider';
+export { default as useAppRoutingContext } from './useAppRoutingContext';

--- a/packages/components/src/routingUrlProvider/useAppRoutingContext.tsx
+++ b/packages/components/src/routingUrlProvider/useAppRoutingContext.tsx
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import appRoutingContext from './AppRoutingContext';
+
+export default function useAppRoutingContext() {
+  return useContext(appRoutingContext);
+}

--- a/packages/components/src/themeProvider/AppThemeContext.tsx
+++ b/packages/components/src/themeProvider/AppThemeContext.tsx
@@ -1,0 +1,11 @@
+import type { CommonButtonProps } from 'hds-react';
+import React from 'react';
+
+export type AppThemeContextProps = {
+  defaultButtonTheme?: CommonButtonProps['theme'];
+  defaultButtonVariant?: CommonButtonProps['variant'];
+};
+
+const AppThemeContext = React.createContext<AppThemeContextProps>({});
+
+export default AppThemeContext;

--- a/packages/components/src/themeProvider/AppThemeProvider.tsx
+++ b/packages/components/src/themeProvider/AppThemeProvider.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import type { AppThemeContextProps } from './AppThemeContext';
+import AppThemeContext from './AppThemeContext';
+
+export type AppThemeProviderProps = AppThemeContextProps & {
+  children: React.ReactNode;
+};
+
+export default function AppThemeProvider({
+  defaultButtonTheme,
+  defaultButtonVariant,
+  children,
+}: AppThemeProviderProps) {
+  const context = {
+    defaultButtonTheme,
+    defaultButtonVariant,
+  };
+  return (
+    <AppThemeContext.Provider value={context}>
+      {children}
+    </AppThemeContext.Provider>
+  );
+}

--- a/packages/components/src/themeProvider/index.ts
+++ b/packages/components/src/themeProvider/index.ts
@@ -1,0 +1,4 @@
+export { default as AppThemeContext } from './AppThemeContext';
+export type { AppThemeProviderProps } from './AppThemeProvider';
+export { default as AppThemeProvider } from './AppThemeProvider';
+export { default as useAppThemeContext } from './useAppThemeContext';

--- a/packages/components/src/themeProvider/useAppThemeContext.tsx
+++ b/packages/components/src/themeProvider/useAppThemeContext.tsx
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import appThemeContext from './AppThemeContext';
+
+export default function useAppThemeContext() {
+  return useContext(appThemeContext);
+}


### PR DESCRIPTION
LIIKUNTA-474.

Add AppRoutingContext and AppThemeContext
to prevent intense prop drilling through components.

The https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/390 was a huge refactoring where there were lots of duplicated code removed (~10K lines, 3K additions). To get that first step done, the application specific functions were served with a prop drilling strategy, which polluted many components. This PR is to replace that prop drilling strategy with some React contexts.

There are now 2 new context & providers:
1. application routing context to provide the application specific URL handlers
2. application theme context to provide the default button themes and variants and such.