### PR TITLE
fix: make venue search card  tags visible in mobile

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueCard/largeVenueCard.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueCard/largeVenueCard.module.scss
@@ -72,11 +72,6 @@
 
     .keywordWrapperDesktop {
       order: 6;
-      //padding: var(--spacing-xs) 0;
-
-      @include respond_below(s) {
-        display: none;
-      }
     }
 
     .buttonWrapper {


### PR DESCRIPTION
## Description
<img width="412" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/16116141/b49c3234-aa06-4a3d-b304-d9417628c35a">

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
