### PR TITLE
fix: venue page style fixes

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueContent/venueContent.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueContent/venueContent.module.scss
@@ -36,8 +36,8 @@
 .description {
   line-height: 1.5;
   white-space: pre-line;
+  font-size: var(--description-font-size);
   p {
-    font-size: var(--description-font-size);
     margin: 1rem 0;
   }
 

--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -107,7 +107,7 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
               <div className={styles.leftPanelEmpty} />
               <div className={styles.textWrapper}>
                 <div>
-                  <VenueKeywords venue={venue} />
+                  <VenueKeywords whiteOnly venue={venue} />
                 </div>
                 <h1 className={styles.title}>{venue.name}</h1>
                 <div className={styles.additionalInfo}>


### PR DESCRIPTION
## Description
-Venue details description 18px font-size
-Venue Hero tags white only

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
