### PR TITLE
fix: neighborhood list  get-method should not start with slash

### DIFF
--- a/proxies/events-graphql-proxy/src/datasources/neighborhoodDataSource.ts
+++ b/proxies/events-graphql-proxy/src/datasources/neighborhoodDataSource.ts
@@ -6,7 +6,7 @@ class NeighborhoodDataSource extends MapOpenDataDataSource {
     NeighborhoodListResponse['data']
   > {
     return this.get(
-      `/wfs?request=getFeature&typeName=avoindata:Kaupunginosajako&outputFormat=json`
+      `wfs?request=getFeature&typeName=avoindata:Kaupunginosajako&outputFormat=json`
     );
   }
 }


### PR DESCRIPTION
HH-309

The datasource get-method should not start with slash,
because then the baseURL won't be used.
The neighborhoodList resolver was the only `this.get`
-datasource call that was starting with slash.
It started failing after the dependency update.

The dependency update PR:
https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/367