### PR TITLE
fix: hero and article tags

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha162",
+    "react-helsinki-headless-cms": "1.0.0-alpha163",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha162",
+    "react-helsinki-headless-cms": "1.0.0-alpha163",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -80,7 +80,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha162",
+    "react-helsinki-headless-cms": "1.0.0-alpha163",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
@@ -74,7 +74,11 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
                 <EventClosedHero onClick={moveToHomePage} />
               ) : (
                 <>
-                  <EventHero event={event} superEvent={superEvent} />
+                  <EventHero
+                    event={event}
+                    superEvent={superEvent}
+                    withActions={false}
+                  />
                   <EventContent
                     event={event}
                     superEvent={superEvent}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,7 +75,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha162",
+    "react-helsinki-headless-cms": "1.0.0-alpha163",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/packages/components/src/components/eventHero/EventHero.tsx
+++ b/packages/components/src/components/eventHero/EventHero.tsx
@@ -40,10 +40,15 @@ import styles from './eventHero.module.scss';
 export type EventHeroProps = {
   event: EventFields;
   superEvent?: SuperEventResponse;
+  withActions?: boolean;
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-const EventHero: React.FC<EventHeroProps> = ({ event, superEvent }) => {
+const EventHero: React.FC<EventHeroProps> = ({
+  event,
+  superEvent,
+  withActions,
+}) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');
   const { fallbackImageUrls } = useConfig();
@@ -179,7 +184,12 @@ const EventHero: React.FC<EventHeroProps> = ({ event, superEvent }) => {
                 </div>
                 {showKeywords && (
                   <div className={styles.categoryWrapper}>
-                    <EventKeywords whiteOnly event={event} showIsFree={true} />
+                    <EventKeywords
+                      whiteOnly
+                      event={event}
+                      showIsFree={true}
+                      withActions={Boolean(withActions)}
+                    />
                   </div>
                 )}
               </div>

--- a/packages/components/src/components/eventHero/EventHero.tsx
+++ b/packages/components/src/components/eventHero/EventHero.tsx
@@ -47,7 +47,7 @@ export type EventHeroProps = {
 const EventHero: React.FC<EventHeroProps> = ({
   event,
   superEvent,
-  withActions,
+  withActions = true,
 }) => {
   const { t } = useTranslation('event');
   const { t: commonTranslation } = useTranslation('common');

--- a/packages/components/src/components/keyword/KeywordTag.tsx
+++ b/packages/components/src/components/keyword/KeywordTag.tsx
@@ -50,6 +50,7 @@ const KeywordTag: FunctionComponent<Props> = ({
         transparent && styles.transparent,
         isToday && styles.isToday,
         isFreeEvent && styles.isFreeEvent,
+        !onClick && styles.noActions,
         className
       )}
       onClick={handleClick}

--- a/packages/components/src/components/keyword/keyword.module.scss
+++ b/packages/components/src/components/keyword/keyword.module.scss
@@ -28,4 +28,8 @@
   &.isFreeEvent {
     background-color: var(--color-keyword-free-event);
   }
+
+  &.noActions:focus {
+    box-shadow: none;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,7 +3322,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha162"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha163"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -13677,7 +13677,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha162"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha163"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -15496,7 +15496,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha162"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha163"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -22587,9 +22587,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha162":
-  version: 1.0.0-alpha162
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha162"
+"react-helsinki-headless-cms@npm:1.0.0-alpha163":
+  version: 1.0.0-alpha163
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha163"
   dependencies:
     hds-design-tokens: "npm:^2.3.0"
     html-react-parser: "npm:^1.4.8"
@@ -22603,7 +22603,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: abf21cb7c0925fab50410577e7da7ce538cf24d5a01b104382fcc8556fff00930da07159d06cdfe0741a8a9a8077ae72381f7e6750019b23404e3b1ccebaffb4
+  checksum: 6226e2062e4885b67d6a9d265a0f63ee349a85bc55b4334bf758d84c5dddfca12852c93e7c56e2e9a282020874d02cac0a1f607597989455d61d488214e59be8
   languageName: node
   linkType: hard
 
@@ -24652,7 +24652,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha162"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha163"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"


### PR DESCRIPTION
## Description
Disable hero and article tags click styles when onClick is not defined. In sports hero tags are not clickable, but in hobbies and events still are.

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
