### PR TITLE
LIIKUNTA-511 | chore: update generated GraphQL types after PR #403 router schema change

### DIFF
--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -11,54 +11,102 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  DateTime: any;
-  GeoJSONCoordinates: any;
-  JSONObject: any;
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTime: { input: any; output: any };
+  GeoJSONCoordinates: { input: any; output: any };
+  JSONObject: { input: any; output: any };
 };
 
-/** TODO: take this from service map / TPREK */
-export type AccessibilityProfile = {
-  __typename?: 'AccessibilityProfile';
-  meta?: Maybe<NodeMeta>;
-  todo?: Maybe<Scalars['String']>;
+export type Accessibility = {
+  __typename?: 'Accessibility';
+  email?: Maybe<Scalars['String']['output']>;
+  phone?: Maybe<Scalars['String']['output']>;
+  sentences?: Maybe<Array<Maybe<AccessibilitySentence>>>;
+  shortcomings?: Maybe<Array<Maybe<AccessibilityShortcoming>>>;
+  viewpoints?: Maybe<Array<Maybe<AccessibilityViewpoint>>>;
+  www?: Maybe<Scalars['String']['output']>;
+};
+
+export enum AccessibilityProfile {
+  HearingAid = 'hearing_aid',
+  ReducedMobility = 'reduced_mobility',
+  Rollator = 'rollator',
+  Stroller = 'stroller',
+  VisuallyImpaired = 'visually_impaired',
+  Wheelchair = 'wheelchair',
+}
+
+export type AccessibilitySentence = {
+  __typename?: 'AccessibilitySentence';
+  sentence?: Maybe<LanguageString>;
+  sentenceGroup?: Maybe<LanguageString>;
+  sentenceGroupName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AccessibilitySentences = {
   __typename?: 'AccessibilitySentences';
-  groupName?: Maybe<Scalars['String']>;
-  sentences?: Maybe<Array<Maybe<Scalars['String']>>>;
+  groupName?: Maybe<Scalars['String']['output']>;
+  sentences?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
 };
+
+export type AccessibilityShortcoming = {
+  __typename?: 'AccessibilityShortcoming';
+  count?: Maybe<Scalars['Int']['output']>;
+  profile?: Maybe<AccessibilityProfile>;
+};
+
+export type AccessibilityViewpoint = {
+  __typename?: 'AccessibilityViewpoint';
+  id?: Maybe<Scalars['ID']['output']>;
+  name?: Maybe<LanguageString>;
+  shortages?: Maybe<Array<Maybe<LanguageString>>>;
+  value?: Maybe<AccessibilityViewpointValue>;
+};
+
+export enum AccessibilityViewpointValue {
+  Green = 'green',
+  Red = 'red',
+  Unknown = 'unknown',
+}
 
 /** TODO: give real structure */
 export type Address = {
   __typename?: 'Address';
   city?: Maybe<LanguageString>;
-  postalCode?: Maybe<Scalars['String']>;
+  postalCode?: Maybe<Scalars['String']['output']>;
   streetAddress?: Maybe<LanguageString>;
 };
 
 export type AdministrativeDivision = {
   __typename?: 'AdministrativeDivision';
-  id?: Maybe<Scalars['ID']>;
-  municipality?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']['output']>;
+  municipality?: Maybe<Scalars['String']['output']>;
   name?: Maybe<LanguageString>;
-  type?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type Audience = {
   __typename?: 'Audience';
-  id?: Maybe<Scalars['ID']>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId?: Maybe<Scalars['String']>;
-  internalType?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']['output']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId?: Maybe<Scalars['String']['output']>;
+  internalType?: Maybe<Scalars['String']['output']>;
   name?: Maybe<LocalizedObject>;
 };
 
@@ -66,27 +114,27 @@ export type Audience = {
 export type Avatar = {
   __typename?: 'Avatar';
   /** URL for the default image or a default type. Accepts &#039;404&#039; (return a 404 instead of a default image), &#039;retro&#039; (8bit), &#039;monsterid&#039; (monster), &#039;wavatar&#039; (cartoon face), &#039;indenticon&#039; (the &#039;quilt&#039;), &#039;mystery&#039;, &#039;mm&#039;, or &#039;mysteryman&#039; (The Oyster Man), &#039;blank&#039; (transparent GIF), or &#039;gravatar_default&#039; (the Gravatar logo). */
-  default?: Maybe<Scalars['String']>;
+  default?: Maybe<Scalars['String']['output']>;
   /** HTML attributes to insert in the IMG element. Is not sanitized. */
-  extraAttr?: Maybe<Scalars['String']>;
+  extraAttr?: Maybe<Scalars['String']['output']>;
   /** Whether to always show the default image, never the Gravatar. */
-  forceDefault?: Maybe<Scalars['Boolean']>;
+  forceDefault?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the avatar was successfully found. */
-  foundAvatar?: Maybe<Scalars['Boolean']>;
+  foundAvatar?: Maybe<Scalars['Boolean']['output']>;
   /** Height of the avatar image. */
-  height?: Maybe<Scalars['Int']>;
+  height?: Maybe<Scalars['Int']['output']>;
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** What rating to display avatars up to. Accepts &#039;G&#039;, &#039;PG&#039;, &#039;R&#039;, &#039;X&#039;, and are judged in that order. */
-  rating?: Maybe<Scalars['String']>;
+  rating?: Maybe<Scalars['String']['output']>;
   /** Type of url scheme to use. Typically HTTP vs. HTTPS. */
-  scheme?: Maybe<Scalars['String']>;
+  scheme?: Maybe<Scalars['String']['output']>;
   /** The size of the avatar in pixels. A value of 96 will match a 96px x 96px gravatar image. */
-  size?: Maybe<Scalars['Int']>;
+  size?: Maybe<Scalars['Int']['output']>;
   /** URL for the gravatar image source. */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
   /** Width of the avatar image. */
-  width?: Maybe<Scalars['Int']>;
+  width?: Maybe<Scalars['Int']['output']>;
 };
 
 /** What rating to display avatars up to. Accepts 'G', 'PG', 'R', 'X', and are judged in that order. Default is the value of the 'avatar_rating' option */
@@ -125,15 +173,15 @@ export enum CacheControlScope {
 export type Card = {
   __typename?: 'Card';
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Description */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Icon */
-  icon?: Maybe<Scalars['String']>;
+  icon?: Maybe<Scalars['String']['output']>;
   /** Link */
   link?: Maybe<Link>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** The category type */
@@ -151,109 +199,109 @@ export type Category = DatabaseIdentifier &
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of databaseId
      */
-    categoryId?: Maybe<Scalars['Int']>;
+    categoryId?: Maybe<Scalars['Int']['output']>;
     /** Connection between the category type and its children categories. */
     children?: Maybe<CategoryToCategoryConnection>;
     /** Connection between the Category type and the ContentNode type */
     contentNodes?: Maybe<CategoryToContentNodeConnection>;
     /** The number of objects connected to the object */
-    count?: Maybe<Scalars['Int']>;
+    count?: Maybe<Scalars['Int']['output']>;
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** The description of the object */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** Connection between the TermNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<TermNodeToEnqueuedScriptConnection>;
     /** Connection between the TermNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<TermNodeToEnqueuedStylesheetConnection>;
     /** The unique resource identifier path */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** List available translations for this post */
     language?: Maybe<Language>;
     /** The link to the term */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The human friendly name of the object. */
-    name?: Maybe<Scalars['String']>;
+    name?: Maybe<Scalars['String']['output']>;
     /** Connection between the category type and its parent category. */
     parent?: Maybe<CategoryToParentCategoryConnectionEdge>;
     /** Database id of the parent node */
-    parentDatabaseId?: Maybe<Scalars['Int']>;
+    parentDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the parent node. */
-    parentId?: Maybe<Scalars['ID']>;
+    parentId?: Maybe<Scalars['ID']['output']>;
     /** Connection between the Category type and the post type */
     posts?: Maybe<CategoryToPostConnection>;
     /** An alphanumeric identifier for the object unique to its type. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** Connection between the Category type and the Taxonomy type */
     taxonomy?: Maybe<CategoryToTaxonomyConnectionEdge>;
     /** The name of the taxonomy that the object is associated with */
-    taxonomyName?: Maybe<Scalars['String']>;
+    taxonomyName?: Maybe<Scalars['String']['output']>;
     /** The ID of the term group that this term object belongs to */
-    termGroupId?: Maybe<Scalars['Int']>;
+    termGroupId?: Maybe<Scalars['Int']['output']>;
     /** The taxonomy ID that the object is associated with */
-    termTaxonomyId?: Maybe<Scalars['Int']>;
+    termTaxonomyId?: Maybe<Scalars['Int']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<Category>;
     /** List all translated versions of this term */
     translations?: Maybe<Array<Maybe<Category>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The category type */
 export type CategoryAncestorsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The category type */
 export type CategoryChildrenArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CategoryToCategoryConnectionWhereArgs>;
 };
 
 /** The category type */
 export type CategoryContentNodesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CategoryToContentNodeConnectionWhereArgs>;
 };
 
 /** The category type */
 export type CategoryEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The category type */
 export type CategoryEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The category type */
 export type CategoryPostsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CategoryToPostConnectionWhereArgs>;
 };
 
@@ -273,7 +321,7 @@ export type CategoryConnection = {
 /** Edge between a Node and a connected category */
 export type CategoryConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected category Node */
   node: Category;
 };
@@ -309,7 +357,7 @@ export type CategoryToAncestorsCategoryConnectionEdge = CategoryConnectionEdge &
   Edge & {
     __typename?: 'CategoryToAncestorsCategoryConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Category;
   };
@@ -331,7 +379,7 @@ export type CategoryToCategoryConnectionEdge = CategoryConnectionEdge &
   Edge & {
     __typename?: 'CategoryToCategoryConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Category;
   };
@@ -339,47 +387,47 @@ export type CategoryToCategoryConnectionEdge = CategoryConnectionEdge &
 /** Arguments for filtering the CategoryToCategoryConnection connection */
 export type CategoryToCategoryConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the Category type and the ContentNode type */
@@ -399,7 +447,7 @@ export type CategoryToContentNodeConnectionEdge = ContentNodeConnectionEdge &
   Edge & {
     __typename?: 'CategoryToContentNodeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentNode;
   };
@@ -411,37 +459,37 @@ export type CategoryToContentNodeConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the Category type and the category type */
@@ -450,7 +498,7 @@ export type CategoryToParentCategoryConnectionEdge = CategoryConnectionEdge &
   OneToOneConnection & {
     __typename?: 'CategoryToParentCategoryConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Category;
   };
@@ -472,7 +520,7 @@ export type CategoryToPostConnectionEdge = Edge &
   PostConnectionEdge & {
     __typename?: 'CategoryToPostConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Post;
   };
@@ -480,67 +528,67 @@ export type CategoryToPostConnectionEdge = Edge &
 /** Arguments for filtering the CategoryToPostConnection connection */
 export type CategoryToPostConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Category ID */
-  categoryId?: InputMaybe<Scalars['Int']>;
+  categoryId?: InputMaybe<Scalars['Int']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Use Category Slug */
-  categoryName?: InputMaybe<Scalars['String']>;
+  categoryName?: InputMaybe<Scalars['String']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Tag Slug */
-  tag?: InputMaybe<Scalars['String']>;
+  tag?: InputMaybe<Scalars['String']['input']>;
   /** Use Tag ID */
-  tagId?: InputMaybe<Scalars['String']>;
+  tagId?: InputMaybe<Scalars['String']['input']>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag slugs, used to display objects from one tag AND another */
-  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of tag slugs, used to include objects in ANY specified tags */
-  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the Category type and the Taxonomy type */
@@ -549,7 +597,7 @@ export type CategoryToTaxonomyConnectionEdge = Edge &
   TaxonomyConnectionEdge & {
     __typename?: 'CategoryToTaxonomyConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Taxonomy;
   };
@@ -557,8 +605,8 @@ export type CategoryToTaxonomyConnectionEdge = Edge &
 export type CmsImage = {
   __typename?: 'CmsImage';
   photographerCredit?: Maybe<LocalizedObject>;
-  title?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** The collection type */
@@ -572,70 +620,70 @@ export type Collection = ContentNode &
   UniformResourceIdentifiable & {
     __typename?: 'Collection';
     /** Background Color */
-    backgroundColor?: Maybe<Scalars['String']>;
+    backgroundColor?: Maybe<Scalars['String']['output']>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    collectionId: Scalars['Int'];
+    collectionId: Scalars['Int']['output'];
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** Description */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
     /** Vanhentumisaika */
-    expirationTime?: Maybe<Scalars['String']>;
+    expirationTime?: Maybe<Scalars['String']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier of the collection-cpt object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Image */
-    image?: Maybe<Scalars['String']>;
+    image?: Maybe<Scalars['String']['output']>;
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** True if the node is a revision of another node */
-    isRevision?: Maybe<Scalars['Boolean']>;
+    isRevision?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Polylang language */
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** List of modules */
     modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
     /** Connection between the Collection type and the collection type */
     preview?: Maybe<CollectionToPreviewConnectionEdge>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
     revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
     /** Connection between the Collection type and the collection type */
@@ -643,45 +691,45 @@ export type Collection = ContentNode &
     /** The SEO Framework data of the collection */
     seo?: Maybe<Seo>;
     /** Show on front page */
-    showOnFrontPage?: Maybe<Scalars['Boolean']>;
+    showOnFrontPage?: Maybe<Scalars['Boolean']['output']>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** The template assigned to the node */
     template?: Maybe<ContentTemplate>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<Collection>;
     /** List all translated versions of this post */
     translations?: Maybe<Array<Maybe<Collection>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The collection type */
 export type CollectionEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The collection type */
 export type CollectionEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The collection type */
 export type CollectionRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CollectionToRevisionConnectionWhereArgs>;
 };
 
@@ -706,7 +754,7 @@ export type CollectionConnection = {
 /** Edge between a Node and a connected collection */
 export type CollectionConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected collection Node */
   node: Collection;
 };
@@ -737,7 +785,7 @@ export type CollectionToPreviewConnectionEdge = CollectionConnectionEdge &
   OneToOneConnection & {
     __typename?: 'CollectionToPreviewConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Collection;
   };
@@ -759,7 +807,7 @@ export type CollectionToRevisionConnectionEdge = CollectionConnectionEdge &
   Edge & {
     __typename?: 'CollectionToRevisionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Collection;
   };
@@ -769,37 +817,37 @@ export type CollectionToRevisionConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** A Comment object */
@@ -807,49 +855,49 @@ export type Comment = DatabaseIdentifier &
   Node & {
     __typename?: 'Comment';
     /** User agent used to post the comment. This field is equivalent to WP_Comment-&gt;comment_agent and the value matching the &quot;comment_agent&quot; column in SQL. */
-    agent?: Maybe<Scalars['String']>;
+    agent?: Maybe<Scalars['String']['output']>;
     /**
      * The approval status of the comment. This field is equivalent to WP_Comment-&gt;comment_approved and the value matching the &quot;comment_approved&quot; column in SQL.
      * @deprecated Deprecated in favor of the `status` field
      */
-    approved?: Maybe<Scalars['Boolean']>;
+    approved?: Maybe<Scalars['Boolean']['output']>;
     /** The author of the comment */
     author?: Maybe<CommentToCommenterConnectionEdge>;
     /** IP address for the author. This field is equivalent to WP_Comment-&gt;comment_author_IP and the value matching the &quot;comment_author_IP&quot; column in SQL. */
-    authorIp?: Maybe<Scalars['String']>;
+    authorIp?: Maybe<Scalars['String']['output']>;
     /**
      * ID for the comment, unique among comments.
      * @deprecated Deprecated in favor of databaseId
      */
-    commentId?: Maybe<Scalars['Int']>;
+    commentId?: Maybe<Scalars['Int']['output']>;
     /** Connection between the Comment type and the ContentNode type */
     commentedOn?: Maybe<CommentToContentNodeConnectionEdge>;
     /** Content of the comment. This field is equivalent to WP_Comment-&gt;comment_content and the value matching the &quot;comment_content&quot; column in SQL. */
-    content?: Maybe<Scalars['String']>;
+    content?: Maybe<Scalars['String']['output']>;
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Date the comment was posted in local time. This field is equivalent to WP_Comment-&gt;date and the value matching the &quot;date&quot; column in SQL. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** Date the comment was posted in GMT. This field is equivalent to WP_Comment-&gt;date_gmt and the value matching the &quot;date_gmt&quot; column in SQL. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier for the comment object */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Karma value for the comment. This field is equivalent to WP_Comment-&gt;comment_karma and the value matching the &quot;comment_karma&quot; column in SQL. */
-    karma?: Maybe<Scalars['Int']>;
+    karma?: Maybe<Scalars['Int']['output']>;
     /** Connection between the Comment type and the Comment type */
     parent?: Maybe<CommentToParentCommentConnectionEdge>;
     /** The database id of the parent comment node or null if it is the root comment */
-    parentDatabaseId?: Maybe<Scalars['Int']>;
+    parentDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the parent comment node. */
-    parentId?: Maybe<Scalars['ID']>;
+    parentId?: Maybe<Scalars['ID']['output']>;
     /** Connection between the Comment type and the Comment type */
     replies?: Maybe<CommentToCommentConnection>;
     /** The approval status of the comment. This field is equivalent to WP_Comment-&gt;comment_approved and the value matching the &quot;comment_approved&quot; column in SQL. */
     status?: Maybe<CommentStatusEnum>;
     /** Type of comment. This field is equivalent to WP_Comment-&gt;comment_type and the value matching the &quot;comment_type&quot; column in SQL. */
-    type?: Maybe<Scalars['String']>;
+    type?: Maybe<Scalars['String']['output']>;
   };
 
 /** A Comment object */
@@ -864,10 +912,10 @@ export type CommentParentArgs = {
 
 /** A Comment object */
 export type CommentRepliesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CommentToCommentConnectionWhereArgs>;
 };
 
@@ -879,24 +927,24 @@ export type CommentAuthor = Commenter &
     /** Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument. */
     avatar?: Maybe<Avatar>;
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** The email for the comment author */
-    email?: Maybe<Scalars['String']>;
+    email?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier for the comment author object */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** The name for the comment author. */
-    name?: Maybe<Scalars['String']>;
+    name?: Maybe<Scalars['String']['output']>;
     /** The url the comment author. */
-    url?: Maybe<Scalars['String']>;
+    url?: Maybe<Scalars['String']['output']>;
   };
 
 /** A Comment Author object */
 export type CommentAuthorAvatarArgs = {
-  forceDefault?: InputMaybe<Scalars['Boolean']>;
+  forceDefault?: InputMaybe<Scalars['Boolean']['input']>;
   rating?: InputMaybe<AvatarRatingEnum>;
-  size?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Connection to Comment Nodes */
@@ -910,7 +958,7 @@ export type CommentConnection = {
 /** Edge between a Node and a connected Comment */
 export type CommentConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected Comment Node */
   node: Comment;
 };
@@ -952,7 +1000,7 @@ export type CommentToCommentConnectionEdge = CommentConnectionEdge &
   Edge & {
     __typename?: 'CommentToCommentConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Comment;
   };
@@ -960,63 +1008,63 @@ export type CommentToCommentConnectionEdge = CommentConnectionEdge &
 /** Arguments for filtering the CommentToCommentConnection connection */
 export type CommentToCommentConnectionWhereArgs = {
   /** Comment author email address. */
-  authorEmail?: InputMaybe<Scalars['String']>;
+  authorEmail?: InputMaybe<Scalars['String']['input']>;
   /** Array of author IDs to include comments for. */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to exclude comments for. */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Comment author URL. */
-  authorUrl?: InputMaybe<Scalars['String']>;
+  authorUrl?: InputMaybe<Scalars['String']['input']>;
   /** Array of comment IDs to include. */
-  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of IDs of users whose unapproved comments will be returned by the query regardless of status. */
-  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Include comments of a given type. */
-  commentType?: InputMaybe<Scalars['String']>;
+  commentType?: InputMaybe<Scalars['String']['input']>;
   /** Include comments from a given array of comment types. */
-  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Exclude comments from a given array of comment types. */
-  commentTypeNotIn?: InputMaybe<Scalars['String']>;
+  commentTypeNotIn?: InputMaybe<Scalars['String']['input']>;
   /** Content object author ID to limit results by. */
-  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to retrieve comments for. */
-  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs *not* to retrieve comments for. */
-  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Limit results to those affiliated with a given content object ID. */
-  contentId?: InputMaybe<Scalars['ID']>;
+  contentId?: InputMaybe<Scalars['ID']['input']>;
   /** Array of content object IDs to include affiliated comments for. */
-  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of content object IDs to exclude affiliated comments for. */
-  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Content object name (i.e. slug ) to retrieve affiliated comments for. */
-  contentName?: InputMaybe<Scalars['String']>;
+  contentName?: InputMaybe<Scalars['String']['input']>;
   /** Content Object parent ID to retrieve affiliated comments for. */
-  contentParent?: InputMaybe<Scalars['Int']>;
+  contentParent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of content object statuses to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentStatus?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Content object type or array of types to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentType?: InputMaybe<Array<InputMaybe<ContentTypeEnum>>>;
   /** Array of IDs or email addresses of users whose unapproved comments will be returned by the query regardless of $status. Default empty */
-  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Karma score to retrieve matching comments for. */
-  karma?: InputMaybe<Scalars['Int']>;
+  karma?: InputMaybe<Scalars['Int']['input']>;
   /** The cardinality of the order of the connection */
   order?: InputMaybe<OrderEnum>;
   /** Field to order the comments by. */
   orderby?: InputMaybe<CommentsConnectionOrderbyEnum>;
   /** Parent ID of comment to retrieve children of. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of parent IDs of comments to retrieve children for. */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of parent IDs of comments *not* to retrieve children for. */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Search term(s) to retrieve matching comments for. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Comment status to limit results by. */
-  status?: InputMaybe<Scalars['String']>;
+  status?: InputMaybe<Scalars['String']['input']>;
   /** Include comments for a specific user ID. */
-  userId?: InputMaybe<Scalars['ID']>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Connection between the Comment type and the Commenter type */
@@ -1025,7 +1073,7 @@ export type CommentToCommenterConnectionEdge = CommenterConnectionEdge &
   OneToOneConnection & {
     __typename?: 'CommentToCommenterConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Commenter;
   };
@@ -1036,7 +1084,7 @@ export type CommentToContentNodeConnectionEdge = ContentNodeConnectionEdge &
   OneToOneConnection & {
     __typename?: 'CommentToContentNodeConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: ContentNode;
   };
@@ -1047,7 +1095,7 @@ export type CommentToParentCommentConnectionEdge = CommentConnectionEdge &
   OneToOneConnection & {
     __typename?: 'CommentToParentCommentConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Comment;
   };
@@ -1055,63 +1103,63 @@ export type CommentToParentCommentConnectionEdge = CommentConnectionEdge &
 /** Arguments for filtering the CommentToParentCommentConnection connection */
 export type CommentToParentCommentConnectionWhereArgs = {
   /** Comment author email address. */
-  authorEmail?: InputMaybe<Scalars['String']>;
+  authorEmail?: InputMaybe<Scalars['String']['input']>;
   /** Array of author IDs to include comments for. */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to exclude comments for. */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Comment author URL. */
-  authorUrl?: InputMaybe<Scalars['String']>;
+  authorUrl?: InputMaybe<Scalars['String']['input']>;
   /** Array of comment IDs to include. */
-  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of IDs of users whose unapproved comments will be returned by the query regardless of status. */
-  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Include comments of a given type. */
-  commentType?: InputMaybe<Scalars['String']>;
+  commentType?: InputMaybe<Scalars['String']['input']>;
   /** Include comments from a given array of comment types. */
-  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Exclude comments from a given array of comment types. */
-  commentTypeNotIn?: InputMaybe<Scalars['String']>;
+  commentTypeNotIn?: InputMaybe<Scalars['String']['input']>;
   /** Content object author ID to limit results by. */
-  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to retrieve comments for. */
-  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs *not* to retrieve comments for. */
-  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Limit results to those affiliated with a given content object ID. */
-  contentId?: InputMaybe<Scalars['ID']>;
+  contentId?: InputMaybe<Scalars['ID']['input']>;
   /** Array of content object IDs to include affiliated comments for. */
-  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of content object IDs to exclude affiliated comments for. */
-  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Content object name (i.e. slug ) to retrieve affiliated comments for. */
-  contentName?: InputMaybe<Scalars['String']>;
+  contentName?: InputMaybe<Scalars['String']['input']>;
   /** Content Object parent ID to retrieve affiliated comments for. */
-  contentParent?: InputMaybe<Scalars['Int']>;
+  contentParent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of content object statuses to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentStatus?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Content object type or array of types to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentType?: InputMaybe<Array<InputMaybe<ContentTypeEnum>>>;
   /** Array of IDs or email addresses of users whose unapproved comments will be returned by the query regardless of $status. Default empty */
-  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Karma score to retrieve matching comments for. */
-  karma?: InputMaybe<Scalars['Int']>;
+  karma?: InputMaybe<Scalars['Int']['input']>;
   /** The cardinality of the order of the connection */
   order?: InputMaybe<OrderEnum>;
   /** Field to order the comments by. */
   orderby?: InputMaybe<CommentsConnectionOrderbyEnum>;
   /** Parent ID of comment to retrieve children of. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of parent IDs of comments to retrieve children for. */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of parent IDs of comments *not* to retrieve children for. */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Search term(s) to retrieve matching comments for. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Comment status to limit results by. */
-  status?: InputMaybe<Scalars['String']>;
+  status?: InputMaybe<Scalars['String']['input']>;
   /** Include comments for a specific user ID. */
-  userId?: InputMaybe<Scalars['ID']>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** The author of a comment */
@@ -1119,23 +1167,23 @@ export type Commenter = {
   /** Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument. */
   avatar?: Maybe<Avatar>;
   /** Identifies the primary key from the database. */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
   /** The email address of the author of a comment. */
-  email?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']['output']>;
   /** The globally unique identifier for the comment author. */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the author information is considered restricted. (not fully public) */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** The name of the author of a comment. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** The url of the author of a comment. */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** Edge between a Node and a connected Commenter */
 export type CommenterConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected Commenter Node */
   node: Commenter;
 };
@@ -1199,25 +1247,25 @@ export type Contact = ContentNode &
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    contactId: Scalars['Int'];
+    contactId: Scalars['Int']['output'];
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** Description */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
@@ -1225,45 +1273,45 @@ export type Contact = ContentNode &
     /** Connection between the NodeWithFeaturedImage type and the MediaItem type */
     featuredImage?: Maybe<NodeWithFeaturedImageToMediaItemConnectionEdge>;
     /** The database identifier for the featured image node assigned to the content node */
-    featuredImageDatabaseId?: Maybe<Scalars['Int']>;
+    featuredImageDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Globally unique ID of the featured image assigned to the node */
-    featuredImageId?: Maybe<Scalars['ID']>;
+    featuredImageId?: Maybe<Scalars['ID']['output']>;
     /** First name */
-    firstName?: Maybe<Scalars['String']>;
+    firstName?: Maybe<Scalars['String']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier of the contact-cpt object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** True if the node is a revision of another node */
-    isRevision?: Maybe<Scalars['Boolean']>;
+    isRevision?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Job Title */
-    jobTitle?: Maybe<Scalars['String']>;
+    jobTitle?: Maybe<Scalars['String']['output']>;
     /** Polylang language */
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** Last name */
-    lastName?: Maybe<Scalars['String']>;
+    lastName?: Maybe<Scalars['String']['output']>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** Connection between the Contact type and the contact type */
     preview?: Maybe<ContactToPreviewConnectionEdge>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
     revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
     /** Connection between the Contact type and the contact type */
@@ -1271,43 +1319,43 @@ export type Contact = ContentNode &
     /** The SEO Framework data of the contact */
     seo?: Maybe<Seo>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** The template assigned to the node */
     template?: Maybe<ContentTemplate>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<Contact>;
     /** List all translated versions of this post */
     translations?: Maybe<Array<Maybe<Contact>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The contact type */
 export type ContactEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The contact type */
 export type ContactEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The contact type */
 export type ContactRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ContactToRevisionConnectionWhereArgs>;
 };
 
@@ -1332,7 +1380,7 @@ export type ContactConnection = {
 /** Edge between a Node and a connected contact */
 export type ContactConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected contact Node */
   node: Contact;
 };
@@ -1352,8 +1400,8 @@ export enum ContactIdType {
 /** Contact details for a person, legal entity, venue or project */
 export type ContactInfo = {
   __typename?: 'ContactInfo';
-  contactUrl?: Maybe<Scalars['String']>;
-  emailAddresses: Array<Scalars['String']>;
+  contactUrl?: Maybe<Scalars['String']['output']>;
+  emailAddresses: Array<Scalars['String']['output']>;
   phoneNumbers: Array<PhoneNumber>;
   postalAddresses: Array<Address>;
 };
@@ -1372,7 +1420,7 @@ export type ContactToPreviewConnectionEdge = ContactConnectionEdge &
   OneToOneConnection & {
     __typename?: 'ContactToPreviewConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Contact;
   };
@@ -1394,7 +1442,7 @@ export type ContactToRevisionConnectionEdge = ContactConnectionEdge &
   Edge & {
     __typename?: 'ContactToRevisionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Contact;
   };
@@ -1404,37 +1452,37 @@ export type ContactToRevisionConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Nodes used to manage content */
@@ -1442,71 +1490,71 @@ export type ContentNode = {
   /** Connection between the ContentNode type and the ContentType type */
   contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
   /** The name of the Content Type the node belongs to */
-  contentTypeName: Scalars['String'];
+  contentTypeName: Scalars['String']['output'];
   /** The ID of the node in the database. */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
   /** Post publishing date. */
-  date?: Maybe<Scalars['String']>;
+  date?: Maybe<Scalars['String']['output']>;
   /** The publishing date set in GMT. */
-  dateGmt?: Maybe<Scalars['String']>;
+  dateGmt?: Maybe<Scalars['String']['output']>;
   /** The desired slug of the post */
-  desiredSlug?: Maybe<Scalars['String']>;
+  desiredSlug?: Maybe<Scalars['String']['output']>;
   /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
   editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
   /** The RSS enclosure for the object */
-  enclosure?: Maybe<Scalars['String']>;
+  enclosure?: Maybe<Scalars['String']['output']>;
   /** Connection between the ContentNode type and the EnqueuedScript type */
   enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
   /** Connection between the ContentNode type and the EnqueuedStylesheet type */
   enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
   /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-  guid?: Maybe<Scalars['String']>;
+  guid?: Maybe<Scalars['String']['output']>;
   /** The unique resource identifier path */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the node is a Content Node */
-  isContentNode: Scalars['Boolean'];
+  isContentNode: Scalars['Boolean']['output'];
   /** Whether the object is a node in the preview state */
-  isPreview?: Maybe<Scalars['Boolean']>;
+  isPreview?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
-  isTermNode: Scalars['Boolean'];
+  isTermNode: Scalars['Boolean']['output'];
   /** The user that most recently edited the node */
   lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
   /** The permalink of the post */
-  link?: Maybe<Scalars['String']>;
+  link?: Maybe<Scalars['String']['output']>;
   /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-  modified?: Maybe<Scalars['String']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-  modifiedGmt?: Maybe<Scalars['String']>;
+  modifiedGmt?: Maybe<Scalars['String']['output']>;
   /** The database id of the preview node */
-  previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+  previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** Whether the object is a node in the preview state */
-  previewRevisionId?: Maybe<Scalars['ID']>;
+  previewRevisionId?: Maybe<Scalars['ID']['output']>;
   /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-  slug?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']['output']>;
   /** The current status of the object */
-  status?: Maybe<Scalars['String']>;
+  status?: Maybe<Scalars['String']['output']>;
   /** The template assigned to a node of content */
   template?: Maybe<ContentTemplate>;
   /** The unique resource identifier path */
-  uri?: Maybe<Scalars['String']>;
+  uri?: Maybe<Scalars['String']['output']>;
 };
 
 /** Nodes used to manage content */
 export type ContentNodeEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Nodes used to manage content */
 export type ContentNodeEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Connection to ContentNode Nodes */
@@ -1520,7 +1568,7 @@ export type ContentNodeConnection = {
 /** Edge between a Node and a connected ContentNode */
 export type ContentNodeConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected ContentNode Node */
   node: ContentNode;
 };
@@ -1541,7 +1589,7 @@ export type ContentNodeToContentTypeConnectionEdge = ContentTypeConnectionEdge &
   OneToOneConnection & {
     __typename?: 'ContentNodeToContentTypeConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: ContentType;
   };
@@ -1552,7 +1600,7 @@ export type ContentNodeToEditLastConnectionEdge = Edge &
   UserConnectionEdge & {
     __typename?: 'ContentNodeToEditLastConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: User;
   };
@@ -1563,9 +1611,9 @@ export type ContentNodeToEditLockConnectionEdge = Edge &
   UserConnectionEdge & {
     __typename?: 'ContentNodeToEditLockConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The timestamp for when the node was last edited */
-    lockTimestamp?: Maybe<Scalars['String']>;
+    lockTimestamp?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: User;
   };
@@ -1587,7 +1635,7 @@ export type ContentNodeToEnqueuedScriptConnectionEdge = Edge &
   EnqueuedScriptConnectionEdge & {
     __typename?: 'ContentNodeToEnqueuedScriptConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedScript;
   };
@@ -1609,7 +1657,7 @@ export type ContentNodeToEnqueuedStylesheetConnectionEdge = Edge &
   EnqueuedStylesheetConnectionEdge & {
     __typename?: 'ContentNodeToEnqueuedStylesheetConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedStylesheet;
   };
@@ -1617,7 +1665,7 @@ export type ContentNodeToEnqueuedStylesheetConnectionEdge = Edge &
 /** The template assigned to a node of content */
 export type ContentTemplate = {
   /** The name of the template */
-  templateName?: Maybe<Scalars['String']>;
+  templateName?: Maybe<Scalars['String']['output']>;
 };
 
 /** An Post Type object */
@@ -1625,85 +1673,85 @@ export type ContentType = Node &
   UniformResourceIdentifiable & {
     __typename?: 'ContentType';
     /** Whether this content type should can be exported. */
-    canExport?: Maybe<Scalars['Boolean']>;
+    canExport?: Maybe<Scalars['Boolean']['output']>;
     /** Connection between the ContentType type and the Taxonomy type */
     connectedTaxonomies?: Maybe<ContentTypeToTaxonomyConnection>;
     /** Connection between the ContentType type and the ContentNode type */
     contentNodes?: Maybe<ContentTypeToContentNodeConnection>;
     /** Whether content of this type should be deleted when the author of it is deleted from the system. */
-    deleteWithUser?: Maybe<Scalars['Boolean']>;
+    deleteWithUser?: Maybe<Scalars['Boolean']['output']>;
     /** Description of the content type. */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** Whether to exclude nodes of this content type from front end search results. */
-    excludeFromSearch?: Maybe<Scalars['Boolean']>;
+    excludeFromSearch?: Maybe<Scalars['Boolean']['output']>;
     /** The plural name of the content type within the GraphQL Schema. */
-    graphqlPluralName?: Maybe<Scalars['String']>;
+    graphqlPluralName?: Maybe<Scalars['String']['output']>;
     /** The singular name of the content type within the GraphQL Schema. */
-    graphqlSingleName?: Maybe<Scalars['String']>;
+    graphqlSingleName?: Maybe<Scalars['String']['output']>;
     /** Whether this content type should have archives. Content archives are generated by type and by date. */
-    hasArchive?: Maybe<Scalars['Boolean']>;
+    hasArchive?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the content type is hierarchical, for example pages. */
-    hierarchical?: Maybe<Scalars['Boolean']>;
+    hierarchical?: Maybe<Scalars['Boolean']['output']>;
     /** The globally unique identifier of the post-type object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether this page is set to the static front page. */
-    isFrontPage: Scalars['Boolean'];
+    isFrontPage: Scalars['Boolean']['output'];
     /** Whether this page is set to the blog posts page. */
-    isPostsPage: Scalars['Boolean'];
+    isPostsPage: Scalars['Boolean']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Display name of the content type. */
-    label?: Maybe<Scalars['String']>;
+    label?: Maybe<Scalars['String']['output']>;
     /** Details about the content type labels. */
     labels?: Maybe<PostTypeLabelDetails>;
     /** The name of the icon file to display as a menu icon. */
-    menuIcon?: Maybe<Scalars['String']>;
+    menuIcon?: Maybe<Scalars['String']['output']>;
     /** The position of this post type in the menu. Only applies if show_in_menu is true. */
-    menuPosition?: Maybe<Scalars['Int']>;
+    menuPosition?: Maybe<Scalars['Int']['output']>;
     /** The internal name of the post type. This should not be used for display purposes. */
-    name?: Maybe<Scalars['String']>;
+    name?: Maybe<Scalars['String']['output']>;
     /** Whether a content type is intended for use publicly either via the admin interface or by front-end users. While the default settings of exclude_from_search, publicly_queryable, show_ui, and show_in_nav_menus are inherited from public, each does not rely on this relationship and controls a very specific intention. */
-    public?: Maybe<Scalars['Boolean']>;
+    public?: Maybe<Scalars['Boolean']['output']>;
     /** Whether queries can be performed on the front end for the content type as part of parse_request(). */
-    publiclyQueryable?: Maybe<Scalars['Boolean']>;
+    publiclyQueryable?: Maybe<Scalars['Boolean']['output']>;
     /** Name of content type to display in REST API &quot;wp/v2&quot; namespace. */
-    restBase?: Maybe<Scalars['String']>;
+    restBase?: Maybe<Scalars['String']['output']>;
     /** The REST Controller class assigned to handling this content type. */
-    restControllerClass?: Maybe<Scalars['String']>;
+    restControllerClass?: Maybe<Scalars['String']['output']>;
     /** Makes this content type available via the admin bar. */
-    showInAdminBar?: Maybe<Scalars['Boolean']>;
+    showInAdminBar?: Maybe<Scalars['Boolean']['output']>;
     /** Whether to add the content type to the GraphQL Schema. */
-    showInGraphql?: Maybe<Scalars['Boolean']>;
+    showInGraphql?: Maybe<Scalars['Boolean']['output']>;
     /** Where to show the content type in the admin menu. To work, $show_ui must be true. If true, the post type is shown in its own top level menu. If false, no menu is shown. If a string of an existing top level menu (eg. &quot;tools.php&quot; or &quot;edit.php?post_type=page&quot;), the post type will be placed as a sub-menu of that. */
-    showInMenu?: Maybe<Scalars['Boolean']>;
+    showInMenu?: Maybe<Scalars['Boolean']['output']>;
     /** Makes this content type available for selection in navigation menus. */
-    showInNavMenus?: Maybe<Scalars['Boolean']>;
+    showInNavMenus?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the content type is associated with a route under the the REST API &quot;wp/v2&quot; namespace. */
-    showInRest?: Maybe<Scalars['Boolean']>;
+    showInRest?: Maybe<Scalars['Boolean']['output']>;
     /** Whether to generate and allow a UI for managing this content type in the admin. */
-    showUi?: Maybe<Scalars['Boolean']>;
+    showUi?: Maybe<Scalars['Boolean']['output']>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** An Post Type object */
 export type ContentTypeConnectedTaxonomiesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** An Post Type object */
 export type ContentTypeContentNodesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ContentTypeToContentNodeConnectionWhereArgs>;
 };
 
@@ -1718,7 +1766,7 @@ export type ContentTypeConnection = {
 /** Edge between a Node and a connected ContentType */
 export type ContentTypeConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected ContentType Node */
   node: ContentType;
 };
@@ -1768,7 +1816,7 @@ export type ContentTypeToContentNodeConnectionEdge = ContentNodeConnectionEdge &
   Edge & {
     __typename?: 'ContentTypeToContentNodeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentNode;
   };
@@ -1780,37 +1828,37 @@ export type ContentTypeToContentNodeConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the ContentType type and the Taxonomy type */
@@ -1830,7 +1878,7 @@ export type ContentTypeToTaxonomyConnectionEdge = Edge &
   TaxonomyConnectionEdge & {
     __typename?: 'ContentTypeToTaxonomyConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Taxonomy;
   };
@@ -1856,18 +1904,18 @@ export enum ContentTypesOfTagEnum {
 /** Input for the createCategory mutation. */
 export type CreateCategoryInput = {
   /** The slug that the category will be an alias of */
-  aliasOf?: InputMaybe<Scalars['String']>;
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The description of the category object */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** The name of the category object to mutate */
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   /** The ID of the category that should be set as the parent */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
   /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createCategory mutation. */
@@ -1876,33 +1924,33 @@ export type CreateCategoryPayload = {
   /** The created category */
   category?: Maybe<Category>;
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
 };
 
 /** Input for the createCollection mutation. */
 export type CreateCollectionInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createCollection mutation. */
 export type CreateCollectionPayload = {
   __typename?: 'CreateCollectionPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   collection?: Maybe<Collection>;
 };
@@ -1910,64 +1958,64 @@ export type CreateCollectionPayload = {
 /** Input for the createComment mutation. */
 export type CreateCommentInput = {
   /** The approval status of the comment. */
-  approved?: InputMaybe<Scalars['String']>;
+  approved?: InputMaybe<Scalars['String']['input']>;
   /** The name of the comment's author. */
-  author?: InputMaybe<Scalars['String']>;
+  author?: InputMaybe<Scalars['String']['input']>;
   /** The email of the comment's author. */
-  authorEmail?: InputMaybe<Scalars['String']>;
+  authorEmail?: InputMaybe<Scalars['String']['input']>;
   /** The url of the comment's author. */
-  authorUrl?: InputMaybe<Scalars['String']>;
+  authorUrl?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The database ID of the post object the comment belongs to. */
-  commentOn?: InputMaybe<Scalars['Int']>;
+  commentOn?: InputMaybe<Scalars['Int']['input']>;
   /** Content of the comment. */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** Parent comment ID of current comment. */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** The approval status of the comment */
   status?: InputMaybe<CommentStatusEnum>;
   /** Type of comment. */
-  type?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createComment mutation. */
 export type CreateCommentPayload = {
   __typename?: 'CreateCommentPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The comment that was created */
   comment?: Maybe<Comment>;
   /** Whether the mutation succeeded. If the comment is not approved, the server will not return the comment to a non authenticated user, but a success message can be returned if the create succeeded, and the client can optimistically add the comment to the client cache */
-  success?: Maybe<Scalars['Boolean']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Input for the createContact mutation. */
 export type CreateContactInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createContact mutation. */
 export type CreateContactPayload = {
   __typename?: 'CreateContactPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   contact?: Maybe<Contact>;
 };
@@ -1975,27 +2023,27 @@ export type CreateContactPayload = {
 /** Input for the createLandingPage mutation. */
 export type CreateLandingPageInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createLandingPage mutation. */
 export type CreateLandingPagePayload = {
   __typename?: 'CreateLandingPagePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   landingPage?: Maybe<LandingPage>;
 };
@@ -2003,43 +2051,43 @@ export type CreateLandingPagePayload = {
 /** Input for the createMediaItem mutation. */
 export type CreateMediaItemInput = {
   /** Alternative text to display when mediaItem is not displayed */
-  altText?: InputMaybe<Scalars['String']>;
+  altText?: InputMaybe<Scalars['String']['input']>;
   /** The userId to assign as the author of the mediaItem */
-  authorId?: InputMaybe<Scalars['ID']>;
+  authorId?: InputMaybe<Scalars['ID']['input']>;
   /** The caption for the mediaItem */
-  caption?: InputMaybe<Scalars['String']>;
+  caption?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The comment status for the mediaItem */
-  commentStatus?: InputMaybe<Scalars['String']>;
+  commentStatus?: InputMaybe<Scalars['String']['input']>;
   /** The date of the mediaItem */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The date (in GMT zone) of the mediaItem */
-  dateGmt?: InputMaybe<Scalars['String']>;
+  dateGmt?: InputMaybe<Scalars['String']['input']>;
   /** Description of the mediaItem */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The file name of the mediaItem */
-  filePath?: InputMaybe<Scalars['String']>;
+  filePath?: InputMaybe<Scalars['String']['input']>;
   /** The file type of the mediaItem */
   fileType?: InputMaybe<MimeTypeEnum>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** The ID of the parent object */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
   /** The ping status for the mediaItem */
-  pingStatus?: InputMaybe<Scalars['String']>;
+  pingStatus?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the mediaItem */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the mediaItem */
   status?: InputMaybe<MediaItemStatusEnum>;
   /** The title of the mediaItem */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createMediaItem mutation. */
 export type CreateMediaItemPayload = {
   __typename?: 'CreateMediaItemPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The MediaItem object mutation type. */
   mediaItem?: Maybe<MediaItem>;
 };
@@ -2047,33 +2095,33 @@ export type CreateMediaItemPayload = {
 /** Input for the createPage mutation. */
 export type CreatePageInput = {
   /** The userId to assign as the author of the object */
-  authorId?: InputMaybe<Scalars['ID']>;
+  authorId?: InputMaybe<Scalars['ID']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The ID of the parent object */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createPage mutation. */
 export type CreatePagePayload = {
   __typename?: 'CreatePagePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   page?: Maybe<Page>;
 };
@@ -2081,22 +2129,22 @@ export type CreatePagePayload = {
 /** Input for the createPostFormat mutation. */
 export type CreatePostFormatInput = {
   /** The slug that the post_format will be an alias of */
-  aliasOf?: InputMaybe<Scalars['String']>;
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The description of the post_format object */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The name of the post_format object to mutate */
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createPostFormat mutation. */
 export type CreatePostFormatPayload = {
   __typename?: 'CreatePostFormatPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The created post_format */
   postFormat?: Maybe<PostFormat>;
 };
@@ -2104,37 +2152,37 @@ export type CreatePostFormatPayload = {
 /** Input for the createPost mutation. */
 export type CreatePostInput = {
   /** The userId to assign as the author of the object */
-  authorId?: InputMaybe<Scalars['ID']>;
+  authorId?: InputMaybe<Scalars['ID']['input']>;
   /** Set connections between the post and categories */
   categories?: InputMaybe<PostCategoriesInput>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Set connections between the post and postFormats */
   postFormats?: InputMaybe<PostPostFormatsInput>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** Set connections between the post and tags */
   tags?: InputMaybe<PostTagsInput>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createPost mutation. */
 export type CreatePostPayload = {
   __typename?: 'CreatePostPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   post?: Maybe<Post>;
 };
@@ -2142,29 +2190,29 @@ export type CreatePostPayload = {
 /** Input for the createRelease mutation. */
 export type CreateReleaseInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createRelease mutation. */
 export type CreateReleasePayload = {
   __typename?: 'CreateReleasePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   release?: Maybe<Release>;
 };
@@ -2172,23 +2220,23 @@ export type CreateReleasePayload = {
 /** Input for the createTag mutation. */
 export type CreateTagInput = {
   /** The slug that the post_tag will be an alias of */
-  aliasOf?: InputMaybe<Scalars['String']>;
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The description of the post_tag object */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** The name of the post_tag object to mutate */
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createTag mutation. */
 export type CreateTagPayload = {
   __typename?: 'CreateTagPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The created post_tag */
   tag?: Maybe<Tag>;
 };
@@ -2196,26 +2244,26 @@ export type CreateTagPayload = {
 /** Input for the createTranslation mutation. */
 export type CreateTranslationInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createTranslation mutation. */
 export type CreateTranslationPayload = {
   __typename?: 'CreateTranslationPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   translation?: Maybe<Translation>;
 };
@@ -2223,48 +2271,48 @@ export type CreateTranslationPayload = {
 /** Input for the createUser mutation. */
 export type CreateUserInput = {
   /** User's AOL IM account. */
-  aim?: InputMaybe<Scalars['String']>;
+  aim?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** A string containing content about the user. */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** A string that will be shown on the site. Defaults to user's username. It is likely that you will want to change this, for both appearance and security through obscurity (that is if you dont use and delete the default admin user). */
-  displayName?: InputMaybe<Scalars['String']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   /** A string containing the user's email address. */
-  email?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']['input']>;
   /** 	The user's first name. */
-  firstName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
   /** User's Jabber account. */
-  jabber?: InputMaybe<Scalars['String']>;
+  jabber?: InputMaybe<Scalars['String']['input']>;
   /** The user's last name. */
-  lastName?: InputMaybe<Scalars['String']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
   /** User's locale. */
-  locale?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains a URL-friendly name for the user. The default is the user's username. */
-  nicename?: InputMaybe<Scalars['String']>;
+  nicename?: InputMaybe<Scalars['String']['input']>;
   /** The user's nickname, defaults to the user's username. */
-  nickname?: InputMaybe<Scalars['String']>;
+  nickname?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains the plain text password for the user. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The date the user registered. Format is Y-m-d H:i:s. */
-  registered?: InputMaybe<Scalars['String']>;
+  registered?: InputMaybe<Scalars['String']['input']>;
   /** A string for whether to enable the rich editor or not. False if not empty. */
-  richEditing?: InputMaybe<Scalars['String']>;
+  richEditing?: InputMaybe<Scalars['String']['input']>;
   /** An array of roles to be assigned to the user. */
-  roles?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  roles?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** A string that contains the user's username for logging in. */
-  username: Scalars['String'];
+  username: Scalars['String']['input'];
   /** A string containing the user's URL for the user's web site. */
-  websiteUrl?: InputMaybe<Scalars['String']>;
+  websiteUrl?: InputMaybe<Scalars['String']['input']>;
   /** User's Yahoo IM account. */
-  yim?: InputMaybe<Scalars['String']>;
+  yim?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the createUser mutation. */
 export type CreateUserPayload = {
   __typename?: 'CreateUserPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The User object mutation type. */
   user?: Maybe<User>;
 };
@@ -2272,17 +2320,17 @@ export type CreateUserPayload = {
 /** Object that can be identified with a Database ID */
 export type DatabaseIdentifier = {
   /** The unique identifier stored in the database */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
 };
 
 /** Date values */
 export type DateInput = {
   /** Day of the month (from 1 to 31) */
-  day?: InputMaybe<Scalars['Int']>;
+  day?: InputMaybe<Scalars['Int']['input']>;
   /** Month number (from 1 to 12) */
-  month?: InputMaybe<Scalars['Int']>;
+  month?: InputMaybe<Scalars['Int']['input']>;
   /** 4 digit year (e.g. 2017) */
-  year?: InputMaybe<Scalars['Int']>;
+  year?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Filter the connection based on input */
@@ -2294,53 +2342,53 @@ export type DateQueryInput = {
   /** Column to query against */
   column?: InputMaybe<PostObjectsConnectionDateColumnEnum>;
   /** For after/before, whether exact value should be matched or not */
-  compare?: InputMaybe<Scalars['String']>;
+  compare?: InputMaybe<Scalars['String']['input']>;
   /** Day of the month (from 1 to 31) */
-  day?: InputMaybe<Scalars['Int']>;
+  day?: InputMaybe<Scalars['Int']['input']>;
   /** Hour (from 0 to 23) */
-  hour?: InputMaybe<Scalars['Int']>;
+  hour?: InputMaybe<Scalars['Int']['input']>;
   /** For after/before, whether exact value should be matched or not */
-  inclusive?: InputMaybe<Scalars['Boolean']>;
+  inclusive?: InputMaybe<Scalars['Boolean']['input']>;
   /** Minute (from 0 to 59) */
-  minute?: InputMaybe<Scalars['Int']>;
+  minute?: InputMaybe<Scalars['Int']['input']>;
   /** Month number (from 1 to 12) */
-  month?: InputMaybe<Scalars['Int']>;
+  month?: InputMaybe<Scalars['Int']['input']>;
   /** OR or AND, how the sub-arrays should be compared */
   relation?: InputMaybe<RelationEnum>;
   /** Second (0 to 59) */
-  second?: InputMaybe<Scalars['Int']>;
+  second?: InputMaybe<Scalars['Int']['input']>;
   /** Week of the year (from 0 to 53) */
-  week?: InputMaybe<Scalars['Int']>;
+  week?: InputMaybe<Scalars['Int']['input']>;
   /** 4 digit year (e.g. 2017) */
-  year?: InputMaybe<Scalars['Int']>;
+  year?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Default images of different post types. Returns url of image of queried post type. Values come from Sivuston Asetukset -&gt; Oletuskuvat. */
 export type DefaultImages = {
   __typename?: 'DefaultImages';
   /** Attachment URL for article image */
-  article?: Maybe<Scalars['String']>;
+  article?: Maybe<Scalars['String']['output']>;
   /** Attachment URL for event image */
-  event?: Maybe<Scalars['String']>;
+  event?: Maybe<Scalars['String']['output']>;
   /** Attachment URL for hero image */
-  hero?: Maybe<Scalars['String']>;
+  hero?: Maybe<Scalars['String']['output']>;
   /** Attachment URL for page image */
-  page?: Maybe<Scalars['String']>;
+  page?: Maybe<Scalars['String']['output']>;
 };
 
 /** The template assigned to the node */
 export type DefaultTemplate = ContentTemplate & {
   __typename?: 'DefaultTemplate';
   /** The name of the template */
-  templateName?: Maybe<Scalars['String']>;
+  templateName?: Maybe<Scalars['String']['output']>;
 };
 
 /** Input for the deleteCategory mutation. */
 export type DeleteCategoryInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the category to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteCategory mutation. */
@@ -2349,91 +2397,91 @@ export type DeleteCategoryPayload = {
   /** The deteted term object */
   category?: Maybe<Category>;
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Input for the deleteCollection mutation. */
 export type DeleteCollectionInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the object should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the collection to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteCollection mutation. */
 export type DeleteCollectionPayload = {
   __typename?: 'DeleteCollectionPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The object before it was deleted */
   collection?: Maybe<Collection>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Input for the deleteComment mutation. */
 export type DeleteCommentInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the comment should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The deleted comment ID */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteComment mutation. */
 export type DeleteCommentPayload = {
   __typename?: 'DeleteCommentPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The deleted comment object */
   comment?: Maybe<Comment>;
   /** The deleted comment ID */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Input for the deleteContact mutation. */
 export type DeleteContactInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the object should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the contact to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteContact mutation. */
 export type DeleteContactPayload = {
   __typename?: 'DeleteContactPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The object before it was deleted */
   contact?: Maybe<Contact>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Input for the deleteLandingPage mutation. */
 export type DeleteLandingPageInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the object should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the landingPage to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteLandingPage mutation. */
 export type DeleteLandingPagePayload = {
   __typename?: 'DeleteLandingPagePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The object before it was deleted */
   landingPage?: Maybe<LandingPage>;
 };
@@ -2441,20 +2489,20 @@ export type DeleteLandingPagePayload = {
 /** Input for the deleteMediaItem mutation. */
 export type DeleteMediaItemInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the mediaItem should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the mediaItem to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteMediaItem mutation. */
 export type DeleteMediaItemPayload = {
   __typename?: 'DeleteMediaItemPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted mediaItem */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The mediaItem before it was deleted */
   mediaItem?: Maybe<MediaItem>;
 };
@@ -2462,20 +2510,20 @@ export type DeleteMediaItemPayload = {
 /** Input for the deletePage mutation. */
 export type DeletePageInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the object should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the page to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deletePage mutation. */
 export type DeletePagePayload = {
   __typename?: 'DeletePagePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The object before it was deleted */
   page?: Maybe<Page>;
 };
@@ -2483,18 +2531,18 @@ export type DeletePagePayload = {
 /** Input for the deletePostFormat mutation. */
 export type DeletePostFormatInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the postFormat to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deletePostFormat mutation. */
 export type DeletePostFormatPayload = {
   __typename?: 'DeletePostFormatPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The deteted term object */
   postFormat?: Maybe<PostFormat>;
 };
@@ -2502,20 +2550,20 @@ export type DeletePostFormatPayload = {
 /** Input for the deletePost mutation. */
 export type DeletePostInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the object should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the post to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deletePost mutation. */
 export type DeletePostPayload = {
   __typename?: 'DeletePostPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The object before it was deleted */
   post?: Maybe<Post>;
 };
@@ -2523,20 +2571,20 @@ export type DeletePostPayload = {
 /** Input for the deleteRelease mutation. */
 export type DeleteReleaseInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the object should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the release to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteRelease mutation. */
 export type DeleteReleasePayload = {
   __typename?: 'DeleteReleasePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The object before it was deleted */
   release?: Maybe<Release>;
 };
@@ -2544,18 +2592,18 @@ export type DeleteReleasePayload = {
 /** Input for the deleteTag mutation. */
 export type DeleteTagInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the tag to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteTag mutation. */
 export type DeleteTagPayload = {
   __typename?: 'DeleteTagPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The deteted term object */
   tag?: Maybe<Tag>;
 };
@@ -2563,20 +2611,20 @@ export type DeleteTagPayload = {
 /** Input for the deleteTranslation mutation. */
 export type DeleteTranslationInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Whether the object should be force deleted instead of being moved to the trash */
-  forceDelete?: InputMaybe<Scalars['Boolean']>;
+  forceDelete?: InputMaybe<Scalars['Boolean']['input']>;
   /** The ID of the translation to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the deleteTranslation mutation. */
 export type DeleteTranslationPayload = {
   __typename?: 'DeleteTranslationPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the deleted object */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The object before it was deleted */
   translation?: Maybe<Translation>;
 };
@@ -2584,20 +2632,20 @@ export type DeleteTranslationPayload = {
 /** Input for the deleteUser mutation. */
 export type DeleteUserInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the user you want to delete */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   /** Reassign posts and links to new User ID. */
-  reassignId?: InputMaybe<Scalars['ID']>;
+  reassignId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** The payload for the deleteUser mutation. */
 export type DeleteUserPayload = {
   __typename?: 'DeleteUserPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The ID of the user that you just deleted */
-  deletedId?: Maybe<Scalars['ID']>;
+  deletedId?: Maybe<Scalars['ID']['output']>;
   /** The deleted user object */
   user?: Maybe<User>;
 };
@@ -2608,8 +2656,8 @@ export type DeleteUserPayload = {
  */
 export type DescriptionResources = {
   __typename?: 'DescriptionResources';
-  externalLinks: Array<Scalars['String']>;
-  infoUrls: Array<Scalars['String']>;
+  externalLinks: Array<Scalars['String']['output']>;
+  infoUrls: Array<Scalars['String']['output']>;
   mediaResources: Array<MediaResource>;
 };
 
@@ -2617,23 +2665,23 @@ export type DescriptionResources = {
 export type DiscussionSettings = {
   __typename?: 'DiscussionSettings';
   /** Salli uusien artikkelien kommentointi. */
-  defaultCommentStatus?: Maybe<Scalars['String']>;
+  defaultCommentStatus?: Maybe<Scalars['String']['output']>;
   /** Salli linkki-ilmoitukset muista blogeista (pingback ja trackback) uusiin artikkeleihin. */
-  defaultPingStatus?: Maybe<Scalars['String']>;
+  defaultPingStatus?: Maybe<Scalars['String']['output']>;
 };
 
 export type Division = {
   __typename?: 'Division';
-  municipality?: Maybe<Scalars['String']>;
+  municipality?: Maybe<Scalars['String']['output']>;
   name?: Maybe<LocalizedObject>;
-  ocdId?: Maybe<Scalars['String']>;
-  type: Scalars['String'];
+  ocdId?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
 };
 
 /** Relational context between connected nodes */
 export type Edge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected node */
   node: Node;
 };
@@ -2643,26 +2691,26 @@ export type ElasticSearchResult = {
   __typename?: 'ElasticSearchResult';
   _shards?: Maybe<Shards>;
   hits?: Maybe<Hits>;
-  timed_out?: Maybe<Scalars['Boolean']>;
-  took?: Maybe<Scalars['Int']>;
+  timed_out?: Maybe<Scalars['Boolean']['output']>;
+  took?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Asset enqueued by the CMS */
 export type EnqueuedAsset = {
   /** @todo */
-  args?: Maybe<Scalars['Boolean']>;
+  args?: Maybe<Scalars['Boolean']['output']>;
   /** Dependencies needed to use this asset */
   dependencies?: Maybe<Array<Maybe<EnqueuedScript>>>;
   /** Extra information needed for the script */
-  extra?: Maybe<Scalars['String']>;
+  extra?: Maybe<Scalars['String']['output']>;
   /** The handle of the enqueued asset */
-  handle?: Maybe<Scalars['String']>;
+  handle?: Maybe<Scalars['String']['output']>;
   /** The ID of the enqueued asset */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** The source of the asset */
-  src?: Maybe<Scalars['String']>;
+  src?: Maybe<Scalars['String']['output']>;
   /** The version of the enqueued asset */
-  version?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['String']['output']>;
 };
 
 /** Script enqueued by the CMS */
@@ -2670,19 +2718,19 @@ export type EnqueuedScript = EnqueuedAsset &
   Node & {
     __typename?: 'EnqueuedScript';
     /** @todo */
-    args?: Maybe<Scalars['Boolean']>;
+    args?: Maybe<Scalars['Boolean']['output']>;
     /** Dependencies needed to use this asset */
     dependencies?: Maybe<Array<Maybe<EnqueuedScript>>>;
     /** Extra information needed for the script */
-    extra?: Maybe<Scalars['String']>;
+    extra?: Maybe<Scalars['String']['output']>;
     /** The handle of the enqueued asset */
-    handle?: Maybe<Scalars['String']>;
+    handle?: Maybe<Scalars['String']['output']>;
     /** The ID of the enqueued asset */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** The source of the asset */
-    src?: Maybe<Scalars['String']>;
+    src?: Maybe<Scalars['String']['output']>;
     /** The version of the enqueued asset */
-    version?: Maybe<Scalars['String']>;
+    version?: Maybe<Scalars['String']['output']>;
   };
 
 /** Connection to EnqueuedScript Nodes */
@@ -2696,7 +2744,7 @@ export type EnqueuedScriptConnection = {
 /** Edge between a Node and a connected EnqueuedScript */
 export type EnqueuedScriptConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected EnqueuedScript Node */
   node: EnqueuedScript;
 };
@@ -2706,19 +2754,19 @@ export type EnqueuedStylesheet = EnqueuedAsset &
   Node & {
     __typename?: 'EnqueuedStylesheet';
     /** @todo */
-    args?: Maybe<Scalars['Boolean']>;
+    args?: Maybe<Scalars['Boolean']['output']>;
     /** Dependencies needed to use this asset */
     dependencies?: Maybe<Array<Maybe<EnqueuedScript>>>;
     /** Extra information needed for the script */
-    extra?: Maybe<Scalars['String']>;
+    extra?: Maybe<Scalars['String']['output']>;
     /** The handle of the enqueued asset */
-    handle?: Maybe<Scalars['String']>;
+    handle?: Maybe<Scalars['String']['output']>;
     /** The ID of the enqueued asset */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** The source of the asset */
-    src?: Maybe<Scalars['String']>;
+    src?: Maybe<Scalars['String']['output']>;
     /** The version of the enqueued asset */
-    version?: Maybe<Scalars['String']>;
+    version?: Maybe<Scalars['String']['output']>;
   };
 
 /** Connection to EnqueuedStylesheet Nodes */
@@ -2732,7 +2780,7 @@ export type EnqueuedStylesheetConnection = {
 /** Edge between a Node and a connected EnqueuedStylesheet */
 export type EnqueuedStylesheetConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected EnqueuedStylesheet Node */
   node: EnqueuedStylesheet;
 };
@@ -2742,12 +2790,12 @@ export type Enrolment = {
   __typename?: 'Enrolment';
   enroller?: Maybe<Person>;
   event?: Maybe<EventOccurrence>;
-  extraInformation?: Maybe<Scalars['String']>;
+  extraInformation?: Maybe<Scalars['String']['output']>;
   meta?: Maybe<NodeMeta>;
-  overseerCount?: Maybe<Scalars['Int']>;
+  overseerCount?: Maybe<Scalars['Int']['output']>;
   overseers?: Maybe<Array<Person>>;
   participantCategory?: Maybe<KeywordString>;
-  participantCount: Scalars['Int'];
+  participantCount: Scalars['Int']['output'];
   participants?: Maybe<Array<Person>>;
   requestedMethodOfNotification?: Maybe<ContactMedium>;
   status?: Maybe<EnrolmentStatus>;
@@ -2759,12 +2807,12 @@ export type EnrolmentPolicy = {
   allowedParticipantCategories: Array<KeywordString>;
   enrolmentTime?: Maybe<TimeDescription>;
   /** maximum number of people who can enrol together (at the same time) */
-  maximumEnrolmentCount?: Maybe<Scalars['Int']>;
+  maximumEnrolmentCount?: Maybe<Scalars['Int']['output']>;
   meta?: Maybe<NodeMeta>;
   /** minimum number of people who can enrol together (at the same time) */
-  minimumEnrolmentCount?: Maybe<Scalars['Int']>;
-  participantMaximumAge: Scalars['Int'];
-  participantMinimumAge: Scalars['Int'];
+  minimumEnrolmentCount?: Maybe<Scalars['Int']['output']>;
+  participantMaximumAge: Scalars['Int']['output'];
+  participantMinimumAge: Scalars['Int']['output'];
   type: Array<EnrolmentPolicyType>;
 };
 
@@ -2791,10 +2839,10 @@ export enum EnrolmentStatus {
 export type EquipmentRequest = {
   __typename?: 'EquipmentRequest';
   deliveryLocation?: Maybe<LocationDescription>;
-  estimatedAmount?: Maybe<Scalars['Int']>;
-  extraInformation: Scalars['String'];
+  estimatedAmount?: Maybe<Scalars['Int']['output']>;
+  extraInformation: Scalars['String']['output'];
   meta?: Maybe<NodeMeta>;
-  requestedEquipment: Scalars['String'];
+  requestedEquipment: Scalars['String']['output'];
   requestedForEvent?: Maybe<Event>;
   returnLocation?: Maybe<LocationDescription>;
 };
@@ -2812,7 +2860,7 @@ export type Event = {
   description?: Maybe<LanguageString>;
   descriptionResources?: Maybe<DescriptionResources>;
   enrolmentPolicy?: Maybe<EnrolmentPolicy>;
-  eventDataSource?: Maybe<Scalars['String']>;
+  eventDataSource?: Maybe<Scalars['String']['output']>;
   eventLanguages: Array<UnifiedSearchLanguageEnum>;
   keywords: Array<KeywordString>;
   meta?: Maybe<NodeMeta>;
@@ -2820,9 +2868,9 @@ export type Event = {
   occurrences: Array<EventOccurrence>;
   organiser?: Maybe<LegalEntity>;
   pricing?: Maybe<Array<EventPricing>>;
-  published?: Maybe<Scalars['DateTime']>;
+  published?: Maybe<Scalars['DateTime']['output']>;
   publisher?: Maybe<LegalEntity>;
-  shortDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']['output']>;
   subEvents: Array<Event>;
   superEvent?: Maybe<Event>;
   targetAudience?: Maybe<Array<KeywordString>>;
@@ -2831,42 +2879,42 @@ export type Event = {
 export type EventDetails = {
   __typename?: 'EventDetails';
   audience: Array<Audience>;
-  audienceMaxAge?: Maybe<Scalars['String']>;
-  audienceMinAge?: Maybe<Scalars['String']>;
-  createdTime?: Maybe<Scalars['String']>;
-  customData?: Maybe<Scalars['String']>;
-  dataSource?: Maybe<Scalars['String']>;
-  datePublished?: Maybe<Scalars['String']>;
+  audienceMaxAge?: Maybe<Scalars['String']['output']>;
+  audienceMinAge?: Maybe<Scalars['String']['output']>;
+  createdTime?: Maybe<Scalars['String']['output']>;
+  customData?: Maybe<Scalars['String']['output']>;
+  dataSource?: Maybe<Scalars['String']['output']>;
+  datePublished?: Maybe<Scalars['String']['output']>;
   description?: Maybe<LocalizedObject>;
-  endTime?: Maybe<Scalars['String']>;
-  enrolmentEndTime?: Maybe<Scalars['String']>;
-  enrolmentStartTime?: Maybe<Scalars['String']>;
-  eventStatus?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']['output']>;
+  enrolmentEndTime?: Maybe<Scalars['String']['output']>;
+  enrolmentStartTime?: Maybe<Scalars['String']['output']>;
+  eventStatus?: Maybe<Scalars['String']['output']>;
   externalLinks: Array<ExternalLink>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   images: Array<Image>;
   inLanguage: Array<InLanguage>;
   infoUrl?: Maybe<LocalizedObject>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId?: Maybe<Scalars['String']>;
-  internalType?: Maybe<Scalars['String']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId?: Maybe<Scalars['String']['output']>;
+  internalType?: Maybe<Scalars['String']['output']>;
   keywords: Array<Keyword>;
-  lastModifiedTime?: Maybe<Scalars['String']>;
+  lastModifiedTime?: Maybe<Scalars['String']['output']>;
   location?: Maybe<Place>;
   locationExtraInfo?: Maybe<LocalizedObject>;
-  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
-  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']['output']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']['output']>;
   name: LocalizedObject;
   offers: Array<Offer>;
   provider?: Maybe<LocalizedObject>;
-  providerContactInfo?: Maybe<Scalars['String']>;
-  publisher?: Maybe<Scalars['ID']>;
-  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
+  providerContactInfo?: Maybe<Scalars['String']['output']>;
+  publisher?: Maybe<Scalars['ID']['output']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']['output']>;
   shortDescription?: Maybe<LocalizedObject>;
-  startTime?: Maybe<Scalars['String']>;
+  startTime?: Maybe<Scalars['String']['output']>;
   subEvents: Array<InternalIdObject>;
   superEvent?: Maybe<InternalIdObject>;
-  superEventType?: Maybe<Scalars['String']>;
+  superEventType?: Maybe<Scalars['String']['output']>;
   typeId?: Maybe<EventTypeId>;
 };
 
@@ -2880,19 +2928,19 @@ export type EventOccurrence = {
   __typename?: 'EventOccurrence';
   /** for events where equipment is requested from the City of Helsinki */
   cityEquipmentRequests?: Maybe<Array<EquipmentRequest>>;
-  currentlyAvailableParticipantCount?: Maybe<Scalars['Int']>;
+  currentlyAvailableParticipantCount?: Maybe<Scalars['Int']['output']>;
   enrolments: Array<Enrolment>;
   /**
    * for information - for example, to guide people who are looking for
    * big or small events, or to give city officials a hint on how much
    * equipment is needed
    */
-  estimatedAttendeeCount?: Maybe<Scalars['Int']>;
+  estimatedAttendeeCount?: Maybe<Scalars['Int']['output']>;
   happensAt?: Maybe<TimeDescription>;
   location?: Maybe<LocationDescription>;
-  maximumAttendeeCount?: Maybe<Scalars['Int']>;
+  maximumAttendeeCount?: Maybe<Scalars['Int']['output']>;
   meta?: Maybe<NodeMeta>;
-  minimumAttendeeCount?: Maybe<Scalars['Int']>;
+  minimumAttendeeCount?: Maybe<Scalars['Int']['output']>;
   /** which event this is an occurrence of */
   ofEvent?: Maybe<Event>;
   status?: Maybe<EventOccurrenceStatus>;
@@ -2910,16 +2958,16 @@ export enum EventOccurrenceStatus {
 export type EventPricing = {
   __typename?: 'EventPricing';
   meta?: Maybe<NodeMeta>;
-  todo?: Maybe<Scalars['String']>;
+  todo?: Maybe<Scalars['String']['output']>;
 };
 
 /** Collection Module: EventSearch */
 export type EventSearch = {
   __typename?: 'EventSearch';
   /** Amount of events listed before &quot;show more -button&quot; */
-  initAmountOfEvents?: Maybe<Scalars['Int']>;
+  initAmountOfEvents?: Maybe<Scalars['Int']['output']>;
   /** Module type */
-  module?: Maybe<Scalars['String']>;
+  module?: Maybe<Scalars['String']['output']>;
   /** List of modules */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /**
@@ -2927,78 +2975,78 @@ export type EventSearch = {
    *                 hakutulosten osoite -link and search params of the module, for example:
    *                 https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
    */
-  showAllLink?: Maybe<Scalars['String']>;
+  showAllLink?: Maybe<Scalars['String']['output']>;
   /** Show all -link */
-  showAllLinkCustom?: Maybe<Scalars['String']>;
+  showAllLinkCustom?: Maybe<Scalars['String']['output']>;
   /** Module title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
   /** Search query */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** Collection Module: EventSearchCarousel */
 export type EventSearchCarousel = {
   __typename?: 'EventSearchCarousel';
   /** Amount of cards in carousel */
-  amountOfCards?: Maybe<Scalars['Int']>;
+  amountOfCards?: Maybe<Scalars['Int']['output']>;
   /** Events nearby */
-  eventsNearby?: Maybe<Scalars['Boolean']>;
+  eventsNearby?: Maybe<Scalars['Boolean']['output']>;
   /** Module type */
-  module?: Maybe<Scalars['String']>;
+  module?: Maybe<Scalars['String']['output']>;
   /** List of modules */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Events order */
-  orderNewestFirst?: Maybe<Scalars['Boolean']>;
+  orderNewestFirst?: Maybe<Scalars['Boolean']['output']>;
   /**
    * Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
    *                                     hakutulosten osoite -link and search params of the module, for example:
    *                                     https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
    */
-  showAllLink?: Maybe<Scalars['String']>;
+  showAllLink?: Maybe<Scalars['String']['output']>;
   /** Show all -link */
-  showAllLinkCustom?: Maybe<Scalars['String']>;
+  showAllLinkCustom?: Maybe<Scalars['String']['output']>;
   /** Module title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
   /** Search query */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** Collection Module: EventSelected */
 export type EventSelected = {
   __typename?: 'EventSelected';
   /** List of event IDs */
-  events?: Maybe<Array<Maybe<Scalars['String']>>>;
+  events?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** Amount of events listed before &quot;show more -button&quot; */
-  initAmountOfEvents?: Maybe<Scalars['Int']>;
+  initAmountOfEvents?: Maybe<Scalars['Int']['output']>;
   /** Module type */
-  module?: Maybe<Scalars['String']>;
+  module?: Maybe<Scalars['String']['output']>;
   /** List of modules */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Show all -link */
-  showAllLink?: Maybe<Scalars['String']>;
+  showAllLink?: Maybe<Scalars['String']['output']>;
   /** Module title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Collection Module: EventSelectedCarousel */
 export type EventSelectedCarousel = {
   __typename?: 'EventSelectedCarousel';
   /** Amount of cards in carousel */
-  amountOfCards?: Maybe<Scalars['Int']>;
+  amountOfCards?: Maybe<Scalars['Int']['output']>;
   /** Amount of cards per row */
-  amountOfCardsPerRow?: Maybe<Scalars['Int']>;
+  amountOfCardsPerRow?: Maybe<Scalars['Int']['output']>;
   /** List of event IDs */
-  events?: Maybe<Array<Maybe<Scalars['String']>>>;
+  events?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** Events nearby */
-  eventsNearby?: Maybe<Scalars['Boolean']>;
+  eventsNearby?: Maybe<Scalars['Boolean']['output']>;
   /** Module type */
-  module?: Maybe<Scalars['String']>;
+  module?: Maybe<Scalars['String']['output']>;
   /** List of modules */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Show all -link */
-  showAllLink?: Maybe<Scalars['String']>;
+  showAllLink?: Maybe<Scalars['String']['output']>;
   /** Module title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 export enum EventTypeId {
@@ -3008,30 +3056,30 @@ export enum EventTypeId {
 
 export type ExternalLink = {
   __typename?: 'ExternalLink';
-  language?: Maybe<Scalars['String']>;
-  link?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars['String']['output']>;
+  link?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 /** The general setting type */
 export type GeneralSettings = {
   __typename?: 'GeneralSettings';
   /** Muoto kaikille päivämäärän merkkijonoille. */
-  dateFormat?: Maybe<Scalars['String']>;
+  dateFormat?: Maybe<Scalars['String']['output']>;
   /** Sivuston kuvaus. */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** WordPressin kieli- ja maakoodi. */
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars['String']['output']>;
   /** Viikonpäivän numero josta viikko alkaa. */
-  startOfWeek?: Maybe<Scalars['Int']>;
+  startOfWeek?: Maybe<Scalars['Int']['output']>;
   /** Muoto kaikille kellonajan merkkijonoille. */
-  timeFormat?: Maybe<Scalars['String']>;
+  timeFormat?: Maybe<Scalars['String']['output']>;
   /** Kaupunki samalla aikavyöhykkeellä kuin sinä. */
-  timezone?: Maybe<Scalars['String']>;
+  timezone?: Maybe<Scalars['String']['output']>;
   /** Sivuston otsikko. */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
   /** Site URL. */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** CRS object properties. */
@@ -3055,18 +3103,18 @@ export type GeoJsonCoordinateReferenceSystem = {
 /** An object that links a geometry to properties in order to provide context. */
 export type GeoJsonFeature = GeoJsonInterface & {
   __typename?: 'GeoJSONFeature';
-  bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
+  bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
   crs: GeoJsonCoordinateReferenceSystem;
   geometry?: Maybe<GeoJsonGeometryInterface>;
-  id?: Maybe<Scalars['String']>;
-  properties?: Maybe<Scalars['JSONObject']>;
+  id?: Maybe<Scalars['String']['output']>;
+  properties?: Maybe<Scalars['JSONObject']['output']>;
   type: GeoJsonType;
 };
 
 /** A set of multiple features. */
 export type GeoJsonFeatureCollection = GeoJsonInterface & {
   __typename?: 'GeoJSONFeatureCollection';
-  bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
+  bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
   crs: GeoJsonCoordinateReferenceSystem;
   features: Array<GeoJsonFeature>;
   type: GeoJsonType;
@@ -3075,21 +3123,21 @@ export type GeoJsonFeatureCollection = GeoJsonInterface & {
 /** A set of multiple geometries, possibly of various types. */
 export type GeoJsonGeometryCollection = GeoJsonInterface & {
   __typename?: 'GeoJSONGeometryCollection';
-  bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
+  bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
   crs: GeoJsonCoordinateReferenceSystem;
   geometries: Array<GeoJsonGeometryInterface>;
   type: GeoJsonType;
 };
 
 export type GeoJsonGeometryInterface = {
-  bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
-  coordinates?: Maybe<Scalars['GeoJSONCoordinates']>;
+  bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+  coordinates?: Maybe<Scalars['GeoJSONCoordinates']['output']>;
   crs: GeoJsonCoordinateReferenceSystem;
   type: GeoJsonType;
 };
 
 export type GeoJsonInterface = {
-  bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
+  bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
   crs: GeoJsonCoordinateReferenceSystem;
   type: GeoJsonType;
 };
@@ -3098,8 +3146,8 @@ export type GeoJsonInterface = {
 export type GeoJsonLineString = GeoJsonGeometryInterface &
   GeoJsonInterface & {
     __typename?: 'GeoJSONLineString';
-    bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
-    coordinates?: Maybe<Scalars['GeoJSONCoordinates']>;
+    bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+    coordinates?: Maybe<Scalars['GeoJSONCoordinates']['output']>;
     crs: GeoJsonCoordinateReferenceSystem;
     type: GeoJsonType;
   };
@@ -3107,16 +3155,16 @@ export type GeoJsonLineString = GeoJsonGeometryInterface &
 /** Properties for link based CRS object. */
 export type GeoJsonLinkedCrsProperties = {
   __typename?: 'GeoJSONLinkedCRSProperties';
-  href: Scalars['String'];
-  type?: Maybe<Scalars['String']>;
+  href: Scalars['String']['output'];
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 /** Object describing multiple connected sequences of geographical points. */
 export type GeoJsonMultiLineString = GeoJsonGeometryInterface &
   GeoJsonInterface & {
     __typename?: 'GeoJSONMultiLineString';
-    bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
-    coordinates?: Maybe<Scalars['GeoJSONCoordinates']>;
+    bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+    coordinates?: Maybe<Scalars['GeoJSONCoordinates']['output']>;
     crs: GeoJsonCoordinateReferenceSystem;
     type: GeoJsonType;
   };
@@ -3125,8 +3173,8 @@ export type GeoJsonMultiLineString = GeoJsonGeometryInterface &
 export type GeoJsonMultiPoint = GeoJsonGeometryInterface &
   GeoJsonInterface & {
     __typename?: 'GeoJSONMultiPoint';
-    bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
-    coordinates?: Maybe<Scalars['GeoJSONCoordinates']>;
+    bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+    coordinates?: Maybe<Scalars['GeoJSONCoordinates']['output']>;
     crs: GeoJsonCoordinateReferenceSystem;
     type: GeoJsonType;
   };
@@ -3135,8 +3183,8 @@ export type GeoJsonMultiPoint = GeoJsonGeometryInterface &
 export type GeoJsonMultiPolygon = GeoJsonGeometryInterface &
   GeoJsonInterface & {
     __typename?: 'GeoJSONMultiPolygon';
-    bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
-    coordinates?: Maybe<Scalars['GeoJSONCoordinates']>;
+    bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+    coordinates?: Maybe<Scalars['GeoJSONCoordinates']['output']>;
     crs: GeoJsonCoordinateReferenceSystem;
     type: GeoJsonType;
   };
@@ -3144,15 +3192,15 @@ export type GeoJsonMultiPolygon = GeoJsonGeometryInterface &
 /** Properties for name based CRS object. */
 export type GeoJsonNamedCrsProperties = {
   __typename?: 'GeoJSONNamedCRSProperties';
-  name: Scalars['String'];
+  name: Scalars['String']['output'];
 };
 
 /** Object describing a single geographical point. */
 export type GeoJsonPoint = GeoJsonGeometryInterface &
   GeoJsonInterface & {
     __typename?: 'GeoJSONPoint';
-    bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
-    coordinates?: Maybe<Scalars['GeoJSONCoordinates']>;
+    bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+    coordinates?: Maybe<Scalars['GeoJSONCoordinates']['output']>;
     crs: GeoJsonCoordinateReferenceSystem;
     type: GeoJsonType;
   };
@@ -3161,8 +3209,8 @@ export type GeoJsonPoint = GeoJsonGeometryInterface &
 export type GeoJsonPolygon = GeoJsonGeometryInterface &
   GeoJsonInterface & {
     __typename?: 'GeoJSONPolygon';
-    bbox?: Maybe<Array<Maybe<Scalars['Float']>>>;
-    coordinates?: Maybe<Scalars['GeoJSONCoordinates']>;
+    bbox?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+    coordinates?: Maybe<Scalars['GeoJSONCoordinates']['output']>;
     crs: GeoJsonCoordinateReferenceSystem;
     type: GeoJsonType;
   };
@@ -3184,17 +3232,17 @@ export enum GeoJsonType {
 export type Hero = {
   __typename?: 'Hero';
   /** The background color of the hero */
-  background_color?: Maybe<Scalars['String']>;
+  background_color?: Maybe<Scalars['String']['output']>;
   /** The background color of the hero */
-  background_image_url?: Maybe<Scalars['String']>;
+  background_image_url?: Maybe<Scalars['String']['output']>;
   /** The desctiption of the hero */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** The title of the hero link */
   link?: Maybe<Link>;
   /** The title of the hero */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
   /** The wave motif of the hero */
-  wave_motif?: Maybe<Scalars['String']>;
+  wave_motif?: Maybe<Scalars['String']['output']>;
 };
 
 /** Content node with hierarchical (parent/child) relationships */
@@ -3206,95 +3254,95 @@ export type HierarchicalContentNode = {
   /** Connection between the ContentNode type and the ContentType type */
   contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
   /** The name of the Content Type the node belongs to */
-  contentTypeName: Scalars['String'];
+  contentTypeName: Scalars['String']['output'];
   /** The unique identifier stored in the database */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
   /** Post publishing date. */
-  date?: Maybe<Scalars['String']>;
+  date?: Maybe<Scalars['String']['output']>;
   /** The publishing date set in GMT. */
-  dateGmt?: Maybe<Scalars['String']>;
+  dateGmt?: Maybe<Scalars['String']['output']>;
   /** The desired slug of the post */
-  desiredSlug?: Maybe<Scalars['String']>;
+  desiredSlug?: Maybe<Scalars['String']['output']>;
   /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
   editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
   /** The RSS enclosure for the object */
-  enclosure?: Maybe<Scalars['String']>;
+  enclosure?: Maybe<Scalars['String']['output']>;
   /** Connection between the ContentNode type and the EnqueuedScript type */
   enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
   /** Connection between the ContentNode type and the EnqueuedStylesheet type */
   enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
   /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-  guid?: Maybe<Scalars['String']>;
+  guid?: Maybe<Scalars['String']['output']>;
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the node is a Content Node */
-  isContentNode: Scalars['Boolean'];
+  isContentNode: Scalars['Boolean']['output'];
   /** Whether the object is a node in the preview state */
-  isPreview?: Maybe<Scalars['Boolean']>;
+  isPreview?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
-  isTermNode: Scalars['Boolean'];
+  isTermNode: Scalars['Boolean']['output'];
   /** The user that most recently edited the node */
   lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
   /** The permalink of the post */
-  link?: Maybe<Scalars['String']>;
+  link?: Maybe<Scalars['String']['output']>;
   /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-  modified?: Maybe<Scalars['String']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-  modifiedGmt?: Maybe<Scalars['String']>;
+  modifiedGmt?: Maybe<Scalars['String']['output']>;
   /** The parent of the node. The parent object can be of various types */
   parent?: Maybe<HierarchicalContentNodeToParentContentNodeConnectionEdge>;
   /** Database id of the parent node */
-  parentDatabaseId?: Maybe<Scalars['Int']>;
+  parentDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** The globally unique identifier of the parent node. */
-  parentId?: Maybe<Scalars['ID']>;
+  parentId?: Maybe<Scalars['ID']['output']>;
   /** The database id of the preview node */
-  previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+  previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** Whether the object is a node in the preview state */
-  previewRevisionId?: Maybe<Scalars['ID']>;
+  previewRevisionId?: Maybe<Scalars['ID']['output']>;
   /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-  slug?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']['output']>;
   /** The current status of the object */
-  status?: Maybe<Scalars['String']>;
+  status?: Maybe<Scalars['String']['output']>;
   /** The template assigned to a node of content */
   template?: Maybe<ContentTemplate>;
   /** The unique resource identifier path */
-  uri?: Maybe<Scalars['String']>;
+  uri?: Maybe<Scalars['String']['output']>;
 };
 
 /** Content node with hierarchical (parent/child) relationships */
 export type HierarchicalContentNodeAncestorsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs>;
 };
 
 /** Content node with hierarchical (parent/child) relationships */
 export type HierarchicalContentNodeChildrenArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs>;
 };
 
 /** Content node with hierarchical (parent/child) relationships */
 export type HierarchicalContentNodeEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Content node with hierarchical (parent/child) relationships */
 export type HierarchicalContentNodeEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Connection between the HierarchicalContentNode type and the ContentNode type */
@@ -3316,7 +3364,7 @@ export type HierarchicalContentNodeToContentNodeAncestorsConnectionEdge =
     Edge & {
       __typename?: 'HierarchicalContentNodeToContentNodeAncestorsConnectionEdge';
       /** A cursor for use in pagination */
-      cursor?: Maybe<Scalars['String']>;
+      cursor?: Maybe<Scalars['String']['output']>;
       /** The item at the end of the edge */
       node: ContentNode;
     };
@@ -3328,37 +3376,37 @@ export type HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the HierarchicalContentNode type and the ContentNode type */
@@ -3380,7 +3428,7 @@ export type HierarchicalContentNodeToContentNodeChildrenConnectionEdge =
     Edge & {
       __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnectionEdge';
       /** A cursor for use in pagination */
-      cursor?: Maybe<Scalars['String']>;
+      cursor?: Maybe<Scalars['String']['output']>;
       /** The item at the end of the edge */
       node: ContentNode;
     };
@@ -3392,37 +3440,37 @@ export type HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the HierarchicalContentNode type and the ContentNode type */
@@ -3432,7 +3480,7 @@ export type HierarchicalContentNodeToParentContentNodeConnectionEdge =
     OneToOneConnection & {
       __typename?: 'HierarchicalContentNodeToParentContentNodeConnectionEdge';
       /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-      cursor?: Maybe<Scalars['String']>;
+      cursor?: Maybe<Scalars['String']['output']>;
       /** The node of the connection, without the edges */
       node: ContentNode;
     };
@@ -3440,81 +3488,81 @@ export type HierarchicalContentNodeToParentContentNodeConnectionEdge =
 /** Node with hierarchical (parent/child) relationships */
 export type HierarchicalNode = {
   /** The unique identifier stored in the database */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Database id of the parent node */
-  parentDatabaseId?: Maybe<Scalars['Int']>;
+  parentDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** The globally unique identifier of the parent node. */
-  parentId?: Maybe<Scalars['ID']>;
+  parentId?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Term node with hierarchical (parent/child) relationships */
 export type HierarchicalTermNode = {
   /** The number of objects connected to the object */
-  count?: Maybe<Scalars['Int']>;
+  count?: Maybe<Scalars['Int']['output']>;
   /** The unique identifier stored in the database */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
   /** The description of the object */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Connection between the TermNode type and the EnqueuedScript type */
   enqueuedScripts?: Maybe<TermNodeToEnqueuedScriptConnection>;
   /** Connection between the TermNode type and the EnqueuedStylesheet type */
   enqueuedStylesheets?: Maybe<TermNodeToEnqueuedStylesheetConnection>;
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the node is a Content Node */
-  isContentNode: Scalars['Boolean'];
+  isContentNode: Scalars['Boolean']['output'];
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
-  isTermNode: Scalars['Boolean'];
+  isTermNode: Scalars['Boolean']['output'];
   /** The link to the term */
-  link?: Maybe<Scalars['String']>;
+  link?: Maybe<Scalars['String']['output']>;
   /** The human friendly name of the object. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** Database id of the parent node */
-  parentDatabaseId?: Maybe<Scalars['Int']>;
+  parentDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** The globally unique identifier of the parent node. */
-  parentId?: Maybe<Scalars['ID']>;
+  parentId?: Maybe<Scalars['ID']['output']>;
   /** An alphanumeric identifier for the object unique to its type. */
-  slug?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']['output']>;
   /** The name of the taxonomy that the object is associated with */
-  taxonomyName?: Maybe<Scalars['String']>;
+  taxonomyName?: Maybe<Scalars['String']['output']>;
   /** The ID of the term group that this term object belongs to */
-  termGroupId?: Maybe<Scalars['Int']>;
+  termGroupId?: Maybe<Scalars['Int']['output']>;
   /** The taxonomy ID that the object is associated with */
-  termTaxonomyId?: Maybe<Scalars['Int']>;
+  termTaxonomyId?: Maybe<Scalars['Int']['output']>;
   /** The unique resource identifier path */
-  uri?: Maybe<Scalars['String']>;
+  uri?: Maybe<Scalars['String']['output']>;
 };
 
 /** Term node with hierarchical (parent/child) relationships */
 export type HierarchicalTermNodeEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Term node with hierarchical (parent/child) relationships */
 export type HierarchicalTermNodeEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type HitTotal = {
   __typename?: 'HitTotal';
-  relation?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['Int']>;
+  relation?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Hits = {
   __typename?: 'Hits';
   hits?: Maybe<Array<Maybe<SingleHit>>>;
-  max_score?: Maybe<Scalars['Float']>;
+  max_score?: Maybe<Scalars['Float']['output']>;
   total?: Maybe<HitTotal>;
 };
 
@@ -3533,53 +3581,53 @@ export enum IdentificationStrength {
 
 export type Image = {
   __typename?: 'Image';
-  createdTime?: Maybe<Scalars['String']>;
-  cropping?: Maybe<Scalars['String']>;
-  dataSource?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId: Scalars['String'];
-  internalType?: Maybe<Scalars['String']>;
-  lastModifiedTime?: Maybe<Scalars['String']>;
-  license?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  photographerName?: Maybe<Scalars['String']>;
-  publisher?: Maybe<Scalars['String']>;
-  url: Scalars['String'];
+  createdTime?: Maybe<Scalars['String']['output']>;
+  cropping?: Maybe<Scalars['String']['output']>;
+  dataSource?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId: Scalars['String']['output'];
+  internalType?: Maybe<Scalars['String']['output']>;
+  lastModifiedTime?: Maybe<Scalars['String']['output']>;
+  license?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  photographerName?: Maybe<Scalars['String']['output']>;
+  publisher?: Maybe<Scalars['String']['output']>;
+  url: Scalars['String']['output'];
 };
 
 export type InLanguage = {
   __typename?: 'InLanguage';
-  id?: Maybe<Scalars['ID']>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId?: Maybe<Scalars['String']>;
-  internalType?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']['output']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId?: Maybe<Scalars['String']['output']>;
+  internalType?: Maybe<Scalars['String']['output']>;
   name?: Maybe<LocalizedObject>;
-  translationAvailable?: Maybe<Scalars['Boolean']>;
+  translationAvailable?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type InternalIdObject = {
   __typename?: 'InternalIdObject';
-  internalId?: Maybe<Scalars['String']>;
+  internalId?: Maybe<Scalars['String']['output']>;
 };
 
 export type Keyword = {
   __typename?: 'Keyword';
-  aggregate?: Maybe<Scalars['Boolean']>;
-  altLabels?: Maybe<Array<Maybe<Scalars['String']>>>;
-  createdTime?: Maybe<Scalars['String']>;
-  dataSource?: Maybe<Scalars['String']>;
-  deprecated?: Maybe<Scalars['Boolean']>;
-  hasUpcomingEvents?: Maybe<Scalars['Boolean']>;
-  id?: Maybe<Scalars['ID']>;
+  aggregate?: Maybe<Scalars['Boolean']['output']>;
+  altLabels?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  createdTime?: Maybe<Scalars['String']['output']>;
+  dataSource?: Maybe<Scalars['String']['output']>;
+  deprecated?: Maybe<Scalars['Boolean']['output']>;
+  hasUpcomingEvents?: Maybe<Scalars['Boolean']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
   image?: Maybe<Image>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId: Scalars['String'];
-  internalType?: Maybe<Scalars['String']>;
-  lastModifiedTime?: Maybe<Scalars['String']>;
-  nEvents?: Maybe<Scalars['Int']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId: Scalars['String']['output'];
+  internalType?: Maybe<Scalars['String']['output']>;
+  lastModifiedTime?: Maybe<Scalars['String']['output']>;
+  nEvents?: Maybe<Scalars['Int']['output']>;
   name?: Maybe<LocalizedObject>;
-  publisher?: Maybe<Scalars['ID']>;
+  publisher?: Maybe<Scalars['ID']['output']>;
 };
 
 export type KeywordListResponse = {
@@ -3594,7 +3642,7 @@ export type KeywordListResponse = {
  */
 export type KeywordString = {
   __typename?: 'KeywordString';
-  name: Scalars['String'];
+  name: Scalars['String']['output'];
 };
 
 /** The landingPage type */
@@ -3608,29 +3656,29 @@ export type LandingPage = ContentNode &
   UniformResourceIdentifiable & {
     __typename?: 'LandingPage';
     /** Background Color */
-    backgroundColor?: Maybe<Scalars['String']>;
+    backgroundColor?: Maybe<Scalars['String']['output']>;
     /** Box Color */
-    boxColor?: Maybe<Scalars['String']>;
+    boxColor?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** Description */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** Desktop Image */
     desktopImage?: Maybe<LandingPageToMediaItemConnection>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
@@ -3638,46 +3686,46 @@ export type LandingPage = ContentNode &
     /** Float Image */
     floatImage?: Maybe<LandingPageToFloatImageConnection>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** Link */
-    heroLink?: Maybe<Array<Maybe<Scalars['String']>>>;
+    heroLink?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
     /** The globally unique identifier of the landing-page-cpt object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** True if the node is a revision of another node */
-    isRevision?: Maybe<Scalars['Boolean']>;
+    isRevision?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    landingPageId: Scalars['Int'];
+    landingPageId: Scalars['Int']['output'];
     /** Polylang language */
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** Mobile Image */
     mobileImage?: Maybe<LandingPageToMobileImageConnection>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** List of modules */
     modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
     /** Connection between the LandingPage type and the landingPage type */
     preview?: Maybe<LandingPageToPreviewConnectionEdge>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
     revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
     /** Connection between the LandingPage type and the landingPage type */
@@ -3685,70 +3733,70 @@ export type LandingPage = ContentNode &
     /** The SEO Framework data of the landingPage */
     seo?: Maybe<Seo>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** The template assigned to the node */
     template?: Maybe<ContentTemplate>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<LandingPage>;
     /** List all translated versions of this post */
     translations?: Maybe<Array<Maybe<LandingPage>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The landingPage type */
 export type LandingPageDesktopImageArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<LandingPageToMediaItemConnectionWhereArgs>;
 };
 
 /** The landingPage type */
 export type LandingPageEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The landingPage type */
 export type LandingPageEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The landingPage type */
 export type LandingPageFloatImageArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<LandingPageToFloatImageConnectionWhereArgs>;
 };
 
 /** The landingPage type */
 export type LandingPageMobileImageArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<LandingPageToMobileImageConnectionWhereArgs>;
 };
 
 /** The landingPage type */
 export type LandingPageRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<LandingPageToRevisionConnectionWhereArgs>;
 };
 
@@ -3773,7 +3821,7 @@ export type LandingPageConnection = {
 /** Edge between a Node and a connected landingPage */
 export type LandingPageConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected landingPage Node */
   node: LandingPage;
 };
@@ -3807,7 +3855,7 @@ export type LandingPageToFloatImageConnectionEdge = Edge &
   MediaItemConnectionEdge & {
     __typename?: 'LandingPageToFloatImageConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MediaItem;
   };
@@ -3819,37 +3867,37 @@ export type LandingPageToFloatImageConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the landingPage type and the MediaItem type */
@@ -3869,7 +3917,7 @@ export type LandingPageToMediaItemConnectionEdge = Edge &
   MediaItemConnectionEdge & {
     __typename?: 'LandingPageToMediaItemConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MediaItem;
   };
@@ -3881,37 +3929,37 @@ export type LandingPageToMediaItemConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the landingPage type and the MediaItem type */
@@ -3931,7 +3979,7 @@ export type LandingPageToMobileImageConnectionEdge = Edge &
   MediaItemConnectionEdge & {
     __typename?: 'LandingPageToMobileImageConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MediaItem;
   };
@@ -3943,37 +3991,37 @@ export type LandingPageToMobileImageConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the LandingPage type and the landingPage type */
@@ -3982,7 +4030,7 @@ export type LandingPageToPreviewConnectionEdge = Edge &
   OneToOneConnection & {
     __typename?: 'LandingPageToPreviewConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: LandingPage;
   };
@@ -4004,7 +4052,7 @@ export type LandingPageToRevisionConnectionEdge = Edge &
   LandingPageConnectionEdge & {
     __typename?: 'LandingPageToRevisionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: LandingPage;
   };
@@ -4014,37 +4062,37 @@ export type LandingPageToRevisionConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Language (Polylang) */
@@ -4053,15 +4101,15 @@ export type Language = {
   /** Language code (Polylang) */
   code?: Maybe<LanguageCodeEnum>;
   /** Language term front page URL */
-  homeUrl?: Maybe<Scalars['String']>;
+  homeUrl?: Maybe<Scalars['String']['output']>;
   /** Language ID (Polylang) */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Language locale (Polylang) */
-  locale?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']['output']>;
   /** Human readable language name (Polylang) */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** Language term slug. Prefer the &quot;code&quot; field if possible (Polylang) */
-  slug?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']['output']>;
 };
 
 /** Enum of all available language codes */
@@ -4083,74 +4131,74 @@ export enum LanguageCodeFilterEnum {
 /** TODO: convert all String's to LanguageString's if linguistic content */
 export type LanguageString = {
   __typename?: 'LanguageString';
-  en?: Maybe<Scalars['String']>;
-  fi?: Maybe<Scalars['String']>;
-  sv?: Maybe<Scalars['String']>;
+  en?: Maybe<Scalars['String']['output']>;
+  fi?: Maybe<Scalars['String']['output']>;
+  sv?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutArticleHighlights */
 export type LayoutArticleHighlights = {
   __typename?: 'LayoutArticleHighlights';
   /** Anchor */
-  anchor?: Maybe<Scalars['String']>;
+  anchor?: Maybe<Scalars['String']['output']>;
   /** Articles */
   articles?: Maybe<Array<Maybe<Post>>>;
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Category */
-  category?: Maybe<Scalars['Int']>;
+  category?: Maybe<Scalars['Int']['output']>;
   /** Amount of articles to list */
-  limit?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']['output']>;
   /** Show more link */
-  showMore?: Maybe<Array<Maybe<Scalars['String']>>>;
+  showMore?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** Tag */
-  tag?: Maybe<Scalars['Int']>;
+  tag?: Maybe<Scalars['Int']['output']>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutArticles */
 export type LayoutArticles = {
   __typename?: 'LayoutArticles';
   /** Anchor */
-  anchor?: Maybe<Scalars['String']>;
+  anchor?: Maybe<Scalars['String']['output']>;
   /** Articles */
   articles?: Maybe<Array<Maybe<Post>>>;
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Category */
-  category?: Maybe<Scalars['Int']>;
+  category?: Maybe<Scalars['Int']['output']>;
   /** Tag */
-  limit?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']['output']>;
   /** Show all -link */
-  showAllLink?: Maybe<Scalars['String']>;
+  showAllLink?: Maybe<Scalars['String']['output']>;
   /** Tag */
-  tag?: Maybe<Scalars['Int']>;
+  tag?: Maybe<Scalars['Int']['output']>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutArticlesCarousel */
 export type LayoutArticlesCarousel = {
   __typename?: 'LayoutArticlesCarousel';
   /** Anchor */
-  anchor?: Maybe<Scalars['String']>;
+  anchor?: Maybe<Scalars['String']['output']>;
   /** Articles */
   articles?: Maybe<Array<Maybe<Post>>>;
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Category */
-  category?: Maybe<Scalars['Int']>;
+  category?: Maybe<Scalars['Int']['output']>;
   /** Amount of articles to list */
-  limit?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']['output']>;
   /** Show all -link */
-  showAllLink?: Maybe<Scalars['String']>;
+  showAllLink?: Maybe<Scalars['String']['output']>;
   /** Show more link */
-  showMore?: Maybe<Array<Maybe<Scalars['String']>>>;
+  showMore?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** Tag */
-  tag?: Maybe<Scalars['Int']>;
+  tag?: Maybe<Scalars['Int']['output']>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutCards */
@@ -4173,67 +4221,67 @@ export type LayoutContact = {
   /** Contacts */
   contacts?: Maybe<Array<Maybe<Contact>>>;
   /** Description */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutContent */
 export type LayoutContent = {
   __typename?: 'LayoutContent';
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Title */
-  content?: Maybe<Scalars['String']>;
+  content?: Maybe<Scalars['String']['output']>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutLinkList */
 export type LayoutLinkList = {
   __typename?: 'LayoutLinkList';
   /** Anchor */
-  anchor?: Maybe<Scalars['String']>;
+  anchor?: Maybe<Scalars['String']['output']>;
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Title */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Links */
   links?: Maybe<Array<Maybe<Link>>>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutPages */
 export type LayoutPages = {
   __typename?: 'LayoutPages';
   /** Anchor */
-  anchor?: Maybe<Scalars['String']>;
+  anchor?: Maybe<Scalars['String']['output']>;
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Description */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Pages */
   pages?: Maybe<Array<Maybe<Page>>>;
   /** Show all -link */
-  showAllLink?: Maybe<Scalars['String']>;
+  showAllLink?: Maybe<Scalars['String']['output']>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutPagesCarousel */
 export type LayoutPagesCarousel = {
   __typename?: 'LayoutPagesCarousel';
   /** Anchor */
-  anchor?: Maybe<Scalars['String']>;
+  anchor?: Maybe<Scalars['String']['output']>;
   /** Background Color */
-  backgroundColor?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Description */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Pages */
   pages?: Maybe<Array<Maybe<Page>>>;
   /** Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 export type LegalEntity = Organisation | Person;
@@ -4242,67 +4290,67 @@ export type LegalEntity = Organisation | Person;
 export type Link = {
   __typename?: 'Link';
   /** The target of the link */
-  target?: Maybe<Scalars['String']>;
+  target?: Maybe<Scalars['String']['output']>;
   /** The title of the link */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
   /** The url of the link */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export type LinkedeventsPlace = {
   __typename?: 'LinkedeventsPlace';
-  _at_context?: Maybe<Scalars['String']>;
-  _at_id?: Maybe<Scalars['String']>;
-  _at_type?: Maybe<Scalars['String']>;
-  address_country?: Maybe<Scalars['String']>;
+  _at_context?: Maybe<Scalars['String']['output']>;
+  _at_id?: Maybe<Scalars['String']['output']>;
+  _at_type?: Maybe<Scalars['String']['output']>;
+  address_country?: Maybe<Scalars['String']['output']>;
   address_locality?: Maybe<LinkedeventsPlaceLocalityString>;
-  address_region?: Maybe<Scalars['String']>;
-  contact_type?: Maybe<Scalars['String']>;
-  created_time?: Maybe<Scalars['String']>;
-  custom_data?: Maybe<Scalars['String']>;
-  data_source?: Maybe<Scalars['String']>;
-  deleted?: Maybe<Scalars['Boolean']>;
+  address_region?: Maybe<Scalars['String']['output']>;
+  contact_type?: Maybe<Scalars['String']['output']>;
+  created_time?: Maybe<Scalars['String']['output']>;
+  custom_data?: Maybe<Scalars['String']['output']>;
+  data_source?: Maybe<Scalars['String']['output']>;
+  deleted?: Maybe<Scalars['Boolean']['output']>;
   description?: Maybe<LinkedeventsPlaceLocalityString>;
   divisions?: Maybe<Array<Maybe<LinkedeventsPlaceDivision>>>;
-  email?: Maybe<Scalars['String']>;
-  has_upcoming_events?: Maybe<Scalars['Boolean']>;
-  id?: Maybe<Scalars['String']>;
-  image?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']['output']>;
+  has_upcoming_events?: Maybe<Scalars['Boolean']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  image?: Maybe<Scalars['String']['output']>;
   info_url?: Maybe<LinkedeventsPlaceLocalityString>;
-  last_modified_time?: Maybe<Scalars['String']>;
-  n_events?: Maybe<Scalars['Int']>;
+  last_modified_time?: Maybe<Scalars['String']['output']>;
+  n_events?: Maybe<Scalars['Int']['output']>;
   name?: Maybe<LinkedeventsPlaceLocalityString>;
   /** Raw Linkedevents Place fields */
-  origin?: Maybe<Scalars['String']>;
-  parent?: Maybe<Scalars['String']>;
+  origin?: Maybe<Scalars['String']['output']>;
+  parent?: Maybe<Scalars['String']['output']>;
   position?: Maybe<LinkedeventsPlacePosition>;
-  post_office_box_num?: Maybe<Scalars['String']>;
-  postal_code?: Maybe<Scalars['String']>;
-  publisher?: Maybe<Scalars['String']>;
-  replaced_by?: Maybe<Scalars['String']>;
+  post_office_box_num?: Maybe<Scalars['String']['output']>;
+  postal_code?: Maybe<Scalars['String']['output']>;
+  publisher?: Maybe<Scalars['String']['output']>;
+  replaced_by?: Maybe<Scalars['String']['output']>;
   street_address?: Maybe<LinkedeventsPlaceLocalityString>;
-  telephone?: Maybe<Scalars['String']>;
+  telephone?: Maybe<Scalars['String']['output']>;
 };
 
 export type LinkedeventsPlaceDivision = {
   __typename?: 'LinkedeventsPlaceDivision';
-  municipality?: Maybe<Scalars['String']>;
+  municipality?: Maybe<Scalars['String']['output']>;
   name?: Maybe<LinkedeventsPlaceLocalityString>;
-  ocd_id?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
+  ocd_id?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type LinkedeventsPlaceLocalityString = {
   __typename?: 'LinkedeventsPlaceLocalityString';
-  en?: Maybe<Scalars['String']>;
-  fi?: Maybe<Scalars['String']>;
-  sv?: Maybe<Scalars['String']>;
+  en?: Maybe<Scalars['String']['output']>;
+  fi?: Maybe<Scalars['String']['output']>;
+  sv?: Maybe<Scalars['String']['output']>;
 };
 
 export type LinkedeventsPlacePosition = {
   __typename?: 'LinkedeventsPlacePosition';
-  coordinates?: Maybe<Array<Maybe<Scalars['Float']>>>;
-  type?: Maybe<Scalars['String']>;
+  coordinates?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type LocalizedCmsImage = {
@@ -4314,16 +4362,16 @@ export type LocalizedCmsImage = {
 
 export type LocalizedCmsKeywords = {
   __typename?: 'LocalizedCmsKeywords';
-  en?: Maybe<Array<Maybe<Scalars['String']>>>;
-  fi?: Maybe<Array<Maybe<Scalars['String']>>>;
-  sv?: Maybe<Array<Maybe<Scalars['String']>>>;
+  en?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  fi?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  sv?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
 };
 
 export type LocalizedObject = {
   __typename?: 'LocalizedObject';
-  en?: Maybe<Scalars['String']>;
-  fi?: Maybe<Scalars['String']>;
-  sv?: Maybe<Scalars['String']>;
+  en?: Maybe<Scalars['String']['output']>;
+  fi?: Maybe<Scalars['String']['output']>;
+  sv?: Maybe<Scalars['String']['output']>;
 };
 
 /** Free-form location, not necessarily at a know venue. */
@@ -4331,7 +4379,7 @@ export type LocationDescription = {
   __typename?: 'LocationDescription';
   address?: Maybe<Address>;
   administrativeDivisions?: Maybe<Array<Maybe<AdministrativeDivision>>>;
-  explanation?: Maybe<Scalars['String']>;
+  explanation?: Maybe<Scalars['String']['output']>;
   geoLocation?: Maybe<GeoJsonFeature>;
   url?: Maybe<LanguageString>;
   venue?: Maybe<UnifiedSearchVenue>;
@@ -4340,48 +4388,48 @@ export type LocationDescription = {
 export type LocationImage = {
   __typename?: 'LocationImage';
   caption?: Maybe<LanguageString>;
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** Collection Module: LocationsSelected */
 export type LocationsSelected = {
   __typename?: 'LocationsSelected';
   /** List of location IDs */
-  locations?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  locations?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   /** Module type */
-  module?: Maybe<Scalars['String']>;
+  module?: Maybe<Scalars['String']['output']>;
   /** List of modules */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Module title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Collection Module: LocationsSelectedCarousel */
 export type LocationsSelectedCarousel = {
   __typename?: 'LocationsSelectedCarousel';
   /** List of location IDs */
-  locations?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  locations?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   /** Module type */
-  module?: Maybe<Scalars['String']>;
+  module?: Maybe<Scalars['String']['output']>;
   /** List of modules */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Module title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** File details for a Media Item */
 export type MediaDetails = {
   __typename?: 'MediaDetails';
   /** The filename of the mediaItem */
-  file?: Maybe<Scalars['String']>;
+  file?: Maybe<Scalars['String']['output']>;
   /** The height of the mediaItem */
-  height?: Maybe<Scalars['Int']>;
+  height?: Maybe<Scalars['Int']['output']>;
   /** Meta information associated with the mediaItem */
   meta?: Maybe<MediaItemMeta>;
   /** The available sizes of the mediaItem */
   sizes?: Maybe<Array<Maybe<MediaSize>>>;
   /** The width of the mediaItem */
-  width?: Maybe<Scalars['Int']>;
+  width?: Maybe<Scalars['Int']['output']>;
 };
 
 /** File details for a Media Item */
@@ -4402,120 +4450,120 @@ export type MediaItem = ContentNode &
   UniformResourceIdentifiable & {
     __typename?: 'MediaItem';
     /** Alternative text to display when resource is not displayed */
-    altText?: Maybe<Scalars['String']>;
+    altText?: Maybe<Scalars['String']['output']>;
     /** Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root). */
     ancestors?: Maybe<HierarchicalContentNodeToContentNodeAncestorsConnection>;
     /** Connection between the NodeWithAuthor type and the User type */
     author?: Maybe<NodeWithAuthorToUserConnectionEdge>;
     /** The database identifier of the author of the node */
-    authorDatabaseId?: Maybe<Scalars['Int']>;
+    authorDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the author of the node */
-    authorId?: Maybe<Scalars['ID']>;
+    authorId?: Maybe<Scalars['ID']['output']>;
     /** The caption for the resource */
-    caption?: Maybe<Scalars['String']>;
+    caption?: Maybe<Scalars['String']['output']>;
     /** Connection between the HierarchicalContentNode type and the ContentNode type */
     children?: Maybe<HierarchicalContentNodeToContentNodeChildrenConnection>;
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** Description of the image (stored as post_content) */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
     /** The filesize in bytes of the resource */
-    fileSize?: Maybe<Scalars['Int']>;
+    fileSize?: Maybe<Scalars['Int']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier of the attachment object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Polylang language */
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** Details about the mediaItem */
     mediaDetails?: Maybe<MediaDetails>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    mediaItemId: Scalars['Int'];
+    mediaItemId: Scalars['Int']['output'];
     /** Url of the mediaItem */
-    mediaItemUrl?: Maybe<Scalars['String']>;
+    mediaItemUrl?: Maybe<Scalars['String']['output']>;
     /** Type of resource */
-    mediaType?: Maybe<Scalars['String']>;
+    mediaType?: Maybe<Scalars['String']['output']>;
     /** The mime type of the mediaItem */
-    mimeType?: Maybe<Scalars['String']>;
+    mimeType?: Maybe<Scalars['String']['output']>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** The parent of the node. The parent object can be of various types */
     parent?: Maybe<HierarchicalContentNodeToParentContentNodeConnectionEdge>;
     /** Database id of the parent node */
-    parentDatabaseId?: Maybe<Scalars['Int']>;
+    parentDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the parent node. */
-    parentId?: Maybe<Scalars['ID']>;
+    parentId?: Maybe<Scalars['ID']['output']>;
     /** Valokuvaajan tiedot */
-    photographerName?: Maybe<Scalars['String']>;
+    photographerName?: Maybe<Scalars['String']['output']>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /** The SEO Framework data of the mediaItem */
     seo?: Maybe<Seo>;
     /** The sizes attribute value for an image. */
-    sizes?: Maybe<Scalars['String']>;
+    sizes?: Maybe<Scalars['String']['output']>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** Url of the mediaItem */
-    sourceUrl?: Maybe<Scalars['String']>;
+    sourceUrl?: Maybe<Scalars['String']['output']>;
     /** The srcset attribute specifies the URL of the image to use in different situations. It is a comma separated string of urls and their widths. */
-    srcSet?: Maybe<Scalars['String']>;
+    srcSet?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** The template assigned to a node of content */
     template?: Maybe<ContentTemplate>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<MediaItem>;
     /** List all translated versions of this post */
     translations?: Maybe<Array<Maybe<MediaItem>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The mediaItem type */
 export type MediaItemAncestorsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs>;
 };
 
@@ -4526,10 +4574,10 @@ export type MediaItemCaptionArgs = {
 
 /** The mediaItem type */
 export type MediaItemChildrenArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs>;
 };
 
@@ -4540,18 +4588,18 @@ export type MediaItemDescriptionArgs = {
 
 /** The mediaItem type */
 export type MediaItemEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The mediaItem type */
 export type MediaItemEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The mediaItem type */
@@ -4595,7 +4643,7 @@ export type MediaItemConnection = {
 /** Edge between a Node and a connected mediaItem */
 export type MediaItemConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected mediaItem Node */
   node: MediaItem;
 };
@@ -4618,29 +4666,29 @@ export enum MediaItemIdType {
 export type MediaItemMeta = {
   __typename?: 'MediaItemMeta';
   /** Aperture measurement of the media item. */
-  aperture?: Maybe<Scalars['Float']>;
+  aperture?: Maybe<Scalars['Float']['output']>;
   /** Information about the camera used to create the media item. */
-  camera?: Maybe<Scalars['String']>;
+  camera?: Maybe<Scalars['String']['output']>;
   /** The text string description associated with the media item. */
-  caption?: Maybe<Scalars['String']>;
+  caption?: Maybe<Scalars['String']['output']>;
   /** Copyright information associated with the media item. */
-  copyright?: Maybe<Scalars['String']>;
+  copyright?: Maybe<Scalars['String']['output']>;
   /** The date/time when the media was created. */
-  createdTimestamp?: Maybe<Scalars['Int']>;
+  createdTimestamp?: Maybe<Scalars['Int']['output']>;
   /** The original creator of the media item. */
-  credit?: Maybe<Scalars['String']>;
+  credit?: Maybe<Scalars['String']['output']>;
   /** The focal length value of the media item. */
-  focalLength?: Maybe<Scalars['Float']>;
+  focalLength?: Maybe<Scalars['Float']['output']>;
   /** The ISO (International Organization for Standardization) value of the media item. */
-  iso?: Maybe<Scalars['Int']>;
+  iso?: Maybe<Scalars['Int']['output']>;
   /** List of keywords used to describe or identfy the media item. */
-  keywords?: Maybe<Array<Maybe<Scalars['String']>>>;
+  keywords?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The vertical or horizontal aspect of the media item. */
-  orientation?: Maybe<Scalars['String']>;
+  orientation?: Maybe<Scalars['String']['output']>;
   /** The shutter speed information of the media item. */
-  shutterSpeed?: Maybe<Scalars['Float']>;
+  shutterSpeed?: Maybe<Scalars['Float']['output']>;
   /** A useful title for the media item. */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** The size of the media item object. */
@@ -4675,26 +4723,26 @@ export enum MediaItemStatusEnum {
 export type MediaResource = {
   __typename?: 'MediaResource';
   meta?: Maybe<NodeMeta>;
-  todo?: Maybe<Scalars['String']>;
+  todo?: Maybe<Scalars['String']['output']>;
 };
 
 /** Details of an available size for a media item */
 export type MediaSize = {
   __typename?: 'MediaSize';
   /** The filename of the referenced size */
-  file?: Maybe<Scalars['String']>;
+  file?: Maybe<Scalars['String']['output']>;
   /** The filesize of the resource */
-  fileSize?: Maybe<Scalars['Int']>;
+  fileSize?: Maybe<Scalars['Int']['output']>;
   /** The height of the referenced size */
-  height?: Maybe<Scalars['String']>;
+  height?: Maybe<Scalars['String']['output']>;
   /** The mime type of the referenced size */
-  mimeType?: Maybe<Scalars['String']>;
+  mimeType?: Maybe<Scalars['String']['output']>;
   /** The referenced size name */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** The url of the referenced size */
-  sourceUrl?: Maybe<Scalars['String']>;
+  sourceUrl?: Maybe<Scalars['String']['output']>;
   /** The width of the referenced size */
-  width?: Maybe<Scalars['String']>;
+  width?: Maybe<Scalars['String']['output']>;
 };
 
 /** Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme. */
@@ -4702,34 +4750,34 @@ export type Menu = DatabaseIdentifier &
   Node & {
     __typename?: 'Menu';
     /** The number of items in the menu */
-    count?: Maybe<Scalars['Int']>;
+    count?: Maybe<Scalars['Int']['output']>;
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** The globally unique identifier of the nav menu object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** The locations a menu is assigned to */
     locations?: Maybe<Array<Maybe<MenuLocationEnum>>>;
     /**
      * WP ID of the nav menu.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    menuId?: Maybe<Scalars['Int']>;
+    menuId?: Maybe<Scalars['Int']['output']>;
     /** Connection between the Menu type and the MenuItem type */
     menuItems?: Maybe<MenuToMenuItemConnection>;
     /** Display name of the menu. Equivalent to WP_Term-&gt;name. */
-    name?: Maybe<Scalars['String']>;
+    name?: Maybe<Scalars['String']['output']>;
     /** The url friendly name of the menu. Equivalent to WP_Term-&gt;slug */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
   };
 
 /** Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme. */
 export type MenuMenuItemsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<MenuToMenuItemConnectionWhereArgs>;
 };
 
@@ -4744,7 +4792,7 @@ export type MenuConnection = {
 /** Edge between a Node and a connected Menu */
 export type MenuConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected Menu Node */
   node: Menu;
 };
@@ -4763,19 +4811,19 @@ export type MenuItem = DatabaseIdentifier &
      */
     connectedObject?: Maybe<MenuItemObjectUnion>;
     /** Class attribute for the menu item link */
-    cssClasses?: Maybe<Array<Maybe<Scalars['String']>>>;
+    cssClasses?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Description of the menu item. */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier of the nav menu item object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Label or title of the menu item. */
-    label?: Maybe<Scalars['String']>;
+    label?: Maybe<Scalars['String']['output']>;
     /** Link relationship (XFN) of the menu item. */
-    linkRelationship?: Maybe<Scalars['String']>;
+    linkRelationship?: Maybe<Scalars['String']['output']>;
     /** The locations the menu item&#039;s Menu is assigned to */
     locations?: Maybe<Array<Maybe<MenuLocationEnum>>>;
     /** The Menu a MenuItem is part of */
@@ -4784,31 +4832,31 @@ export type MenuItem = DatabaseIdentifier &
      * WP ID of the menu item.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    menuItemId?: Maybe<Scalars['Int']>;
+    menuItemId?: Maybe<Scalars['Int']['output']>;
     /** Menu item order */
-    order?: Maybe<Scalars['Int']>;
+    order?: Maybe<Scalars['Int']['output']>;
     /** The database id of the parent menu item or null if it is the root */
-    parentDatabaseId?: Maybe<Scalars['Int']>;
+    parentDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the parent nav menu item object. */
-    parentId?: Maybe<Scalars['ID']>;
+    parentId?: Maybe<Scalars['ID']['output']>;
     /** Path for the resource. Relative path for internal resources. Absolute path for external resources. */
-    path?: Maybe<Scalars['String']>;
+    path?: Maybe<Scalars['String']['output']>;
     /** Target attribute for the menu item link. */
-    target?: Maybe<Scalars['String']>;
+    target?: Maybe<Scalars['String']['output']>;
     /** Title attribute for the menu item link */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** The uri of the resource the menu item links to */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
     /** URL or destination of the menu item. */
-    url?: Maybe<Scalars['String']>;
+    url?: Maybe<Scalars['String']['output']>;
   };
 
 /** Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu. */
 export type MenuItemChildItemsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<MenuItemToMenuItemConnectionWhereArgs>;
 };
 
@@ -4823,7 +4871,7 @@ export type MenuItemConnection = {
 /** Edge between a Node and a connected MenuItem */
 export type MenuItemConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected MenuItem Node */
   node: MenuItem;
 };
@@ -4831,21 +4879,21 @@ export type MenuItemConnectionEdge = {
 /** Nodes that can be linked to as Menu Items */
 export type MenuItemLinkable = {
   /** The unique identifier stored in the database */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
   /** The unique resource identifier path */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the node is a Content Node */
-  isContentNode: Scalars['Boolean'];
+  isContentNode: Scalars['Boolean']['output'];
   /** Whether the node is a Term */
-  isTermNode: Scalars['Boolean'];
+  isTermNode: Scalars['Boolean']['output'];
   /** The unique resource identifier path */
-  uri?: Maybe<Scalars['String']>;
+  uri?: Maybe<Scalars['String']['output']>;
 };
 
 /** Edge between a Node and a connected MenuItemLinkable */
 export type MenuItemLinkableConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected MenuItemLinkable Node */
   node: MenuItemLinkable;
 };
@@ -4867,7 +4915,7 @@ export type MenuItemToMenuConnectionEdge = Edge &
   OneToOneConnection & {
     __typename?: 'MenuItemToMenuConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Menu;
   };
@@ -4889,7 +4937,7 @@ export type MenuItemToMenuItemConnectionEdge = Edge &
   MenuItemConnectionEdge & {
     __typename?: 'MenuItemToMenuItemConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MenuItem;
   };
@@ -4897,13 +4945,13 @@ export type MenuItemToMenuItemConnectionEdge = Edge &
 /** Arguments for filtering the MenuItemToMenuItemConnection connection */
 export type MenuItemToMenuItemConnectionWhereArgs = {
   /** The database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** The menu location for the menu being queried */
   location?: InputMaybe<MenuLocationEnum>;
   /** The database ID of the parent menu object */
-  parentDatabaseId?: InputMaybe<Scalars['Int']>;
+  parentDatabaseId?: InputMaybe<Scalars['Int']['input']>;
   /** The ID of the parent menu object */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Connection between the MenuItem type and the MenuItemLinkable type */
@@ -4912,7 +4960,7 @@ export type MenuItemToMenuItemLinkableConnectionEdge = Edge &
   OneToOneConnection & {
     __typename?: 'MenuItemToMenuItemLinkableConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: MenuItemLinkable;
   };
@@ -4970,7 +5018,7 @@ export type MenuToMenuItemConnectionEdge = Edge &
   MenuItemConnectionEdge & {
     __typename?: 'MenuToMenuItemConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MenuItem;
   };
@@ -4978,20 +5026,20 @@ export type MenuToMenuItemConnectionEdge = Edge &
 /** Arguments for filtering the MenuToMenuItemConnection connection */
 export type MenuToMenuItemConnectionWhereArgs = {
   /** The database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** The menu location for the menu being queried */
   location?: InputMaybe<MenuLocationEnum>;
   /** The database ID of the parent menu object */
-  parentDatabaseId?: InputMaybe<Scalars['Int']>;
+  parentDatabaseId?: InputMaybe<Scalars['Int']['input']>;
   /** The ID of the parent menu object */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type Meta = {
   __typename?: 'Meta';
-  count: Scalars['Int'];
-  next?: Maybe<Scalars['String']>;
-  previous?: Maybe<Scalars['String']>;
+  count: Scalars['Int']['output'];
+  next?: Maybe<Scalars['String']['output']>;
+  previous?: Maybe<Scalars['String']['output']>;
 };
 
 /** The MimeType of the object */
@@ -5065,7 +5113,7 @@ export enum MimeTypeEnum {
 /** The root mutation */
 export type Mutation = {
   __typename?: 'Mutation';
-  _empty?: Maybe<Scalars['String']>;
+  _empty?: Maybe<Scalars['String']['output']>;
   /** The createCategory mutation */
   createCategory?: Maybe<CreateCategoryPayload>;
   /** The createCollection mutation */
@@ -5119,7 +5167,7 @@ export type Mutation = {
   /** The deleteUser mutation */
   deleteUser?: Maybe<DeleteUserPayload>;
   /** Increase the count. */
-  increaseCount?: Maybe<Scalars['Int']>;
+  increaseCount?: Maybe<Scalars['Int']['output']>;
   /** The registerUser mutation */
   registerUser?: Maybe<RegisterUserPayload>;
   /** The resetUserPassword mutation */
@@ -5290,7 +5338,7 @@ export type MutationDeleteUserArgs = {
 
 /** The root mutation */
 export type MutationIncreaseCountArgs = {
-  count?: InputMaybe<Scalars['Int']>;
+  count?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root mutation */
@@ -5385,7 +5433,7 @@ export type MutationUpdateUserArgs = {
 
 export type Neighborhood = {
   __typename?: 'Neighborhood';
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   name: LocalizedObject;
 };
 
@@ -5398,14 +5446,14 @@ export type NeighborhoodListResponse = {
 /** An object with an ID */
 export type Node = {
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
 };
 
 export type NodeMeta = {
   __typename?: 'NodeMeta';
-  createdAt?: Maybe<Scalars['DateTime']>;
-  id: Scalars['ID'];
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['ID']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 /** A node that can have an author assigned to it */
@@ -5413,11 +5461,11 @@ export type NodeWithAuthor = {
   /** Connection between the NodeWithAuthor type and the User type */
   author?: Maybe<NodeWithAuthorToUserConnectionEdge>;
   /** The database identifier of the author of the node */
-  authorDatabaseId?: Maybe<Scalars['Int']>;
+  authorDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** The globally unique identifier of the author of the node */
-  authorId?: Maybe<Scalars['ID']>;
+  authorId?: Maybe<Scalars['ID']['output']>;
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
 };
 
 /** Connection between the NodeWithAuthor type and the User type */
@@ -5426,7 +5474,7 @@ export type NodeWithAuthorToUserConnectionEdge = Edge &
   UserConnectionEdge & {
     __typename?: 'NodeWithAuthorToUserConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: User;
   };
@@ -5434,9 +5482,9 @@ export type NodeWithAuthorToUserConnectionEdge = Edge &
 /** A node that supports the content editor */
 export type NodeWithContentEditor = {
   /** The content of the post. */
-  content?: Maybe<Scalars['String']>;
+  content?: Maybe<Scalars['String']['output']>;
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
 };
 
 /** A node that supports the content editor */
@@ -5449,11 +5497,11 @@ export type NodeWithFeaturedImage = {
   /** Connection between the NodeWithFeaturedImage type and the MediaItem type */
   featuredImage?: Maybe<NodeWithFeaturedImageToMediaItemConnectionEdge>;
   /** The database identifier for the featured image node assigned to the content node */
-  featuredImageDatabaseId?: Maybe<Scalars['Int']>;
+  featuredImageDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** Globally unique ID of the featured image assigned to the node */
-  featuredImageId?: Maybe<Scalars['ID']>;
+  featuredImageId?: Maybe<Scalars['ID']['output']>;
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
 };
 
 /** Connection between the NodeWithFeaturedImage type and the MediaItem type */
@@ -5462,7 +5510,7 @@ export type NodeWithFeaturedImageToMediaItemConnectionEdge = Edge &
   OneToOneConnection & {
     __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: MediaItem;
   };
@@ -5470,17 +5518,17 @@ export type NodeWithFeaturedImageToMediaItemConnectionEdge = Edge &
 /** A node that can have page attributes */
 export type NodeWithPageAttributes = {
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: Maybe<Scalars['Int']>;
+  menuOrder?: Maybe<Scalars['Int']['output']>;
 };
 
 /** A node that can have revisions */
 export type NodeWithRevisions = {
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** True if the node is a revision of another node */
-  isRevision?: Maybe<Scalars['Boolean']>;
+  isRevision?: Maybe<Scalars['Boolean']['output']>;
   /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
   revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
 };
@@ -5492,7 +5540,7 @@ export type NodeWithRevisionsToContentNodeConnectionEdge =
     OneToOneConnection & {
       __typename?: 'NodeWithRevisionsToContentNodeConnectionEdge';
       /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-      cursor?: Maybe<Scalars['String']>;
+      cursor?: Maybe<Scalars['String']['output']>;
       /** The node of the connection, without the edges */
       node: ContentNode;
     };
@@ -5500,7 +5548,7 @@ export type NodeWithRevisionsToContentNodeConnectionEdge =
 /** A node that can have a template associated with it */
 export type NodeWithTemplate = {
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** The template assigned to the node */
   template?: Maybe<ContentTemplate>;
 };
@@ -5508,9 +5556,9 @@ export type NodeWithTemplate = {
 /** A node that NodeWith a title */
 export type NodeWithTitle = {
   /** The globally unique ID for the object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** A node that NodeWith a title */
@@ -5522,103 +5570,103 @@ export type NodeWithTitleTitleArgs = {
 export type Notification = {
   __typename?: 'Notification';
   /** Notification content */
-  content?: Maybe<Scalars['String']>;
+  content?: Maybe<Scalars['String']['output']>;
   /** Notification end date */
-  endDate?: Maybe<Scalars['String']>;
+  endDate?: Maybe<Scalars['String']['output']>;
   /** Notification level */
-  level?: Maybe<Scalars['String']>;
+  level?: Maybe<Scalars['String']['output']>;
   /** Notification link text */
-  linkText?: Maybe<Scalars['String']>;
+  linkText?: Maybe<Scalars['String']['output']>;
   /** Notification link url */
-  linkUrl?: Maybe<Scalars['String']>;
+  linkUrl?: Maybe<Scalars['String']['output']>;
   /** Notification start date */
-  startDate?: Maybe<Scalars['String']>;
+  startDate?: Maybe<Scalars['String']['output']>;
   /** Notification title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 export type Offer = {
   __typename?: 'Offer';
   description?: Maybe<LocalizedObject>;
   infoUrl?: Maybe<LocalizedObject>;
-  isFree?: Maybe<Scalars['Boolean']>;
+  isFree?: Maybe<Scalars['Boolean']['output']>;
   price?: Maybe<LocalizedObject>;
 };
 
 /** A singular connection from one Node to another, with support for relational data on the &quot;edge&quot; of the connection. */
 export type OneToOneConnection = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected node */
   node: Node;
 };
 
 export type Ontology = {
   __typename?: 'Ontology';
-  id?: Maybe<Scalars['Int']>;
-  label?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
 };
 
 export type OntologyTree = {
   __typename?: 'OntologyTree';
-  ancestorIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  childIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  id?: Maybe<Scalars['ID']>;
-  level?: Maybe<Scalars['Int']>;
+  ancestorIds?: Maybe<Array<Maybe<Scalars['ID']['output']>>>;
+  childIds?: Maybe<Array<Maybe<Scalars['ID']['output']>>>;
+  id?: Maybe<Scalars['ID']['output']>;
+  level?: Maybe<Scalars['Int']['output']>;
   name?: Maybe<LanguageString>;
-  parentId?: Maybe<Scalars['ID']>;
+  parentId?: Maybe<Scalars['ID']['output']>;
 };
 
 export type OntologyWord = {
   __typename?: 'OntologyWord';
-  id?: Maybe<Scalars['ID']>;
+  id?: Maybe<Scalars['ID']['output']>;
   label?: Maybe<LanguageString>;
 };
 
 export type Ontologyword = {
   __typename?: 'Ontologyword';
-  can_add_clarification?: Maybe<Scalars['Boolean']>;
-  can_add_schoolyear?: Maybe<Scalars['Boolean']>;
-  extra_searchwords_fi?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  ontologyword_en?: Maybe<Scalars['String']>;
-  ontologyword_fi?: Maybe<Scalars['String']>;
-  ontologyword_sv?: Maybe<Scalars['String']>;
-  unit_ids?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  can_add_clarification?: Maybe<Scalars['Boolean']['output']>;
+  can_add_schoolyear?: Maybe<Scalars['Boolean']['output']>;
+  extra_searchwords_fi?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  ontologyword_en?: Maybe<Scalars['String']['output']>;
+  ontologyword_fi?: Maybe<Scalars['String']['output']>;
+  ontologyword_sv?: Maybe<Scalars['String']['output']>;
+  unit_ids?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
 };
 
 export type OpeningHour = {
   __typename?: 'OpeningHour';
-  date: Scalars['String'];
+  date: Scalars['String']['output'];
   times: Array<Time>;
 };
 
 export type OpeningHours = {
   __typename?: 'OpeningHours';
   data?: Maybe<Array<Maybe<OpeningHoursDay>>>;
-  is_open_now_url?: Maybe<Scalars['String']>;
+  is_open_now_url?: Maybe<Scalars['String']['output']>;
   today?: Maybe<Array<Maybe<OpeningHoursTimes>>>;
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export type OpeningHoursDay = {
   __typename?: 'OpeningHoursDay';
-  date?: Maybe<Scalars['String']>;
+  date?: Maybe<Scalars['String']['output']>;
   times?: Maybe<Array<Maybe<OpeningHoursTimes>>>;
 };
 
 export type OpeningHoursTimes = {
   __typename?: 'OpeningHoursTimes';
-  endTime?: Maybe<Scalars['String']>;
-  endTimeOnNextDay?: Maybe<Scalars['Boolean']>;
-  fullDay?: Maybe<Scalars['Boolean']>;
-  resourceState?: Maybe<Scalars['String']>;
-  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']['output']>;
+  endTimeOnNextDay?: Maybe<Scalars['Boolean']['output']>;
+  fullDay?: Maybe<Scalars['Boolean']['output']>;
+  resourceState?: Maybe<Scalars['String']['output']>;
+  startTime?: Maybe<Scalars['String']['output']>;
 };
 
 export type OrderByDistance = {
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
   order?: InputMaybe<SortOrder>;
 };
 
@@ -5643,22 +5691,22 @@ export type Organisation = {
 
 export type OrganizationDetails = {
   __typename?: 'OrganizationDetails';
-  affiliatedOrganizations?: Maybe<Array<Maybe<Scalars['String']>>>;
-  classification?: Maybe<Scalars['String']>;
-  createdTime?: Maybe<Scalars['String']>;
-  dataSource?: Maybe<Scalars['String']>;
-  dissolutionDate?: Maybe<Scalars['String']>;
-  foundingDate?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId: Scalars['String'];
-  internalType?: Maybe<Scalars['String']>;
-  isAffiliated: Scalars['Boolean'];
-  lastModifiedTime?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  parentOrganization?: Maybe<Scalars['String']>;
-  replacedBy?: Maybe<Scalars['String']>;
-  subOrganizations?: Maybe<Array<Maybe<Scalars['String']>>>;
+  affiliatedOrganizations?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  classification?: Maybe<Scalars['String']['output']>;
+  createdTime?: Maybe<Scalars['String']['output']>;
+  dataSource?: Maybe<Scalars['String']['output']>;
+  dissolutionDate?: Maybe<Scalars['String']['output']>;
+  foundingDate?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId: Scalars['String']['output'];
+  internalType?: Maybe<Scalars['String']['output']>;
+  isAffiliated: Scalars['Boolean']['output'];
+  lastModifiedTime?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  parentOrganization?: Maybe<Scalars['String']['output']>;
+  replacedBy?: Maybe<Scalars['String']['output']>;
+  subOrganizations?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
 };
 
 /** The page type */
@@ -5683,96 +5731,96 @@ export type Page = ContentNode &
     /** Connection between the NodeWithAuthor type and the User type */
     author?: Maybe<NodeWithAuthorToUserConnectionEdge>;
     /** The database identifier of the author of the node */
-    authorDatabaseId?: Maybe<Scalars['Int']>;
+    authorDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the author of the node */
-    authorId?: Maybe<Scalars['ID']>;
+    authorId?: Maybe<Scalars['ID']['output']>;
     /** Connection between the HierarchicalContentNode type and the ContentNode type */
     children?: Maybe<HierarchicalContentNodeToContentNodeChildrenConnection>;
     /** The content of the post. */
-    content?: Maybe<Scalars['String']>;
+    content?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
     /** Vanhentumisaika */
-    expirationTime?: Maybe<Scalars['String']>;
+    expirationTime?: Maybe<Scalars['String']['output']>;
     /** Connection between the NodeWithFeaturedImage type and the MediaItem type */
     featuredImage?: Maybe<NodeWithFeaturedImageToMediaItemConnectionEdge>;
     /** The database identifier for the featured image node assigned to the content node */
-    featuredImageDatabaseId?: Maybe<Scalars['Int']>;
+    featuredImageDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Globally unique ID of the featured image assigned to the node */
-    featuredImageId?: Maybe<Scalars['ID']>;
+    featuredImageId?: Maybe<Scalars['ID']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** Hero fields */
     hero?: Maybe<Hero>;
     /** The globally unique identifier of the page object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether this page is set to the static front page. */
-    isFrontPage: Scalars['Boolean'];
+    isFrontPage: Scalars['Boolean']['output'];
     /** Whether this page is set to the blog posts page. */
-    isPostsPage: Scalars['Boolean'];
+    isPostsPage: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether this page is set to the privacy page. */
-    isPrivacyPage: Scalars['Boolean'];
+    isPrivacyPage: Scalars['Boolean']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** True if the node is a revision of another node */
-    isRevision?: Maybe<Scalars['Boolean']>;
+    isRevision?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Polylang language */
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** Ingressi */
-    lead?: Maybe<Scalars['String']>;
+    lead?: Maybe<Scalars['String']['output']>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-    menuOrder?: Maybe<Scalars['Int']>;
+    menuOrder?: Maybe<Scalars['Int']['output']>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** List of modules */
     modules?: Maybe<Array<Maybe<PageModulesUnionType>>>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    pageId: Scalars['Int'];
+    pageId: Scalars['Int']['output'];
     /** The parent of the node. The parent object can be of various types */
     parent?: Maybe<HierarchicalContentNodeToParentContentNodeConnectionEdge>;
     /** Database id of the parent node */
-    parentDatabaseId?: Maybe<Scalars['Int']>;
+    parentDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the parent node. */
-    parentId?: Maybe<Scalars['ID']>;
+    parentId?: Maybe<Scalars['ID']['output']>;
     /** Connection between the Page type and the page type */
     preview?: Maybe<PageToPreviewConnectionEdge>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
     revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
     /** Connection between the Page type and the page type */
@@ -5780,40 +5828,40 @@ export type Page = ContentNode &
     /** The SEO Framework data of the page */
     seo?: Maybe<Seo>;
     /** Näytä alisivut */
-    showChildPages?: Maybe<Scalars['Boolean']>;
+    showChildPages?: Maybe<Scalars['Boolean']['output']>;
     /** List of modules */
     sidebar?: Maybe<Array<Maybe<PageSidebarUnionType>>>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** The template assigned to a node of content */
     template?: Maybe<ContentTemplate>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<Page>;
     /** List all translated versions of this post */
     translations?: Maybe<Array<Maybe<Page>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The page type */
 export type PageAncestorsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs>;
 };
 
 /** The page type */
 export type PageChildrenArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs>;
 };
 
@@ -5824,26 +5872,26 @@ export type PageContentArgs = {
 
 /** The page type */
 export type PageEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The page type */
 export type PageEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The page type */
 export type PageRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PageToRevisionConnectionWhereArgs>;
 };
 
@@ -5868,7 +5916,7 @@ export type PageConnection = {
 /** Edge between a Node and a connected page */
 export type PageConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected page Node */
   node: Page;
 };
@@ -5912,7 +5960,7 @@ export type PageToPreviewConnectionEdge = Edge &
   PageConnectionEdge & {
     __typename?: 'PageToPreviewConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Page;
   };
@@ -5934,7 +5982,7 @@ export type PageToRevisionConnectionEdge = Edge &
   PageConnectionEdge & {
     __typename?: 'PageToRevisionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Page;
   };
@@ -5942,98 +5990,98 @@ export type PageToRevisionConnectionEdge = Edge &
 /** Arguments for filtering the PageToRevisionConnection connection */
 export type PageToRevisionConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type PalvelukarttaUnit = {
   __typename?: 'PalvelukarttaUnit';
-  accessibility_viewpoints?: Maybe<Scalars['String']>;
-  address_city_en?: Maybe<Scalars['String']>;
-  address_city_fi?: Maybe<Scalars['String']>;
-  address_city_sv?: Maybe<Scalars['String']>;
-  address_zip?: Maybe<Scalars['String']>;
-  call_charge_info_en?: Maybe<Scalars['String']>;
-  call_charge_info_fi?: Maybe<Scalars['String']>;
-  call_charge_info_sv?: Maybe<Scalars['String']>;
-  created_time?: Maybe<Scalars['String']>;
-  data_source_url?: Maybe<Scalars['String']>;
-  dept_id?: Maybe<Scalars['String']>;
-  desc_en?: Maybe<Scalars['String']>;
-  desc_fi?: Maybe<Scalars['String']>;
-  desc_sv?: Maybe<Scalars['String']>;
-  easting_etrs_gk25?: Maybe<Scalars['Int']>;
-  easting_etrs_tm35fin?: Maybe<Scalars['Int']>;
-  extra_searchwords_en?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  latitude?: Maybe<Scalars['Float']>;
-  longitude?: Maybe<Scalars['Float']>;
-  manual_coordinates?: Maybe<Scalars['Boolean']>;
-  modified_time?: Maybe<Scalars['String']>;
-  name_en?: Maybe<Scalars['String']>;
-  name_fi?: Maybe<Scalars['String']>;
-  name_sv?: Maybe<Scalars['String']>;
-  northing_etrs_gk25?: Maybe<Scalars['Int']>;
-  northing_etrs_tm35fin?: Maybe<Scalars['Int']>;
-  ontologytree_ids?: Maybe<Array<Maybe<Scalars['Int']>>>;
-  ontologyword_ids?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  accessibility_viewpoints?: Maybe<Scalars['String']['output']>;
+  address_city_en?: Maybe<Scalars['String']['output']>;
+  address_city_fi?: Maybe<Scalars['String']['output']>;
+  address_city_sv?: Maybe<Scalars['String']['output']>;
+  address_zip?: Maybe<Scalars['String']['output']>;
+  call_charge_info_en?: Maybe<Scalars['String']['output']>;
+  call_charge_info_fi?: Maybe<Scalars['String']['output']>;
+  call_charge_info_sv?: Maybe<Scalars['String']['output']>;
+  created_time?: Maybe<Scalars['String']['output']>;
+  data_source_url?: Maybe<Scalars['String']['output']>;
+  dept_id?: Maybe<Scalars['String']['output']>;
+  desc_en?: Maybe<Scalars['String']['output']>;
+  desc_fi?: Maybe<Scalars['String']['output']>;
+  desc_sv?: Maybe<Scalars['String']['output']>;
+  easting_etrs_gk25?: Maybe<Scalars['Int']['output']>;
+  easting_etrs_tm35fin?: Maybe<Scalars['Int']['output']>;
+  extra_searchwords_en?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  manual_coordinates?: Maybe<Scalars['Boolean']['output']>;
+  modified_time?: Maybe<Scalars['String']['output']>;
+  name_en?: Maybe<Scalars['String']['output']>;
+  name_fi?: Maybe<Scalars['String']['output']>;
+  name_sv?: Maybe<Scalars['String']['output']>;
+  northing_etrs_gk25?: Maybe<Scalars['Int']['output']>;
+  northing_etrs_tm35fin?: Maybe<Scalars['Int']['output']>;
+  ontologytree_ids?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
+  ontologyword_ids?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   ontologyword_ids_enriched?: Maybe<Array<Maybe<Ontologyword>>>;
-  org_id?: Maybe<Scalars['String']>;
-  organizer_name?: Maybe<Scalars['String']>;
-  organizer_type?: Maybe<Scalars['String']>;
+  org_id?: Maybe<Scalars['String']['output']>;
+  organizer_name?: Maybe<Scalars['String']['output']>;
+  organizer_type?: Maybe<Scalars['String']['output']>;
   /** Raw palvelukartta Unit fields */
-  origin?: Maybe<Scalars['String']>;
-  phone?: Maybe<Scalars['String']>;
-  picture_caption_en?: Maybe<Scalars['String']>;
-  picture_caption_fi?: Maybe<Scalars['String']>;
-  picture_caption_sv?: Maybe<Scalars['String']>;
-  picture_url?: Maybe<Scalars['String']>;
-  provider_type?: Maybe<Scalars['String']>;
-  street_address_en?: Maybe<Scalars['String']>;
-  street_address_fi?: Maybe<Scalars['String']>;
-  street_address_sv?: Maybe<Scalars['String']>;
-  www_en?: Maybe<Scalars['String']>;
-  www_fi?: Maybe<Scalars['String']>;
-  www_sv?: Maybe<Scalars['String']>;
+  origin?: Maybe<Scalars['String']['output']>;
+  phone?: Maybe<Scalars['String']['output']>;
+  picture_caption_en?: Maybe<Scalars['String']['output']>;
+  picture_caption_fi?: Maybe<Scalars['String']['output']>;
+  picture_caption_sv?: Maybe<Scalars['String']['output']>;
+  picture_url?: Maybe<Scalars['String']['output']>;
+  provider_type?: Maybe<Scalars['String']['output']>;
+  street_address_en?: Maybe<Scalars['String']['output']>;
+  street_address_fi?: Maybe<Scalars['String']['output']>;
+  street_address_sv?: Maybe<Scalars['String']['output']>;
+  www_en?: Maybe<Scalars['String']['output']>;
+  www_fi?: Maybe<Scalars['String']['output']>;
+  www_sv?: Maybe<Scalars['String']['output']>;
 };
 
 /** TODO: take from Profile */
@@ -6042,46 +6090,46 @@ export type Person = {
   contactDetails?: Maybe<ContactInfo>;
   identificationStrength?: Maybe<IdentificationStrength>;
   meta?: Maybe<NodeMeta>;
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   preferredLanguages?: Maybe<Array<UnifiedSearchLanguageEnum>>;
   preferredMedium?: Maybe<ContactMedium>;
 };
 
 export type PhoneNumber = {
   __typename?: 'PhoneNumber';
-  countryCode: Scalars['String'];
-  restNumber: Scalars['String'];
+  countryCode: Scalars['String']['output'];
+  restNumber: Scalars['String']['output'];
 };
 
 export type Place = {
   __typename?: 'Place';
-  addressCountry?: Maybe<Scalars['String']>;
+  addressCountry?: Maybe<Scalars['String']['output']>;
   addressLocality?: Maybe<LocalizedObject>;
-  addressRegion?: Maybe<Scalars['String']>;
-  contactType?: Maybe<Scalars['String']>;
-  createdTime?: Maybe<Scalars['String']>;
-  customData?: Maybe<Scalars['String']>;
-  dataSource?: Maybe<Scalars['String']>;
-  deleted?: Maybe<Scalars['Boolean']>;
-  description?: Maybe<Scalars['String']>;
+  addressRegion?: Maybe<Scalars['String']['output']>;
+  contactType?: Maybe<Scalars['String']['output']>;
+  createdTime?: Maybe<Scalars['String']['output']>;
+  customData?: Maybe<Scalars['String']['output']>;
+  dataSource?: Maybe<Scalars['String']['output']>;
+  deleted?: Maybe<Scalars['Boolean']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
   divisions?: Maybe<Array<Division>>;
-  email?: Maybe<Scalars['String']>;
-  hasUpcomingEvents?: Maybe<Scalars['Boolean']>;
-  id?: Maybe<Scalars['ID']>;
+  email?: Maybe<Scalars['String']['output']>;
+  hasUpcomingEvents?: Maybe<Scalars['Boolean']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
   image?: Maybe<Image>;
   infoUrl?: Maybe<LocalizedObject>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId: Scalars['String'];
-  internalType?: Maybe<Scalars['String']>;
-  lastModifiedTime?: Maybe<Scalars['String']>;
-  nEvents?: Maybe<Scalars['Int']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId: Scalars['String']['output'];
+  internalType?: Maybe<Scalars['String']['output']>;
+  lastModifiedTime?: Maybe<Scalars['String']['output']>;
+  nEvents?: Maybe<Scalars['Int']['output']>;
   name?: Maybe<LocalizedObject>;
-  parent?: Maybe<Scalars['ID']>;
+  parent?: Maybe<Scalars['ID']['output']>;
   position?: Maybe<PlacePosition>;
-  postOfficeBoxNum?: Maybe<Scalars['String']>;
-  postalCode?: Maybe<Scalars['String']>;
-  publisher?: Maybe<Scalars['ID']>;
-  replacedBy?: Maybe<Scalars['String']>;
+  postOfficeBoxNum?: Maybe<Scalars['String']['output']>;
+  postalCode?: Maybe<Scalars['String']['output']>;
+  publisher?: Maybe<Scalars['ID']['output']>;
+  replacedBy?: Maybe<Scalars['String']['output']>;
   streetAddress?: Maybe<LocalizedObject>;
   telephone?: Maybe<LocalizedObject>;
 };
@@ -6094,31 +6142,31 @@ export type PlaceListResponse = {
 
 export type PlacePosition = {
   __typename?: 'PlacePosition';
-  coordinates: Array<Scalars['Float']>;
-  type: Scalars['String'];
+  coordinates: Array<Scalars['Float']['output']>;
+  type: Scalars['String']['output'];
 };
 
 /** An plugin object */
 export type Plugin = Node & {
   __typename?: 'Plugin';
   /** Name of the plugin author(s), may also be a company name. */
-  author?: Maybe<Scalars['String']>;
+  author?: Maybe<Scalars['String']['output']>;
   /** URI for the related author(s)/company website. */
-  authorUri?: Maybe<Scalars['String']>;
+  authorUri?: Maybe<Scalars['String']['output']>;
   /** Description of the plugin. */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** The globally unique identifier of the plugin object. */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Display name of the plugin. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** Plugin path. */
-  path?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']['output']>;
   /** URI for the plugin website. This is useful for directing users for support requests etc. */
-  pluginUri?: Maybe<Scalars['String']>;
+  pluginUri?: Maybe<Scalars['String']['output']>;
   /** Current version of the plugin. */
-  version?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['String']['output']>;
 };
 
 /** Connection to Plugin Nodes */
@@ -6132,7 +6180,7 @@ export type PluginConnection = {
 /** Edge between a Node and a connected Plugin */
 export type PluginConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected Plugin Node */
   node: Plugin;
 };
@@ -6161,8 +6209,8 @@ export enum PluginStatusEnum {
 
 export type Point = {
   __typename?: 'Point';
-  coordinates: Array<Scalars['Float']>;
-  type?: Maybe<Scalars['String']>;
+  coordinates: Array<Scalars['Float']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 /** The post type */
@@ -6182,71 +6230,71 @@ export type Post = ContentNode &
     /** Connection between the NodeWithAuthor type and the User type */
     author?: Maybe<NodeWithAuthorToUserConnectionEdge>;
     /** The database identifier of the author of the node */
-    authorDatabaseId?: Maybe<Scalars['Int']>;
+    authorDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the author of the node */
-    authorId?: Maybe<Scalars['ID']>;
+    authorId?: Maybe<Scalars['ID']['output']>;
     /** Connection between the Post type and the category type */
     categories?: Maybe<PostToCategoryConnection>;
     /** The content of the post. */
-    content?: Maybe<Scalars['String']>;
+    content?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
     /** Vanhentumisaika */
-    expirationTime?: Maybe<Scalars['String']>;
+    expirationTime?: Maybe<Scalars['String']['output']>;
     /** Connection between the NodeWithFeaturedImage type and the MediaItem type */
     featuredImage?: Maybe<NodeWithFeaturedImageToMediaItemConnectionEdge>;
     /** The database identifier for the featured image node assigned to the content node */
-    featuredImageDatabaseId?: Maybe<Scalars['Int']>;
+    featuredImageDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Globally unique ID of the featured image assigned to the node */
-    featuredImageId?: Maybe<Scalars['ID']>;
+    featuredImageId?: Maybe<Scalars['ID']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** Hide Published Date */
-    hidePublishedDate?: Maybe<Scalars['Boolean']>;
+    hidePublishedDate?: Maybe<Scalars['Boolean']['output']>;
     /** The globally unique identifier of the post object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** True if the node is a revision of another node */
-    isRevision?: Maybe<Scalars['Boolean']>;
+    isRevision?: Maybe<Scalars['Boolean']['output']>;
     /** Whether this page is sticky */
-    isSticky: Scalars['Boolean'];
+    isSticky: Scalars['Boolean']['output'];
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Polylang language */
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** Ingressi */
-    lead?: Maybe<Scalars['String']>;
+    lead?: Maybe<Scalars['String']['output']>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** List of modules */
     modules?: Maybe<Array<Maybe<PostModulesUnionType>>>;
     /** Connection between the Post type and the postFormat type */
@@ -6255,13 +6303,13 @@ export type Post = ContentNode &
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    postId: Scalars['Int'];
+    postId: Scalars['Int']['output'];
     /** Connection between the Post type and the post type */
     preview?: Maybe<PostToPreviewConnectionEdge>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
     revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
     /** Connection between the Post type and the post type */
@@ -6271,9 +6319,9 @@ export type Post = ContentNode &
     /** List of modules */
     sidebar?: Maybe<Array<Maybe<PostSidebarUnionType>>>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** Connection between the Post type and the tag type */
     tags?: Maybe<PostToTagConnection>;
     /** The template assigned to the node */
@@ -6281,21 +6329,21 @@ export type Post = ContentNode &
     /** Connection between the Post type and the TermNode type */
     terms?: Maybe<PostToTermNodeConnection>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<Post>;
     /** List all translated versions of this post */
     translations?: Maybe<Array<Maybe<Post>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The post type */
 export type PostCategoriesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PostToCategoryConnectionWhereArgs>;
 };
 
@@ -6306,53 +6354,53 @@ export type PostContentArgs = {
 
 /** The post type */
 export type PostEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The post type */
 export type PostEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The post type */
 export type PostPostFormatsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PostToPostFormatConnectionWhereArgs>;
 };
 
 /** The post type */
 export type PostRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PostToRevisionConnectionWhereArgs>;
 };
 
 /** The post type */
 export type PostTagsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PostToTagConnectionWhereArgs>;
 };
 
 /** The post type */
 export type PostTermsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PostToTermNodeConnectionWhereArgs>;
 };
 
@@ -6369,7 +6417,7 @@ export type PostTranslationArgs = {
 /** Set relationships between the post to categories */
 export type PostCategoriesInput = {
   /** If true, this will append the category to existing related categories. If false, this will replace existing relationships. Default true. */
-  append?: InputMaybe<Scalars['Boolean']>;
+  append?: InputMaybe<Scalars['Boolean']['input']>;
   /** The input list of items to set. */
   nodes?: InputMaybe<Array<InputMaybe<PostCategoriesNodeInput>>>;
 };
@@ -6377,13 +6425,13 @@ export type PostCategoriesInput = {
 /** List of categories to connect the post to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists. */
 export type PostCategoriesNodeInput = {
   /** The description of the category. This field is used to set a description of the category if a new one is created during the mutation. */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the category. If present, this will be used to connect to the post. If no existing category exists with this ID, no connection will be made. */
-  id?: InputMaybe<Scalars['ID']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** The name of the category. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field. */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the category. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection to post Nodes */
@@ -6397,7 +6445,7 @@ export type PostConnection = {
 /** Edge between a Node and a connected post */
 export type PostConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected post Node */
   node: Post;
 };
@@ -6411,79 +6459,79 @@ export type PostFormat = DatabaseIdentifier &
     /** Connection between the PostFormat type and the ContentNode type */
     contentNodes?: Maybe<PostFormatToContentNodeConnection>;
     /** The number of objects connected to the object */
-    count?: Maybe<Scalars['Int']>;
+    count?: Maybe<Scalars['Int']['output']>;
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** The description of the object */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** Connection between the TermNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<TermNodeToEnqueuedScriptConnection>;
     /** Connection between the TermNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<TermNodeToEnqueuedStylesheetConnection>;
     /** The unique resource identifier path */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** The link to the term */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The human friendly name of the object. */
-    name?: Maybe<Scalars['String']>;
+    name?: Maybe<Scalars['String']['output']>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of databaseId
      */
-    postFormatId?: Maybe<Scalars['Int']>;
+    postFormatId?: Maybe<Scalars['Int']['output']>;
     /** Connection between the PostFormat type and the post type */
     posts?: Maybe<PostFormatToPostConnection>;
     /** An alphanumeric identifier for the object unique to its type. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** Connection between the PostFormat type and the Taxonomy type */
     taxonomy?: Maybe<PostFormatToTaxonomyConnectionEdge>;
     /** The name of the taxonomy that the object is associated with */
-    taxonomyName?: Maybe<Scalars['String']>;
+    taxonomyName?: Maybe<Scalars['String']['output']>;
     /** The ID of the term group that this term object belongs to */
-    termGroupId?: Maybe<Scalars['Int']>;
+    termGroupId?: Maybe<Scalars['Int']['output']>;
     /** The taxonomy ID that the object is associated with */
-    termTaxonomyId?: Maybe<Scalars['Int']>;
+    termTaxonomyId?: Maybe<Scalars['Int']['output']>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The postFormat type */
 export type PostFormatContentNodesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PostFormatToContentNodeConnectionWhereArgs>;
 };
 
 /** The postFormat type */
 export type PostFormatEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The postFormat type */
 export type PostFormatEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The postFormat type */
 export type PostFormatPostsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PostFormatToPostConnectionWhereArgs>;
 };
 
@@ -6498,7 +6546,7 @@ export type PostFormatConnection = {
 /** Edge between a Node and a connected postFormat */
 export type PostFormatConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected postFormat Node */
   node: PostFormat;
 };
@@ -6534,7 +6582,7 @@ export type PostFormatToContentNodeConnectionEdge = ContentNodeConnectionEdge &
   Edge & {
     __typename?: 'PostFormatToContentNodeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentNode;
   };
@@ -6546,37 +6594,37 @@ export type PostFormatToContentNodeConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the PostFormat type and the post type */
@@ -6596,7 +6644,7 @@ export type PostFormatToPostConnectionEdge = Edge &
   PostConnectionEdge & {
     __typename?: 'PostFormatToPostConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Post;
   };
@@ -6604,67 +6652,67 @@ export type PostFormatToPostConnectionEdge = Edge &
 /** Arguments for filtering the PostFormatToPostConnection connection */
 export type PostFormatToPostConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Category ID */
-  categoryId?: InputMaybe<Scalars['Int']>;
+  categoryId?: InputMaybe<Scalars['Int']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Use Category Slug */
-  categoryName?: InputMaybe<Scalars['String']>;
+  categoryName?: InputMaybe<Scalars['String']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Tag Slug */
-  tag?: InputMaybe<Scalars['String']>;
+  tag?: InputMaybe<Scalars['String']['input']>;
   /** Use Tag ID */
-  tagId?: InputMaybe<Scalars['String']>;
+  tagId?: InputMaybe<Scalars['String']['input']>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag slugs, used to display objects from one tag AND another */
-  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of tag slugs, used to include objects in ANY specified tags */
-  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the PostFormat type and the Taxonomy type */
@@ -6673,7 +6721,7 @@ export type PostFormatToTaxonomyConnectionEdge = Edge &
   TaxonomyConnectionEdge & {
     __typename?: 'PostFormatToTaxonomyConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Taxonomy;
   };
@@ -6758,7 +6806,7 @@ export type PostObjectsConnectionOrderbyInput = {
 /** Set relationships between the post to postFormats */
 export type PostPostFormatsInput = {
   /** If true, this will append the postFormat to existing related postFormats. If false, this will replace existing relationships. Default true. */
-  append?: InputMaybe<Scalars['Boolean']>;
+  append?: InputMaybe<Scalars['Boolean']['input']>;
   /** The input list of items to set. */
   nodes?: InputMaybe<Array<InputMaybe<PostPostFormatsNodeInput>>>;
 };
@@ -6766,13 +6814,13 @@ export type PostPostFormatsInput = {
 /** List of postFormats to connect the post to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists. */
 export type PostPostFormatsNodeInput = {
   /** The description of the postFormat. This field is used to set a description of the postFormat if a new one is created during the mutation. */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the postFormat. If present, this will be used to connect to the post. If no existing postFormat exists with this ID, no connection will be made. */
-  id?: InputMaybe<Scalars['ID']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** The name of the postFormat. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field. */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the postFormat. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type PostSidebarUnionType =
@@ -6820,7 +6868,7 @@ export enum PostStatusEnum {
 /** Set relationships between the post to tags */
 export type PostTagsInput = {
   /** If true, this will append the tag to existing related tags. If false, this will replace existing relationships. Default true. */
-  append?: InputMaybe<Scalars['Boolean']>;
+  append?: InputMaybe<Scalars['Boolean']['input']>;
   /** The input list of items to set. */
   nodes?: InputMaybe<Array<InputMaybe<PostTagsNodeInput>>>;
 };
@@ -6828,13 +6876,13 @@ export type PostTagsInput = {
 /** List of tags to connect the post to. If an ID is set, it will be used to create the connection. If not, it will look for a slug. If neither are valid existing terms, and the site is configured to allow terms to be created during post mutations, a term will be created using the Name if it exists in the input, then fallback to the slug if it exists. */
 export type PostTagsNodeInput = {
   /** The description of the tag. This field is used to set a description of the tag if a new one is created during the mutation. */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the tag. If present, this will be used to connect to the post. If no existing tag exists with this ID, no connection will be made. */
-  id?: InputMaybe<Scalars['ID']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** The name of the tag. This field is used to create a new term, if term creation is enabled in nested mutations, and if one does not already exist with the provided slug or ID or if a slug or ID is not provided. If no name is included and a term is created, the creation will fallback to the slug field. */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the tag. If no ID is present, this field will be used to make a connection. If no existing term exists with this slug, this field will be used as a fallback to the Name field when creating a new term to connect to, if term creation is enabled as a nested mutation. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the Post type and the category type */
@@ -6854,7 +6902,7 @@ export type PostToCategoryConnectionEdge = CategoryConnectionEdge &
   Edge & {
     __typename?: 'PostToCategoryConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Category;
   };
@@ -6862,47 +6910,47 @@ export type PostToCategoryConnectionEdge = CategoryConnectionEdge &
 /** Arguments for filtering the PostToCategoryConnection connection */
 export type PostToCategoryConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the Post type and the postFormat type */
@@ -6922,7 +6970,7 @@ export type PostToPostFormatConnectionEdge = Edge &
   PostFormatConnectionEdge & {
     __typename?: 'PostToPostFormatConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: PostFormat;
   };
@@ -6930,47 +6978,47 @@ export type PostToPostFormatConnectionEdge = Edge &
 /** Arguments for filtering the PostToPostFormatConnection connection */
 export type PostToPostFormatConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the Post type and the post type */
@@ -6979,7 +7027,7 @@ export type PostToPreviewConnectionEdge = Edge &
   PostConnectionEdge & {
     __typename?: 'PostToPreviewConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Post;
   };
@@ -7001,7 +7049,7 @@ export type PostToRevisionConnectionEdge = Edge &
   PostConnectionEdge & {
     __typename?: 'PostToRevisionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Post;
   };
@@ -7009,67 +7057,67 @@ export type PostToRevisionConnectionEdge = Edge &
 /** Arguments for filtering the PostToRevisionConnection connection */
 export type PostToRevisionConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Category ID */
-  categoryId?: InputMaybe<Scalars['Int']>;
+  categoryId?: InputMaybe<Scalars['Int']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Use Category Slug */
-  categoryName?: InputMaybe<Scalars['String']>;
+  categoryName?: InputMaybe<Scalars['String']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Tag Slug */
-  tag?: InputMaybe<Scalars['String']>;
+  tag?: InputMaybe<Scalars['String']['input']>;
   /** Use Tag ID */
-  tagId?: InputMaybe<Scalars['String']>;
+  tagId?: InputMaybe<Scalars['String']['input']>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag slugs, used to display objects from one tag AND another */
-  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of tag slugs, used to include objects in ANY specified tags */
-  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the Post type and the tag type */
@@ -7089,7 +7137,7 @@ export type PostToTagConnectionEdge = Edge &
   TagConnectionEdge & {
     __typename?: 'PostToTagConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Tag;
   };
@@ -7097,47 +7145,47 @@ export type PostToTagConnectionEdge = Edge &
 /** Arguments for filtering the PostToTagConnection connection */
 export type PostToTagConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the Post type and the TermNode type */
@@ -7157,7 +7205,7 @@ export type PostToTermNodeConnectionEdge = Edge &
   TermNodeConnectionEdge & {
     __typename?: 'PostToTermNodeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: TermNode;
   };
@@ -7165,120 +7213,134 @@ export type PostToTermNodeConnectionEdge = Edge &
 /** Arguments for filtering the PostToTermNodeConnection connection */
 export type PostToTermNodeConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The Taxonomy to filter terms by */
   taxonomies?: InputMaybe<Array<InputMaybe<TaxonomyEnum>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Details for labels of the PostType */
 export type PostTypeLabelDetails = {
   __typename?: 'PostTypeLabelDetails';
   /** Default is ‘Add New’ for both hierarchical and non-hierarchical types. */
-  addNew?: Maybe<Scalars['String']>;
+  addNew?: Maybe<Scalars['String']['output']>;
   /** Label for adding a new singular item. */
-  addNewItem?: Maybe<Scalars['String']>;
+  addNewItem?: Maybe<Scalars['String']['output']>;
   /** Label to signify all items in a submenu link. */
-  allItems?: Maybe<Scalars['String']>;
+  allItems?: Maybe<Scalars['String']['output']>;
   /** Label for archives in nav menus */
-  archives?: Maybe<Scalars['String']>;
+  archives?: Maybe<Scalars['String']['output']>;
   /** Label for the attributes meta box. */
-  attributes?: Maybe<Scalars['String']>;
+  attributes?: Maybe<Scalars['String']['output']>;
   /** Label for editing a singular item. */
-  editItem?: Maybe<Scalars['String']>;
+  editItem?: Maybe<Scalars['String']['output']>;
   /** Label for the Featured Image meta box title. */
-  featuredImage?: Maybe<Scalars['String']>;
+  featuredImage?: Maybe<Scalars['String']['output']>;
   /** Label for the table views hidden heading. */
-  filterItemsList?: Maybe<Scalars['String']>;
+  filterItemsList?: Maybe<Scalars['String']['output']>;
   /** Label for the media frame button. */
-  insertIntoItem?: Maybe<Scalars['String']>;
+  insertIntoItem?: Maybe<Scalars['String']['output']>;
   /** Label for the table hidden heading. */
-  itemsList?: Maybe<Scalars['String']>;
+  itemsList?: Maybe<Scalars['String']['output']>;
   /** Label for the table pagination hidden heading. */
-  itemsListNavigation?: Maybe<Scalars['String']>;
+  itemsListNavigation?: Maybe<Scalars['String']['output']>;
   /** Label for the menu name. */
-  menuName?: Maybe<Scalars['String']>;
+  menuName?: Maybe<Scalars['String']['output']>;
   /** General name for the post type, usually plural. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** Label for the new item page title. */
-  newItem?: Maybe<Scalars['String']>;
+  newItem?: Maybe<Scalars['String']['output']>;
   /** Label used when no items are found. */
-  notFound?: Maybe<Scalars['String']>;
+  notFound?: Maybe<Scalars['String']['output']>;
   /** Label used when no items are in the trash. */
-  notFoundInTrash?: Maybe<Scalars['String']>;
+  notFoundInTrash?: Maybe<Scalars['String']['output']>;
   /** Label used to prefix parents of hierarchical items. */
-  parentItemColon?: Maybe<Scalars['String']>;
+  parentItemColon?: Maybe<Scalars['String']['output']>;
   /** Label for removing the featured image. */
-  removeFeaturedImage?: Maybe<Scalars['String']>;
+  removeFeaturedImage?: Maybe<Scalars['String']['output']>;
   /** Label for searching plural items. */
-  searchItems?: Maybe<Scalars['String']>;
+  searchItems?: Maybe<Scalars['String']['output']>;
   /** Label for setting the featured image. */
-  setFeaturedImage?: Maybe<Scalars['String']>;
+  setFeaturedImage?: Maybe<Scalars['String']['output']>;
   /** Name for one object of this post type. */
-  singularName?: Maybe<Scalars['String']>;
+  singularName?: Maybe<Scalars['String']['output']>;
   /** Label for the media frame filter. */
-  uploadedToThisItem?: Maybe<Scalars['String']>;
+  uploadedToThisItem?: Maybe<Scalars['String']['output']>;
   /** Label in the media frame for using a featured image. */
-  useFeaturedImage?: Maybe<Scalars['String']>;
+  useFeaturedImage?: Maybe<Scalars['String']['output']>;
   /** Label for viewing a singular item. */
-  viewItem?: Maybe<Scalars['String']>;
+  viewItem?: Maybe<Scalars['String']['output']>;
   /** Label for viewing post type archives. */
-  viewItems?: Maybe<Scalars['String']>;
+  viewItems?: Maybe<Scalars['String']['output']>;
 };
 
 /** Nodes that can be seen in a preview (unpublished) state. */
 export type Previewable = {
   /** Whether the object is a node in the preview state */
-  isPreview?: Maybe<Scalars['Boolean']>;
+  isPreview?: Maybe<Scalars['Boolean']['output']>;
   /** The database id of the preview node */
-  previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+  previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** Whether the object is a node in the preview state */
-  previewRevisionId?: Maybe<Scalars['ID']>;
+  previewRevisionId?: Maybe<Scalars['ID']['output']>;
 };
+
+export enum ProviderType {
+  Association = 'ASSOCIATION',
+  ContractSchool = 'CONTRACT_SCHOOL',
+  Municipality = 'MUNICIPALITY',
+  OtherProductionMethod = 'OTHER_PRODUCTION_METHOD',
+  PaymentCommitment = 'PAYMENT_COMMITMENT',
+  PrivateCompany = 'PRIVATE_COMPANY',
+  PurchasedService = 'PURCHASED_SERVICE',
+  SelfProduced = 'SELF_PRODUCED',
+  SupportedOperations = 'SUPPORTED_OPERATIONS',
+  UnknownProductionMethod = 'UNKNOWN_PRODUCTION_METHOD',
+  VoucherService = 'VOUCHER_SERVICE',
+}
 
 /** The root entry point into the Graph */
 export type Query = {
   __typename?: 'Query';
-  _empty?: Maybe<Scalars['String']>;
+  _empty?: Maybe<Scalars['String']['output']>;
   administrativeDivisions?: Maybe<Array<Maybe<AdministrativeDivision>>>;
   /** Entry point to get all settings for the site */
   allSettings?: Maybe<Settings>;
@@ -7434,7 +7496,7 @@ export type Query = {
   /** Connection between the RootQuery type and the Theme type */
   themes?: Maybe<RootQueryToThemeConnection>;
   /** Translate string using pll_translate_string() (Polylang) */
-  translateString?: Maybe<Scalars['String']>;
+  translateString?: Maybe<Scalars['String']['output']>;
   /** An object of the translation Type. Translations */
   translation?: Maybe<Translation>;
   /**
@@ -7464,683 +7526,700 @@ export type Query = {
 
 /** The root entry point into the Graph */
 export type QueryAdministrativeDivisionsArgs = {
-  helsinkiCommonOnly?: InputMaybe<Scalars['Boolean']>;
+  helsinkiCommonOnly?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryCategoriesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToCategoryConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryCategoryArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<CategoryIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryCollectionArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<CollectionIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryCollectionByArgs = {
-  collectionId?: InputMaybe<Scalars['Int']>;
-  id?: InputMaybe<Scalars['ID']>;
-  slug?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
+  collectionId?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryCollectionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToCollectionConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryCommentArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<CommentNodeIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryCommentsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToCommentConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryContactArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<ContactIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryContactByArgs = {
-  contactId?: InputMaybe<Scalars['Int']>;
-  id?: InputMaybe<Scalars['ID']>;
-  slug?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
+  contactId?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryContactsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToContactConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryContentNodeArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
   contentType?: InputMaybe<ContentTypeEnum>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<ContentNodeIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryContentNodesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToContentNodeConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryContentTypeArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<ContentTypeIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryContentTypesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryDefaultImagesArgs = {
-  language: Scalars['String'];
+  language: Scalars['String']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryEventDetailsArgs = {
-  id?: InputMaybe<Scalars['ID']>;
-  include?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 /** The root entry point into the Graph */
 export type QueryEventListArgs = {
-  allOngoing?: InputMaybe<Scalars['Boolean']>;
-  allOngoingAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  allOngoingOr?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  audienceMaxAgeGt?: InputMaybe<Scalars['String']>;
-  audienceMaxAgeLt?: InputMaybe<Scalars['String']>;
-  audienceMinAgeGt?: InputMaybe<Scalars['String']>;
-  audienceMinAgeLt?: InputMaybe<Scalars['String']>;
-  combinedText?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  division?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  end?: InputMaybe<Scalars['String']>;
-  endsAfter?: InputMaybe<Scalars['String']>;
-  endsBefore?: InputMaybe<Scalars['String']>;
+  allOngoing?: InputMaybe<Scalars['Boolean']['input']>;
+  allOngoingAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allOngoingOr?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  audienceMaxAgeGt?: InputMaybe<Scalars['String']['input']>;
+  audienceMaxAgeLt?: InputMaybe<Scalars['String']['input']>;
+  audienceMinAgeGt?: InputMaybe<Scalars['String']['input']>;
+  audienceMinAgeLt?: InputMaybe<Scalars['String']['input']>;
+  combinedText?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  division?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  end?: InputMaybe<Scalars['String']['input']>;
+  endsAfter?: InputMaybe<Scalars['String']['input']>;
+  endsBefore?: InputMaybe<Scalars['String']['input']>;
   eventType?: InputMaybe<Array<InputMaybe<EventTypeId>>>;
-  ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  inLanguage?: InputMaybe<Scalars['String']>;
-  include?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  internetBased?: InputMaybe<Scalars['Boolean']>;
-  internetOngoingAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  internetOngoingOr?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  isFree?: InputMaybe<Scalars['Boolean']>;
-  keyword?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  keywordAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  keywordNot?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  keywordOrSet1?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  keywordOrSet2?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  keywordOrSet3?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  language?: InputMaybe<Scalars['String']>;
-  localOngoingAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  localOngoingOr?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  localOngoingOrSet1?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  localOngoingOrSet2?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  localOngoingOrSet3?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  location?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  page?: InputMaybe<Scalars['Int']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  publisher?: InputMaybe<Scalars['ID']>;
-  sort?: InputMaybe<Scalars['String']>;
-  start?: InputMaybe<Scalars['String']>;
-  startsAfter?: InputMaybe<Scalars['String']>;
-  startsBefore?: InputMaybe<Scalars['String']>;
-  suitableFor?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
-  superEvent?: InputMaybe<Scalars['ID']>;
-  superEventType?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  text?: InputMaybe<Scalars['String']>;
-  translation?: InputMaybe<Scalars['String']>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  inLanguage?: InputMaybe<Scalars['String']['input']>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internetBased?: InputMaybe<Scalars['Boolean']['input']>;
+  internetOngoingAnd?: InputMaybe<
+    Array<InputMaybe<Scalars['String']['input']>>
+  >;
+  internetOngoingOr?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  isFree?: InputMaybe<Scalars['Boolean']['input']>;
+  keyword?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  keywordAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  keywordNot?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  keywordOrSet1?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  keywordOrSet2?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  keywordOrSet3?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  language?: InputMaybe<Scalars['String']['input']>;
+  localOngoingAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  localOngoingOr?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  localOngoingOrSet1?: InputMaybe<
+    Array<InputMaybe<Scalars['String']['input']>>
+  >;
+  localOngoingOrSet2?: InputMaybe<
+    Array<InputMaybe<Scalars['String']['input']>>
+  >;
+  localOngoingOrSet3?: InputMaybe<
+    Array<InputMaybe<Scalars['String']['input']>>
+  >;
+  location?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  publisher?: InputMaybe<Scalars['ID']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['String']['input']>;
+  startsAfter?: InputMaybe<Scalars['String']['input']>;
+  startsBefore?: InputMaybe<Scalars['String']['input']>;
+  suitableFor?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  superEvent?: InputMaybe<Scalars['ID']['input']>;
+  superEventType?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  text?: InputMaybe<Scalars['String']['input']>;
+  translation?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryEventsByIdsArgs = {
-  end?: InputMaybe<Scalars['String']>;
+  end?: InputMaybe<Scalars['String']['input']>;
   eventType?: InputMaybe<Array<InputMaybe<EventTypeId>>>;
-  ids: Array<Scalars['ID']>;
-  include?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  page?: InputMaybe<Scalars['Int']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  sort?: InputMaybe<Scalars['String']>;
-  start?: InputMaybe<Scalars['String']>;
+  ids: Array<Scalars['ID']['input']>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryKeywordDetailsArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryKeywordListArgs = {
-  dataSource?: InputMaybe<Scalars['String']>;
-  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']>;
-  page?: InputMaybe<Scalars['Int']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  showAllKeywords?: InputMaybe<Scalars['Boolean']>;
-  sort?: InputMaybe<Scalars['String']>;
-  text?: InputMaybe<Scalars['String']>;
+  dataSource?: InputMaybe<Scalars['String']['input']>;
+  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  showAllKeywords?: InputMaybe<Scalars['Boolean']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  text?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryLandingPageArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<LandingPageIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryLandingPageByArgs = {
-  id?: InputMaybe<Scalars['ID']>;
-  landingPageId?: InputMaybe<Scalars['Int']>;
-  slug?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  landingPageId?: InputMaybe<Scalars['Int']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryLandingPagesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToLandingPageConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryMediaItemArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<MediaItemIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryMediaItemByArgs = {
-  id?: InputMaybe<Scalars['ID']>;
-  mediaItemId?: InputMaybe<Scalars['Int']>;
-  slug?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  mediaItemId?: InputMaybe<Scalars['Int']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryMediaItemsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToMediaItemConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryMenuArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<MenuNodeIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryMenuItemArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<MenuItemNodeIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryMenuItemsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToMenuItemConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryMenusArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToMenuConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryNodeArgs = {
-  id?: InputMaybe<Scalars['ID']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryNodeByUriArgs = {
-  uri: Scalars['String'];
+  uri: Scalars['String']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryNotificationArgs = {
-  language: Scalars['String'];
+  language: Scalars['String']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryOntologyTreeArgs = {
-  leavesOnly?: InputMaybe<Scalars['Boolean']>;
-  rootId?: InputMaybe<Scalars['ID']>;
+  leavesOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  rootId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryOntologyWordsArgs = {
-  ids?: InputMaybe<Array<Scalars['ID']>>;
+  ids?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
 /** The root entry point into the Graph */
 export type QueryOrganizationDetailsArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryPageArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<PageIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPageByArgs = {
-  id?: InputMaybe<Scalars['ID']>;
-  pageId?: InputMaybe<Scalars['Int']>;
-  uri?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  pageId?: InputMaybe<Scalars['Int']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPageByTemplateArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars['String']['input']>;
   template?: InputMaybe<TemplateEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPagesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToPageConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPlaceDetailsArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryPlaceListArgs = {
-  dataSource?: InputMaybe<Scalars['String']>;
-  divisions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']>;
-  page?: InputMaybe<Scalars['Int']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  showAllPlaces?: InputMaybe<Scalars['Boolean']>;
-  sort?: InputMaybe<Scalars['String']>;
-  text?: InputMaybe<Scalars['String']>;
+  dataSource?: InputMaybe<Scalars['String']['input']>;
+  divisions?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  showAllPlaces?: InputMaybe<Scalars['Boolean']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  text?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPluginArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryPluginsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToPluginConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPostArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<PostIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPostByArgs = {
-  id?: InputMaybe<Scalars['ID']>;
-  postId?: InputMaybe<Scalars['Int']>;
-  slug?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  postId?: InputMaybe<Scalars['Int']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPostFormatArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<PostFormatIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPostFormatsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToPostFormatConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryPostsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToPostConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryRegisteredScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryRegisteredStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryReleaseArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<ReleaseIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryReleaseByArgs = {
-  id?: InputMaybe<Scalars['ID']>;
-  releaseId?: InputMaybe<Scalars['Int']>;
-  slug?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  releaseId?: InputMaybe<Scalars['Int']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryReleasesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToReleaseConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToRevisionsConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QuerySiteSettingsArgs = {
-  language: Scalars['String'];
+  language: Scalars['String']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryTagArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<TagIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTagsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToTagConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTaxonomiesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTaxonomyArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<TaxonomyIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTermNodeArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<TermNodeIdTypeEnum>;
   taxonomy?: InputMaybe<TaxonomyEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTermsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToTermNodeConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryThemeArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryThemesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTranslateStringArgs = {
   language: LanguageCodeEnum;
-  string: Scalars['String'];
+  string: Scalars['String']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryTranslationArgs = {
-  asPreview?: InputMaybe<Scalars['Boolean']>;
-  id: Scalars['ID'];
+  asPreview?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<TranslationIdType>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTranslationByArgs = {
-  id?: InputMaybe<Scalars['ID']>;
-  slug?: InputMaybe<Scalars['String']>;
-  translationId?: InputMaybe<Scalars['Int']>;
-  uri?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  translationId?: InputMaybe<Scalars['Int']['input']>;
+  uri?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTranslationsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToTranslationConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUnifiedSearchArgs = {
-  administrativeDivisionId?: InputMaybe<Scalars['ID']>;
-  administrativeDivisionIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  index?: InputMaybe<Scalars['String']>;
+  accessibilityProfilesWithoutShortcomings?: InputMaybe<
+    Array<InputMaybe<AccessibilityProfile>>
+  >;
+  administrativeDivisionId?: InputMaybe<Scalars['ID']['input']>;
+  administrativeDivisionIds?: InputMaybe<
+    Array<InputMaybe<Scalars['ID']['input']>>
+  >;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  index?: InputMaybe<Scalars['String']['input']>;
   languages?: Array<UnifiedSearchLanguage>;
-  last?: InputMaybe<Scalars['Int']>;
-  ontology?: InputMaybe<Scalars['String']>;
-  ontologyTreeId?: InputMaybe<Scalars['ID']>;
-  ontologyTreeIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  ontologyWordIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  openAt?: InputMaybe<Scalars['String']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  mustHaveReservableResource?: InputMaybe<Scalars['Boolean']['input']>;
+  ontology?: InputMaybe<Scalars['String']['input']>;
+  ontologyTreeId?: InputMaybe<Scalars['ID']['input']>;
+  ontologyTreeIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  ontologyWordIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  openAt?: InputMaybe<Scalars['String']['input']>;
   orderByDistance?: InputMaybe<OrderByDistance>;
   orderByName?: InputMaybe<OrderByName>;
-  q?: InputMaybe<Scalars['String']>;
+  providerTypes?: InputMaybe<Array<InputMaybe<ProviderType>>>;
+  q?: InputMaybe<Scalars['String']['input']>;
+  serviceOwnerTypes?: InputMaybe<Array<InputMaybe<ServiceOwnerType>>>;
+  targetGroups?: InputMaybe<Array<InputMaybe<TargetGroup>>>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUnifiedSearchCompletionSuggestionsArgs = {
-  index?: InputMaybe<Scalars['String']>;
+  index?: InputMaybe<Scalars['String']['input']>;
   languages?: Array<UnifiedSearchLanguage>;
-  prefix?: InputMaybe<Scalars['String']>;
-  size?: InputMaybe<Scalars['Int']>;
+  prefix?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUserArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   idType?: InputMaybe<UserNodeIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUserRoleArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryUserRolesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUsersArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<RootQueryToUserConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryVenueArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The root entry point into the Graph */
 export type QueryVenuesByIdsArgs = {
-  ids?: InputMaybe<Array<Scalars['ID']>>;
+  ids?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
 export type RawJson = {
   __typename?: 'RawJSON';
-  data?: Maybe<Scalars['String']>;
+  data?: Maybe<Scalars['String']['output']>;
 };
 
 /** The reading setting type */
 export type ReadingSettings = {
   __typename?: 'ReadingSettings';
   /** Tunniste sivusta, joka näyttää uusimmat artikkelit */
-  pageForPosts?: Maybe<Scalars['Int']>;
+  pageForPosts?: Maybe<Scalars['Int']['output']>;
   /** Tunniste sivusta, joka näytetään etusivulla */
-  pageOnFront?: Maybe<Scalars['Int']>;
+  pageOnFront?: Maybe<Scalars['Int']['output']>;
   /** Näytä enintään */
-  postsPerPage?: Maybe<Scalars['Int']>;
+  postsPerPage?: Maybe<Scalars['Int']['output']>;
   /** Mitä näytetään etusivulla */
-  showOnFront?: Maybe<Scalars['String']>;
+  showOnFront?: Maybe<Scalars['String']['output']>;
 };
 
 /** Input for the registerUser mutation. */
 export type RegisterUserInput = {
   /** User's AOL IM account. */
-  aim?: InputMaybe<Scalars['String']>;
+  aim?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** A string containing content about the user. */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** A string that will be shown on the site. Defaults to user's username. It is likely that you will want to change this, for both appearance and security through obscurity (that is if you dont use and delete the default admin user). */
-  displayName?: InputMaybe<Scalars['String']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   /** A string containing the user's email address. */
-  email?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']['input']>;
   /** 	The user's first name. */
-  firstName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
   /** User's Jabber account. */
-  jabber?: InputMaybe<Scalars['String']>;
+  jabber?: InputMaybe<Scalars['String']['input']>;
   /** The user's last name. */
-  lastName?: InputMaybe<Scalars['String']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
   /** User's locale. */
-  locale?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains a URL-friendly name for the user. The default is the user's username. */
-  nicename?: InputMaybe<Scalars['String']>;
+  nicename?: InputMaybe<Scalars['String']['input']>;
   /** The user's nickname, defaults to the user's username. */
-  nickname?: InputMaybe<Scalars['String']>;
+  nickname?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains the plain text password for the user. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The date the user registered. Format is Y-m-d H:i:s. */
-  registered?: InputMaybe<Scalars['String']>;
+  registered?: InputMaybe<Scalars['String']['input']>;
   /** A string for whether to enable the rich editor or not. False if not empty. */
-  richEditing?: InputMaybe<Scalars['String']>;
+  richEditing?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains the user's username. */
-  username: Scalars['String'];
+  username: Scalars['String']['input'];
   /** A string containing the user's URL for the user's web site. */
-  websiteUrl?: InputMaybe<Scalars['String']>;
+  websiteUrl?: InputMaybe<Scalars['String']['input']>;
   /** User's Yahoo IM account. */
-  yim?: InputMaybe<Scalars['String']>;
+  yim?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the registerUser mutation. */
 export type RegisterUserPayload = {
   __typename?: 'RegisterUserPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The User object mutation type. */
   user?: Maybe<User>;
 };
@@ -8165,64 +8244,64 @@ export type Release = ContentNode &
   UniformResourceIdentifiable & {
     __typename?: 'Release';
     /** The content of the post. */
-    content?: Maybe<Scalars['String']>;
+    content?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
     /** Vanhentumisaika */
-    expirationTime?: Maybe<Scalars['String']>;
+    expirationTime?: Maybe<Scalars['String']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier of the release-cpt object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** True if the node is a revision of another node */
-    isRevision?: Maybe<Scalars['Boolean']>;
+    isRevision?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Polylang language */
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** Connection between the Release type and the release type */
     preview?: Maybe<ReleaseToPreviewConnectionEdge>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    releaseId: Scalars['Int'];
+    releaseId: Scalars['Int']['output'];
     /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
     revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
     /** Connection between the Release type and the release type */
@@ -8230,19 +8309,19 @@ export type Release = ContentNode &
     /** The SEO Framework data of the release */
     seo?: Maybe<Seo>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** The template assigned to the node */
     template?: Maybe<ContentTemplate>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<Release>;
     /** List all translated versions of this post */
     translations?: Maybe<Array<Maybe<Release>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The release type */
@@ -8252,26 +8331,26 @@ export type ReleaseContentArgs = {
 
 /** The release type */
 export type ReleaseEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The release type */
 export type ReleaseEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The release type */
 export type ReleaseRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ReleaseToRevisionConnectionWhereArgs>;
 };
 
@@ -8296,7 +8375,7 @@ export type ReleaseConnection = {
 /** Edge between a Node and a connected release */
 export type ReleaseConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected release Node */
   node: Release;
 };
@@ -8319,7 +8398,7 @@ export type ReleaseToPreviewConnectionEdge = Edge &
   ReleaseConnectionEdge & {
     __typename?: 'ReleaseToPreviewConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Release;
   };
@@ -8341,7 +8420,7 @@ export type ReleaseToRevisionConnectionEdge = Edge &
   ReleaseConnectionEdge & {
     __typename?: 'ReleaseToRevisionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Release;
   };
@@ -8351,59 +8430,81 @@ export type ReleaseToRevisionConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Input for the resetUserPassword mutation. */
 export type ResetUserPasswordInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Password reset key */
-  key?: InputMaybe<Scalars['String']>;
+  key?: InputMaybe<Scalars['String']['input']>;
   /** The user's login (username). */
-  login?: InputMaybe<Scalars['String']>;
+  login?: InputMaybe<Scalars['String']['input']>;
   /** The new password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the resetUserPassword mutation. */
 export type ResetUserPasswordPayload = {
   __typename?: 'ResetUserPasswordPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The User object mutation type. */
   user?: Maybe<User>;
 };
+
+export type Resource = {
+  __typename?: 'Resource';
+  description?: Maybe<LanguageString>;
+  externalReservationUrl?: Maybe<Scalars['String']['output']>;
+  genericTerms?: Maybe<LanguageString>;
+  id?: Maybe<Scalars['ID']['output']>;
+  name?: Maybe<LanguageString>;
+  paymentTerms?: Maybe<LanguageString>;
+  reservable?: Maybe<Scalars['Boolean']['output']>;
+  reservationInfo?: Maybe<LanguageString>;
+  responsibleContactInfo?: Maybe<LanguageString>;
+  specificTerms?: Maybe<LanguageString>;
+  type?: Maybe<ResourceType>;
+  userPermissions?: Maybe<ResourceUserPermissions>;
+};
+
+export enum ResourceMainType {
+  Item = 'item',
+  Person = 'person',
+  Space = 'space',
+}
 
 export enum ResourceState {
   Closed = 'closed',
@@ -8419,23 +8520,35 @@ export enum ResourceState {
   WithReservation = 'with_reservation',
 }
 
+export type ResourceType = {
+  __typename?: 'ResourceType';
+  id?: Maybe<Scalars['ID']['output']>;
+  mainType?: Maybe<ResourceMainType>;
+  name?: Maybe<LanguageString>;
+};
+
+export type ResourceUserPermissions = {
+  __typename?: 'ResourceUserPermissions';
+  canMakeReservations?: Maybe<Scalars['Boolean']['output']>;
+};
+
 /** Input for the restoreComment mutation. */
 export type RestoreCommentInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the comment to be restored */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 /** The payload for the restoreComment mutation. */
 export type RestoreCommentPayload = {
   __typename?: 'RestoreCommentPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The restored comment object */
   comment?: Maybe<Comment>;
   /** The ID of the restored comment */
-  restoredId?: Maybe<Scalars['ID']>;
+  restoredId?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Connection between the RootQuery type and the category type */
@@ -8455,7 +8568,7 @@ export type RootQueryToCategoryConnectionEdge = CategoryConnectionEdge &
   Edge & {
     __typename?: 'RootQueryToCategoryConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Category;
   };
@@ -8463,51 +8576,51 @@ export type RootQueryToCategoryConnectionEdge = CategoryConnectionEdge &
 /** Arguments for filtering the RootQueryToCategoryConnection connection */
 export type RootQueryToCategoryConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by Categorys by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter Categorys by one or more languages (Polylang) */
   languages?: InputMaybe<Array<LanguageCodeEnum>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the RootQuery type and the collection type */
@@ -8527,7 +8640,7 @@ export type RootQueryToCollectionConnectionEdge = CollectionConnectionEdge &
   Edge & {
     __typename?: 'RootQueryToCollectionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Collection;
   };
@@ -8537,11 +8650,11 @@ export type RootQueryToCollectionConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by Collections by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter Collections by one or more languages (Polylang) */
@@ -8549,29 +8662,29 @@ export type RootQueryToCollectionConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the Comment type */
@@ -8591,7 +8704,7 @@ export type RootQueryToCommentConnectionEdge = CommentConnectionEdge &
   Edge & {
     __typename?: 'RootQueryToCommentConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Comment;
   };
@@ -8599,63 +8712,63 @@ export type RootQueryToCommentConnectionEdge = CommentConnectionEdge &
 /** Arguments for filtering the RootQueryToCommentConnection connection */
 export type RootQueryToCommentConnectionWhereArgs = {
   /** Comment author email address. */
-  authorEmail?: InputMaybe<Scalars['String']>;
+  authorEmail?: InputMaybe<Scalars['String']['input']>;
   /** Array of author IDs to include comments for. */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to exclude comments for. */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Comment author URL. */
-  authorUrl?: InputMaybe<Scalars['String']>;
+  authorUrl?: InputMaybe<Scalars['String']['input']>;
   /** Array of comment IDs to include. */
-  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of IDs of users whose unapproved comments will be returned by the query regardless of status. */
-  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Include comments of a given type. */
-  commentType?: InputMaybe<Scalars['String']>;
+  commentType?: InputMaybe<Scalars['String']['input']>;
   /** Include comments from a given array of comment types. */
-  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Exclude comments from a given array of comment types. */
-  commentTypeNotIn?: InputMaybe<Scalars['String']>;
+  commentTypeNotIn?: InputMaybe<Scalars['String']['input']>;
   /** Content object author ID to limit results by. */
-  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to retrieve comments for. */
-  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs *not* to retrieve comments for. */
-  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Limit results to those affiliated with a given content object ID. */
-  contentId?: InputMaybe<Scalars['ID']>;
+  contentId?: InputMaybe<Scalars['ID']['input']>;
   /** Array of content object IDs to include affiliated comments for. */
-  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of content object IDs to exclude affiliated comments for. */
-  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Content object name (i.e. slug ) to retrieve affiliated comments for. */
-  contentName?: InputMaybe<Scalars['String']>;
+  contentName?: InputMaybe<Scalars['String']['input']>;
   /** Content Object parent ID to retrieve affiliated comments for. */
-  contentParent?: InputMaybe<Scalars['Int']>;
+  contentParent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of content object statuses to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentStatus?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Content object type or array of types to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentType?: InputMaybe<Array<InputMaybe<ContentTypeEnum>>>;
   /** Array of IDs or email addresses of users whose unapproved comments will be returned by the query regardless of $status. Default empty */
-  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Karma score to retrieve matching comments for. */
-  karma?: InputMaybe<Scalars['Int']>;
+  karma?: InputMaybe<Scalars['Int']['input']>;
   /** The cardinality of the order of the connection */
   order?: InputMaybe<OrderEnum>;
   /** Field to order the comments by. */
   orderby?: InputMaybe<CommentsConnectionOrderbyEnum>;
   /** Parent ID of comment to retrieve children of. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of parent IDs of comments to retrieve children for. */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of parent IDs of comments *not* to retrieve children for. */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Search term(s) to retrieve matching comments for. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Comment status to limit results by. */
-  status?: InputMaybe<Scalars['String']>;
+  status?: InputMaybe<Scalars['String']['input']>;
   /** Include comments for a specific user ID. */
-  userId?: InputMaybe<Scalars['ID']>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Connection between the RootQuery type and the contact type */
@@ -8675,7 +8788,7 @@ export type RootQueryToContactConnectionEdge = ContactConnectionEdge &
   Edge & {
     __typename?: 'RootQueryToContactConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Contact;
   };
@@ -8685,11 +8798,11 @@ export type RootQueryToContactConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by Contacts by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter Contacts by one or more languages (Polylang) */
@@ -8697,29 +8810,29 @@ export type RootQueryToContactConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the ContentNode type */
@@ -8739,7 +8852,7 @@ export type RootQueryToContentNodeConnectionEdge = ContentNodeConnectionEdge &
   Edge & {
     __typename?: 'RootQueryToContentNodeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentNode;
   };
@@ -8751,11 +8864,11 @@ export type RootQueryToContentNodeConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter content nodes by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter content nodes by one or more languages (Polylang) */
@@ -8763,29 +8876,29 @@ export type RootQueryToContentNodeConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the ContentType type */
@@ -8805,7 +8918,7 @@ export type RootQueryToContentTypeConnectionEdge = ContentTypeConnectionEdge &
   Edge & {
     __typename?: 'RootQueryToContentTypeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentType;
   };
@@ -8827,7 +8940,7 @@ export type RootQueryToEnqueuedScriptConnectionEdge = Edge &
   EnqueuedScriptConnectionEdge & {
     __typename?: 'RootQueryToEnqueuedScriptConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedScript;
   };
@@ -8849,7 +8962,7 @@ export type RootQueryToEnqueuedStylesheetConnectionEdge = Edge &
   EnqueuedStylesheetConnectionEdge & {
     __typename?: 'RootQueryToEnqueuedStylesheetConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedStylesheet;
   };
@@ -8871,7 +8984,7 @@ export type RootQueryToLandingPageConnectionEdge = Edge &
   LandingPageConnectionEdge & {
     __typename?: 'RootQueryToLandingPageConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: LandingPage;
   };
@@ -8881,11 +8994,11 @@ export type RootQueryToLandingPageConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by LandingPages by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter LandingPages by one or more languages (Polylang) */
@@ -8893,29 +9006,29 @@ export type RootQueryToLandingPageConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the mediaItem type */
@@ -8935,7 +9048,7 @@ export type RootQueryToMediaItemConnectionEdge = Edge &
   MediaItemConnectionEdge & {
     __typename?: 'RootQueryToMediaItemConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MediaItem;
   };
@@ -8943,21 +9056,21 @@ export type RootQueryToMediaItemConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToMediaItemConnection connection */
 export type RootQueryToMediaItemConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by MediaItems by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter MediaItems by one or more languages (Polylang) */
@@ -8965,29 +9078,29 @@ export type RootQueryToMediaItemConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the Menu type */
@@ -9007,7 +9120,7 @@ export type RootQueryToMenuConnectionEdge = Edge &
   MenuConnectionEdge & {
     __typename?: 'RootQueryToMenuConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Menu;
   };
@@ -9015,11 +9128,11 @@ export type RootQueryToMenuConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToMenuConnection connection */
 export type RootQueryToMenuConnectionWhereArgs = {
   /** The database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** The menu location for the menu being queried */
   location?: InputMaybe<MenuLocationEnum>;
   /** The slug of the menu to query items for */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the MenuItem type */
@@ -9039,7 +9152,7 @@ export type RootQueryToMenuItemConnectionEdge = Edge &
   MenuItemConnectionEdge & {
     __typename?: 'RootQueryToMenuItemConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MenuItem;
   };
@@ -9047,14 +9160,14 @@ export type RootQueryToMenuItemConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToMenuItemConnection connection */
 export type RootQueryToMenuItemConnectionWhereArgs = {
   /** The database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** The menu location for the menu being queried */
   location?: InputMaybe<MenuLocationEnum>;
   /** The database ID of the parent menu object */
-  parentDatabaseId?: InputMaybe<Scalars['Int']>;
+  parentDatabaseId?: InputMaybe<Scalars['Int']['input']>;
   /** The ID of the parent menu object */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Connection between the RootQuery type and the page type */
@@ -9074,7 +9187,7 @@ export type RootQueryToPageConnectionEdge = Edge &
   PageConnectionEdge & {
     __typename?: 'RootQueryToPageConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Page;
   };
@@ -9082,21 +9195,21 @@ export type RootQueryToPageConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToPageConnection connection */
 export type RootQueryToPageConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by Pages by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter Pages by one or more languages (Polylang) */
@@ -9104,29 +9217,29 @@ export type RootQueryToPageConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the Plugin type */
@@ -9146,7 +9259,7 @@ export type RootQueryToPluginConnectionEdge = Edge &
   PluginConnectionEdge & {
     __typename?: 'RootQueryToPluginConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Plugin;
   };
@@ -9154,7 +9267,7 @@ export type RootQueryToPluginConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToPluginConnection connection */
 export type RootQueryToPluginConnectionWhereArgs = {
   /** Show plugin based on a keyword search. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve plugins where plugin status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PluginStatusEnum>>>;
   /** Show plugins with a specific status. */
@@ -9178,7 +9291,7 @@ export type RootQueryToPostConnectionEdge = Edge &
   PostConnectionEdge & {
     __typename?: 'RootQueryToPostConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Post;
   };
@@ -9186,29 +9299,29 @@ export type RootQueryToPostConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToPostConnection connection */
 export type RootQueryToPostConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Category ID */
-  categoryId?: InputMaybe<Scalars['Int']>;
+  categoryId?: InputMaybe<Scalars['Int']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Use Category Slug */
-  categoryName?: InputMaybe<Scalars['String']>;
+  categoryName?: InputMaybe<Scalars['String']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by Posts by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter Posts by one or more languages (Polylang) */
@@ -9216,41 +9329,41 @@ export type RootQueryToPostConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Tag Slug */
-  tag?: InputMaybe<Scalars['String']>;
+  tag?: InputMaybe<Scalars['String']['input']>;
   /** Use Tag ID */
-  tagId?: InputMaybe<Scalars['String']>;
+  tagId?: InputMaybe<Scalars['String']['input']>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag slugs, used to display objects from one tag AND another */
-  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of tag slugs, used to include objects in ANY specified tags */
-  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the postFormat type */
@@ -9270,7 +9383,7 @@ export type RootQueryToPostFormatConnectionEdge = Edge &
   PostFormatConnectionEdge & {
     __typename?: 'RootQueryToPostFormatConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: PostFormat;
   };
@@ -9278,47 +9391,47 @@ export type RootQueryToPostFormatConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToPostFormatConnection connection */
 export type RootQueryToPostFormatConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the RootQuery type and the release type */
@@ -9338,7 +9451,7 @@ export type RootQueryToReleaseConnectionEdge = Edge &
   ReleaseConnectionEdge & {
     __typename?: 'RootQueryToReleaseConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Release;
   };
@@ -9348,11 +9461,11 @@ export type RootQueryToReleaseConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by Releases by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter Releases by one or more languages (Polylang) */
@@ -9360,29 +9473,29 @@ export type RootQueryToReleaseConnectionWhereArgs = {
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the ContentNode type */
@@ -9402,7 +9515,7 @@ export type RootQueryToRevisionsConnectionEdge = ContentNodeConnectionEdge &
   Edge & {
     __typename?: 'RootQueryToRevisionsConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentNode;
   };
@@ -9414,37 +9527,37 @@ export type RootQueryToRevisionsConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the tag type */
@@ -9464,7 +9577,7 @@ export type RootQueryToTagConnectionEdge = Edge &
   TagConnectionEdge & {
     __typename?: 'RootQueryToTagConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Tag;
   };
@@ -9472,51 +9585,51 @@ export type RootQueryToTagConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToTagConnection connection */
 export type RootQueryToTagConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter by Tags by language code (Polylang) */
   language?: InputMaybe<LanguageCodeFilterEnum>;
   /** Filter Tags by one or more languages (Polylang) */
   languages?: InputMaybe<Array<LanguageCodeEnum>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the RootQuery type and the Taxonomy type */
@@ -9536,7 +9649,7 @@ export type RootQueryToTaxonomyConnectionEdge = Edge &
   TaxonomyConnectionEdge & {
     __typename?: 'RootQueryToTaxonomyConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Taxonomy;
   };
@@ -9558,7 +9671,7 @@ export type RootQueryToTermNodeConnectionEdge = Edge &
   TermNodeConnectionEdge & {
     __typename?: 'RootQueryToTermNodeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: TermNode;
   };
@@ -9566,49 +9679,49 @@ export type RootQueryToTermNodeConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToTermNodeConnection connection */
 export type RootQueryToTermNodeConnectionWhereArgs = {
   /** Unique cache key to be produced when this query is stored in an object cache. Default is 'core'. */
-  cacheDomain?: InputMaybe<Scalars['String']>;
+  cacheDomain?: InputMaybe<Scalars['String']['input']>;
   /** Term ID to retrieve child terms of. If multiple taxonomies are passed, $child_of is ignored. Default 0. */
-  childOf?: InputMaybe<Scalars['Int']>;
+  childOf?: InputMaybe<Scalars['Int']['input']>;
   /** True to limit results to terms that have no children. This parameter has no effect on non-hierarchical taxonomies. Default false. */
-  childless?: InputMaybe<Scalars['Boolean']>;
+  childless?: InputMaybe<Scalars['Boolean']['input']>;
   /** Retrieve terms where the description is LIKE the input value. Default empty. */
-  descriptionLike?: InputMaybe<Scalars['String']>;
+  descriptionLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of term ids to exclude. If $include is non-empty, $exclude is ignored. Default empty array. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term ids to exclude along with all of their descendant terms. If $include is non-empty, $exclude_tree is ignored. Default empty array. */
-  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  excludeTree?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to hide terms not assigned to any posts. Accepts true or false. Default false */
-  hideEmpty?: InputMaybe<Scalars['Boolean']>;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
   /** Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). Default true. */
-  hierarchical?: InputMaybe<Scalars['Boolean']>;
+  hierarchical?: InputMaybe<Scalars['Boolean']['input']>;
   /** Array of term ids to include. Default empty array. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of names to return term(s) for. Default empty. */
-  name?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  name?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Retrieve terms where the name is LIKE the input value. Default empty. */
-  nameLike?: InputMaybe<Scalars['String']>;
+  nameLike?: InputMaybe<Scalars['String']['input']>;
   /** Array of object IDs. Results will be limited to terms associated with these objects. */
-  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  objectIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Direction the connection should be ordered in */
   order?: InputMaybe<OrderEnum>;
   /** Field(s) to order terms by. Defaults to 'name'. */
   orderby?: InputMaybe<TermObjectsConnectionOrderbyEnum>;
   /** Whether to pad the quantity of a term's children in the quantity of each term's "count" object variable. Default false. */
-  padCounts?: InputMaybe<Scalars['Boolean']>;
+  padCounts?: InputMaybe<Scalars['Boolean']['input']>;
   /** Parent term ID to retrieve direct-child terms of. Default empty. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Search criteria to match terms. Will be SQL-formatted with wildcards before and after. Default empty. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of slugs to return term(s) for. Default empty. */
-  slug?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The Taxonomy to filter terms by */
   taxonomies?: InputMaybe<Array<InputMaybe<TaxonomyEnum>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of term taxonomy IDs, to match when querying terms. */
-  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  termTaxonomyId?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Whether to prime meta caches for matched terms. Default true. */
-  updateTermMetaCache?: InputMaybe<Scalars['Boolean']>;
+  updateTermMetaCache?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Connection between the RootQuery type and the Theme type */
@@ -9628,7 +9741,7 @@ export type RootQueryToThemeConnectionEdge = Edge &
   ThemeConnectionEdge & {
     __typename?: 'RootQueryToThemeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Theme;
   };
@@ -9650,7 +9763,7 @@ export type RootQueryToTranslationConnectionEdge = Edge &
   TranslationConnectionEdge & {
     __typename?: 'RootQueryToTranslationConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Translation;
   };
@@ -9660,37 +9773,37 @@ export type RootQueryToTranslationConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the RootQuery type and the User type */
@@ -9710,7 +9823,7 @@ export type RootQueryToUserConnectionEdge = Edge &
   UserConnectionEdge & {
     __typename?: 'RootQueryToUserConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: User;
   };
@@ -9718,23 +9831,23 @@ export type RootQueryToUserConnectionEdge = Edge &
 /** Arguments for filtering the RootQueryToUserConnection connection */
 export type RootQueryToUserConnectionWhereArgs = {
   /** Array of userIds to exclude. */
-  exclude?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  exclude?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
   /** Pass an array of post types to filter results to users who have published posts in those post types. */
   hasPublishedPosts?: InputMaybe<Array<InputMaybe<ContentTypeEnum>>>;
   /** Array of userIds to include. */
-  include?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+  include?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
   /** The user login. */
-  login?: InputMaybe<Scalars['String']>;
+  login?: InputMaybe<Scalars['String']['input']>;
   /** An array of logins to include. Users matching one of these logins will be included in results. */
-  loginIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  loginIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** An array of logins to exclude. Users matching one of these logins will not be included in results. */
-  loginNotIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  loginNotIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The user nicename. */
-  nicename?: InputMaybe<Scalars['String']>;
+  nicename?: InputMaybe<Scalars['String']['input']>;
   /** An array of nicenames to include. Users matching one of these nicenames will be included in results. */
-  nicenameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nicenameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** An array of nicenames to exclude. Users matching one of these nicenames will not be included in results. */
-  nicenameNotIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nicenameNotIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<UsersConnectionOrderbyInput>>>;
   /** An array of role names that users must match to be included in results. Note that this is an inclusive list: users must match *each* role. */
@@ -9744,7 +9857,7 @@ export type RootQueryToUserConnectionWhereArgs = {
   /** An array of role names to exclude. Users matching one or more of these roles will not be included in results. */
   roleNotIn?: InputMaybe<Array<InputMaybe<UserRoleEnum>>>;
   /** Search keyword. Searches for possible string matches on columns. When "searchColumns" is left empty, it tries to determine which column to search in based on search string. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Array of column names to be searched. Accepts 'ID', 'login', 'nicename', 'email', 'url'. */
   searchColumns?: InputMaybe<
     Array<InputMaybe<UsersConnectionSearchColumnEnum>>
@@ -9768,7 +9881,7 @@ export type RootQueryToUserRoleConnectionEdge = Edge &
   UserRoleConnectionEdge & {
     __typename?: 'RootQueryToUserRoleConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: UserRole;
   };
@@ -9776,69 +9889,69 @@ export type RootQueryToUserRoleConnectionEdge = Edge &
 export type Seo = {
   __typename?: 'SEO';
   /** Canonical URL */
-  canonicalUrl?: Maybe<Scalars['String']>;
+  canonicalUrl?: Maybe<Scalars['String']['output']>;
   /** SEO Description */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Whether this page should be excluded from all archive queries */
-  excludeFromArchive?: Maybe<Scalars['Boolean']>;
+  excludeFromArchive?: Maybe<Scalars['Boolean']['output']>;
   /** Whether this page should be excluded from all search queries */
-  excludeLocalSearch?: Maybe<Scalars['Boolean']>;
+  excludeLocalSearch?: Maybe<Scalars['Boolean']['output']>;
   /** Whether search engines should show cached links of this page */
-  noArchive?: Maybe<Scalars['Boolean']>;
+  noArchive?: Maybe<Scalars['Boolean']['output']>;
   /** Whether search engines should follow the links of this page */
-  noFollow?: Maybe<Scalars['Boolean']>;
+  noFollow?: Maybe<Scalars['Boolean']['output']>;
   /** Whether search engines should index this page */
-  noIndex?: Maybe<Scalars['Boolean']>;
+  noIndex?: Maybe<Scalars['Boolean']['output']>;
   /** Open Graph description */
-  openGraphDescription?: Maybe<Scalars['String']>;
+  openGraphDescription?: Maybe<Scalars['String']['output']>;
   /** Open Graph title */
-  openGraphTitle?: Maybe<Scalars['String']>;
+  openGraphTitle?: Maybe<Scalars['String']['output']>;
   /** Open Graph type (&#039;website&#039;, &#039;article&#039;, ...) */
-  openGraphType?: Maybe<Scalars['String']>;
+  openGraphType?: Maybe<Scalars['String']['output']>;
   /** 301 redirect URL to force visitors to another page */
-  redirectUrl?: Maybe<Scalars['String']>;
+  redirectUrl?: Maybe<Scalars['String']['output']>;
   /** If true, site title is/should not be added to the end of the SEO title */
-  removeSiteTitle?: Maybe<Scalars['Boolean']>;
+  removeSiteTitle?: Maybe<Scalars['Boolean']['output']>;
   socialImage?: Maybe<MediaItem>;
   /** SEO Title */
-  title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']['output']>;
   /** Twitter description */
-  twitterDescription?: Maybe<Scalars['String']>;
+  twitterDescription?: Maybe<Scalars['String']['output']>;
   /** Twitter title */
-  twitterTitle?: Maybe<Scalars['String']>;
+  twitterTitle?: Maybe<Scalars['String']['output']>;
 };
 
 export type SearchResultConnection = {
   __typename?: 'SearchResultConnection';
-  count?: Maybe<Scalars['Int']>;
+  count?: Maybe<Scalars['Int']['output']>;
   edges: Array<SearchResultEdge>;
   /** Elasticsearch raw results */
   es_results?: Maybe<Array<Maybe<ElasticSearchResult>>>;
-  max_score?: Maybe<Scalars['Float']>;
+  max_score?: Maybe<Scalars['Float']['output']>;
   pageInfo?: Maybe<SearchResultPageInfo>;
 };
 
 export type SearchResultEdge = {
   __typename?: 'SearchResultEdge';
-  cursor: Scalars['String'];
+  cursor: Scalars['String']['output'];
   node: SearchResultNode;
 };
 
 export type SearchResultNode = {
   __typename?: 'SearchResultNode';
-  _score?: Maybe<Scalars['Float']>;
+  _score?: Maybe<Scalars['Float']['output']>;
   event?: Maybe<Event>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   searchCategories: Array<UnifiedSearchResultCategory>;
   venue?: Maybe<UnifiedSearchVenue>;
 };
 
 export type SearchResultPageInfo = {
   __typename?: 'SearchResultPageInfo';
-  endCursor?: Maybe<Scalars['String']>;
-  hasNextPage: Scalars['Boolean'];
-  hasPreviousPage: Scalars['Boolean'];
-  startCursor?: Maybe<Scalars['String']>;
+  endCursor?: Maybe<Scalars['String']['output']>;
+  hasNextPage: Scalars['Boolean']['output'];
+  hasPreviousPage: Scalars['Boolean']['output'];
+  startCursor?: Maybe<Scalars['String']['output']>;
 };
 
 export type SearchSuggestionConnection = {
@@ -9849,18 +9962,18 @@ export type SearchSuggestionConnection = {
 /** Input for the sendPasswordResetEmail mutation. */
 export type SendPasswordResetEmailInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains the user's username or email address. */
-  username: Scalars['String'];
+  username: Scalars['String']['input'];
 };
 
 /** The payload for the sendPasswordResetEmail mutation. */
 export type SendPasswordResetEmailPayload = {
   __typename?: 'SendPasswordResetEmailPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** Whether the mutation completed successfully. This does NOT necessarily mean that an email was sent. */
-  success?: Maybe<Scalars['Boolean']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
   /**
    * The user that the password reset email was sent to
    * @deprecated This field will be removed in a future version of WPGraphQL
@@ -9871,69 +9984,94 @@ export type SendPasswordResetEmailPayload = {
 export type SeoSettings = {
   __typename?: 'SeoSettings';
   /** Title separator setting for seo titles */
-  separator?: Maybe<Scalars['String']>;
+  separator?: Maybe<Scalars['String']['output']>;
 };
+
+export type ServiceOwner = {
+  __typename?: 'ServiceOwner';
+  name?: Maybe<LanguageString>;
+  providerType?: Maybe<ProviderType>;
+  type?: Maybe<ServiceOwnerType>;
+};
+
+export enum ServiceOwnerType {
+  MunicipalService = 'MUNICIPAL_SERVICE',
+  NotDisplayed = 'NOT_DISPLAYED',
+  PrivateContractSchool = 'PRIVATE_CONTRACT_SCHOOL',
+  PrivateService = 'PRIVATE_SERVICE',
+  PurchasedService = 'PURCHASED_SERVICE',
+  ServiceByJointMunicipalAuthority = 'SERVICE_BY_JOINT_MUNICIPAL_AUTHORITY',
+  ServiceByMunicipallyOwnedCompany = 'SERVICE_BY_MUNICIPALLY_OWNED_COMPANY',
+  ServiceByMunicipalGroupEntity = 'SERVICE_BY_MUNICIPAL_GROUP_ENTITY',
+  ServiceByOtherMunicipality = 'SERVICE_BY_OTHER_MUNICIPALITY',
+  ServiceByRegionalCooperationOrganization = 'SERVICE_BY_REGIONAL_COOPERATION_ORGANIZATION',
+  ServiceByWellbeingArea = 'SERVICE_BY_WELLBEING_AREA',
+  StateContractSchool = 'STATE_CONTRACT_SCHOOL',
+  StateService = 'STATE_SERVICE',
+  SupportedOperations = 'SUPPORTED_OPERATIONS',
+  VoucherService = 'VOUCHER_SERVICE',
+}
 
 /** All of the registered settings */
 export type Settings = {
   __typename?: 'Settings';
   /** Settings of the the string Settings Group */
-  discussionSettingsDefaultCommentStatus?: Maybe<Scalars['String']>;
+  discussionSettingsDefaultCommentStatus?: Maybe<Scalars['String']['output']>;
   /** Settings of the the string Settings Group */
-  discussionSettingsDefaultPingStatus?: Maybe<Scalars['String']>;
+  discussionSettingsDefaultPingStatus?: Maybe<Scalars['String']['output']>;
   /** Settings of the the string Settings Group */
-  generalSettingsDateFormat?: Maybe<Scalars['String']>;
+  generalSettingsDateFormat?: Maybe<Scalars['String']['output']>;
   /** Settings of the the string Settings Group */
-  generalSettingsDescription?: Maybe<Scalars['String']>;
+  generalSettingsDescription?: Maybe<Scalars['String']['output']>;
   /** Settings of the the string Settings Group */
-  generalSettingsLanguage?: Maybe<Scalars['String']>;
+  generalSettingsLanguage?: Maybe<Scalars['String']['output']>;
   /** Settings of the the integer Settings Group */
-  generalSettingsStartOfWeek?: Maybe<Scalars['Int']>;
+  generalSettingsStartOfWeek?: Maybe<Scalars['Int']['output']>;
   /** Settings of the the string Settings Group */
-  generalSettingsTimeFormat?: Maybe<Scalars['String']>;
+  generalSettingsTimeFormat?: Maybe<Scalars['String']['output']>;
   /** Settings of the the string Settings Group */
-  generalSettingsTimezone?: Maybe<Scalars['String']>;
+  generalSettingsTimezone?: Maybe<Scalars['String']['output']>;
   /** Settings of the the string Settings Group */
-  generalSettingsTitle?: Maybe<Scalars['String']>;
+  generalSettingsTitle?: Maybe<Scalars['String']['output']>;
   /** Settings of the the integer Settings Group */
-  readingSettingsPageForPosts?: Maybe<Scalars['Int']>;
+  readingSettingsPageForPosts?: Maybe<Scalars['Int']['output']>;
   /** Settings of the the integer Settings Group */
-  readingSettingsPageOnFront?: Maybe<Scalars['Int']>;
+  readingSettingsPageOnFront?: Maybe<Scalars['Int']['output']>;
   /** Settings of the the integer Settings Group */
-  readingSettingsPostsPerPage?: Maybe<Scalars['Int']>;
+  readingSettingsPostsPerPage?: Maybe<Scalars['Int']['output']>;
   /** Settings of the the string Settings Group */
-  readingSettingsShowOnFront?: Maybe<Scalars['String']>;
+  readingSettingsShowOnFront?: Maybe<Scalars['String']['output']>;
   /** Settings of the the integer Settings Group */
-  writingSettingsDefaultCategory?: Maybe<Scalars['Int']>;
+  writingSettingsDefaultCategory?: Maybe<Scalars['Int']['output']>;
   /** Settings of the the string Settings Group */
-  writingSettingsDefaultPostFormat?: Maybe<Scalars['String']>;
+  writingSettingsDefaultPostFormat?: Maybe<Scalars['String']['output']>;
   /** Settings of the the boolean Settings Group */
-  writingSettingsUseSmilies?: Maybe<Scalars['Boolean']>;
+  writingSettingsUseSmilies?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type Shards = {
   __typename?: 'Shards';
-  failed?: Maybe<Scalars['Int']>;
-  skipped?: Maybe<Scalars['Int']>;
-  successful?: Maybe<Scalars['Int']>;
-  total?: Maybe<Scalars['Int']>;
+  failed?: Maybe<Scalars['Int']['output']>;
+  skipped?: Maybe<Scalars['Int']['output']>;
+  successful?: Maybe<Scalars['Int']['output']>;
+  total?: Maybe<Scalars['Int']['output']>;
 };
 
 export type SingleHit = {
   __typename?: 'SingleHit';
-  _id?: Maybe<Scalars['String']>;
-  _index?: Maybe<Scalars['String']>;
-  _score?: Maybe<Scalars['Float']>;
+  _id?: Maybe<Scalars['String']['output']>;
+  _index?: Maybe<Scalars['String']['output']>;
+  _score?: Maybe<Scalars['Float']['output']>;
   _source?: Maybe<RawJson>;
-  _type?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']['output']>;
 };
 
 export type SiteSettings = {
   __typename?: 'SiteSettings';
   /** Attachment ID for logo */
-  logo?: Maybe<Scalars['String']>;
+  logo?: Maybe<Scalars['String']['output']>;
   /** Identifying name */
-  siteName?: Maybe<Scalars['String']>;
+  siteName?: Maybe<Scalars['String']['output']>;
 };
 
 export enum SortOrder {
@@ -9944,43 +10082,43 @@ export enum SortOrder {
 export type StaticPage = {
   __typename?: 'StaticPage';
   contentSection?: Maybe<LocalizedObject>;
-  contentYype?: Maybe<Scalars['Int']>;
-  depth?: Maybe<Scalars['Int']>;
-  draftTitle?: Maybe<Scalars['String']>;
-  expireAt?: Maybe<Scalars['String']>;
-  expired?: Maybe<Scalars['Boolean']>;
-  firstPublishedAt?: Maybe<Scalars['String']>;
-  goLiveAt?: Maybe<Scalars['String']>;
-  hasUnpublishedChanges?: Maybe<Scalars['Boolean']>;
+  contentYype?: Maybe<Scalars['Int']['output']>;
+  depth?: Maybe<Scalars['Int']['output']>;
+  draftTitle?: Maybe<Scalars['String']['output']>;
+  expireAt?: Maybe<Scalars['String']['output']>;
+  expired?: Maybe<Scalars['Boolean']['output']>;
+  firstPublishedAt?: Maybe<Scalars['String']['output']>;
+  goLiveAt?: Maybe<Scalars['String']['output']>;
+  hasUnpublishedChanges?: Maybe<Scalars['Boolean']['output']>;
   headingSection?: Maybe<LocalizedObject>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   keywords?: Maybe<LocalizedCmsKeywords>;
-  lastPublishedAt?: Maybe<Scalars['String']>;
-  latestRevisionCreatedAt?: Maybe<Scalars['String']>;
-  live?: Maybe<Scalars['Boolean']>;
-  liveRevision?: Maybe<Scalars['Int']>;
-  locked?: Maybe<Scalars['Boolean']>;
-  lockedAt?: Maybe<Scalars['String']>;
-  lockedBy?: Maybe<Scalars['String']>;
-  numchild?: Maybe<Scalars['Int']>;
-  owner?: Maybe<Scalars['Int']>;
-  path?: Maybe<Scalars['String']>;
-  searchDescription?: Maybe<Scalars['String']>;
-  seoTitle?: Maybe<Scalars['String']>;
-  showInMenus?: Maybe<Scalars['Boolean']>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  urlPath?: Maybe<Scalars['String']>;
+  lastPublishedAt?: Maybe<Scalars['String']['output']>;
+  latestRevisionCreatedAt?: Maybe<Scalars['String']['output']>;
+  live?: Maybe<Scalars['Boolean']['output']>;
+  liveRevision?: Maybe<Scalars['Int']['output']>;
+  locked?: Maybe<Scalars['Boolean']['output']>;
+  lockedAt?: Maybe<Scalars['String']['output']>;
+  lockedBy?: Maybe<Scalars['String']['output']>;
+  numchild?: Maybe<Scalars['Int']['output']>;
+  owner?: Maybe<Scalars['Int']['output']>;
+  path?: Maybe<Scalars['String']['output']>;
+  searchDescription?: Maybe<Scalars['String']['output']>;
+  seoTitle?: Maybe<Scalars['String']['output']>;
+  showInMenus?: Maybe<Scalars['Boolean']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  urlPath?: Maybe<Scalars['String']['output']>;
 };
 
 export type Subscription = {
   __typename?: 'Subscription';
-  _empty?: Maybe<Scalars['String']>;
+  _empty?: Maybe<Scalars['String']['output']>;
 };
 
 export type Suggestion = {
   __typename?: 'Suggestion';
-  label: Scalars['String'];
+  label: Scalars['String']['output'];
 };
 
 /** The tag type */
@@ -9993,85 +10131,85 @@ export type Tag = DatabaseIdentifier &
     /** Connection between the Tag type and the ContentNode type */
     contentNodes?: Maybe<TagToContentNodeConnection>;
     /** The number of objects connected to the object */
-    count?: Maybe<Scalars['Int']>;
+    count?: Maybe<Scalars['Int']['output']>;
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** The description of the object */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** Connection between the TermNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<TermNodeToEnqueuedScriptConnection>;
     /** Connection between the TermNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<TermNodeToEnqueuedStylesheetConnection>;
     /** The unique resource identifier path */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** List available translations for this post */
     language?: Maybe<Language>;
     /** The link to the term */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The human friendly name of the object. */
-    name?: Maybe<Scalars['String']>;
+    name?: Maybe<Scalars['String']['output']>;
     /** Connection between the Tag type and the post type */
     posts?: Maybe<TagToPostConnection>;
     /** An alphanumeric identifier for the object unique to its type. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of databaseId
      */
-    tagId?: Maybe<Scalars['Int']>;
+    tagId?: Maybe<Scalars['Int']['output']>;
     /** Connection between the Tag type and the Taxonomy type */
     taxonomy?: Maybe<TagToTaxonomyConnectionEdge>;
     /** The name of the taxonomy that the object is associated with */
-    taxonomyName?: Maybe<Scalars['String']>;
+    taxonomyName?: Maybe<Scalars['String']['output']>;
     /** The ID of the term group that this term object belongs to */
-    termGroupId?: Maybe<Scalars['Int']>;
+    termGroupId?: Maybe<Scalars['Int']['output']>;
     /** The taxonomy ID that the object is associated with */
-    termTaxonomyId?: Maybe<Scalars['Int']>;
+    termTaxonomyId?: Maybe<Scalars['Int']['output']>;
     /** Get specific translation version of this object */
     translation?: Maybe<Tag>;
     /** List all translated versions of this term */
     translations?: Maybe<Array<Maybe<Tag>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The tag type */
 export type TagContentNodesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TagToContentNodeConnectionWhereArgs>;
 };
 
 /** The tag type */
 export type TagEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The tag type */
 export type TagEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The tag type */
 export type TagPostsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TagToPostConnectionWhereArgs>;
 };
 
@@ -10091,7 +10229,7 @@ export type TagConnection = {
 /** Edge between a Node and a connected tag */
 export type TagConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected tag Node */
   node: Tag;
 };
@@ -10127,7 +10265,7 @@ export type TagToContentNodeConnectionEdge = ContentNodeConnectionEdge &
   Edge & {
     __typename?: 'TagToContentNodeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentNode;
   };
@@ -10139,37 +10277,37 @@ export type TagToContentNodeConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the Tag type and the post type */
@@ -10189,7 +10327,7 @@ export type TagToPostConnectionEdge = Edge &
   PostConnectionEdge & {
     __typename?: 'TagToPostConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Post;
   };
@@ -10197,67 +10335,67 @@ export type TagToPostConnectionEdge = Edge &
 /** Arguments for filtering the TagToPostConnection connection */
 export type TagToPostConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Category ID */
-  categoryId?: InputMaybe<Scalars['Int']>;
+  categoryId?: InputMaybe<Scalars['Int']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Use Category Slug */
-  categoryName?: InputMaybe<Scalars['String']>;
+  categoryName?: InputMaybe<Scalars['String']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Tag Slug */
-  tag?: InputMaybe<Scalars['String']>;
+  tag?: InputMaybe<Scalars['String']['input']>;
   /** Use Tag ID */
-  tagId?: InputMaybe<Scalars['String']>;
+  tagId?: InputMaybe<Scalars['String']['input']>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag slugs, used to display objects from one tag AND another */
-  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of tag slugs, used to include objects in ANY specified tags */
-  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the Tag type and the Taxonomy type */
@@ -10266,10 +10404,21 @@ export type TagToTaxonomyConnectionEdge = Edge &
   TaxonomyConnectionEdge & {
     __typename?: 'TagToTaxonomyConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Taxonomy;
   };
+
+export enum TargetGroup {
+  Associations = 'ASSOCIATIONS',
+  ChildrenAndFamilies = 'CHILDREN_AND_FAMILIES',
+  Disabled = 'DISABLED',
+  ElderlyPeople = 'ELDERLY_PEOPLE',
+  Enterprises = 'ENTERPRISES',
+  Immigrants = 'IMMIGRANTS',
+  Individuals = 'INDIVIDUALS',
+  Youth = 'YOUTH',
+}
 
 /** A taxonomy object */
 export type Taxonomy = Node & {
@@ -10277,51 +10426,51 @@ export type Taxonomy = Node & {
   /** List of Content Types associated with the Taxonomy */
   connectedContentTypes?: Maybe<TaxonomyToContentTypeConnection>;
   /** Description of the taxonomy. This field is equivalent to WP_Taxonomy-&gt;description */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** The plural name of the post type within the GraphQL Schema. */
-  graphqlPluralName?: Maybe<Scalars['String']>;
+  graphqlPluralName?: Maybe<Scalars['String']['output']>;
   /** The singular name of the post type within the GraphQL Schema. */
-  graphqlSingleName?: Maybe<Scalars['String']>;
+  graphqlSingleName?: Maybe<Scalars['String']['output']>;
   /** Whether the taxonomy is hierarchical */
-  hierarchical?: Maybe<Scalars['Boolean']>;
+  hierarchical?: Maybe<Scalars['Boolean']['output']>;
   /** The globally unique identifier of the taxonomy object. */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Name of the taxonomy shown in the menu. Usually plural. */
-  label?: Maybe<Scalars['String']>;
+  label?: Maybe<Scalars['String']['output']>;
   /** The display name of the taxonomy. This field is equivalent to WP_Taxonomy-&gt;label */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** Whether the taxonomy is publicly queryable */
-  public?: Maybe<Scalars['Boolean']>;
+  public?: Maybe<Scalars['Boolean']['output']>;
   /** Name of content type to diplay in REST API &quot;wp/v2&quot; namespace. */
-  restBase?: Maybe<Scalars['String']>;
+  restBase?: Maybe<Scalars['String']['output']>;
   /** The REST Controller class assigned to handling this content type. */
-  restControllerClass?: Maybe<Scalars['String']>;
+  restControllerClass?: Maybe<Scalars['String']['output']>;
   /** Whether to show the taxonomy as part of a tag cloud widget. This field is equivalent to WP_Taxonomy-&gt;show_tagcloud */
-  showCloud?: Maybe<Scalars['Boolean']>;
+  showCloud?: Maybe<Scalars['Boolean']['output']>;
   /** Whether to display a column for the taxonomy on its post type listing screens. */
-  showInAdminColumn?: Maybe<Scalars['Boolean']>;
+  showInAdminColumn?: Maybe<Scalars['Boolean']['output']>;
   /** Whether to add the post type to the GraphQL Schema. */
-  showInGraphql?: Maybe<Scalars['Boolean']>;
+  showInGraphql?: Maybe<Scalars['Boolean']['output']>;
   /** Whether to show the taxonomy in the admin menu */
-  showInMenu?: Maybe<Scalars['Boolean']>;
+  showInMenu?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the taxonomy is available for selection in navigation menus. */
-  showInNavMenus?: Maybe<Scalars['Boolean']>;
+  showInNavMenus?: Maybe<Scalars['Boolean']['output']>;
   /** Whether to show the taxonomy in the quick/bulk edit panel. */
-  showInQuickEdit?: Maybe<Scalars['Boolean']>;
+  showInQuickEdit?: Maybe<Scalars['Boolean']['output']>;
   /** Whether to add the post type route in the REST API &quot;wp/v2&quot; namespace. */
-  showInRest?: Maybe<Scalars['Boolean']>;
+  showInRest?: Maybe<Scalars['Boolean']['output']>;
   /** Whether to generate and allow a UI for managing terms in this taxonomy in the admin */
-  showUi?: Maybe<Scalars['Boolean']>;
+  showUi?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** A taxonomy object */
 export type TaxonomyConnectedContentTypesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Connection to Taxonomy Nodes */
@@ -10335,7 +10484,7 @@ export type TaxonomyConnection = {
 /** Edge between a Node and a connected Taxonomy */
 export type TaxonomyConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected Taxonomy Node */
   node: Taxonomy;
 };
@@ -10375,7 +10524,7 @@ export type TaxonomyToContentTypeConnectionEdge = ContentTypeConnectionEdge &
   Edge & {
     __typename?: 'TaxonomyToContentTypeConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentType;
   };
@@ -10389,53 +10538,53 @@ export enum TemplateEnum {
 /** Terms are nodes within a Taxonomy, used to group and relate other nodes. */
 export type TermNode = {
   /** The number of objects connected to the object */
-  count?: Maybe<Scalars['Int']>;
+  count?: Maybe<Scalars['Int']['output']>;
   /** Identifies the primary key from the database. */
-  databaseId: Scalars['Int'];
+  databaseId: Scalars['Int']['output'];
   /** The description of the object */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Connection between the TermNode type and the EnqueuedScript type */
   enqueuedScripts?: Maybe<TermNodeToEnqueuedScriptConnection>;
   /** Connection between the TermNode type and the EnqueuedStylesheet type */
   enqueuedStylesheets?: Maybe<TermNodeToEnqueuedStylesheetConnection>;
   /** The unique resource identifier path */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the node is a Content Node */
-  isContentNode: Scalars['Boolean'];
+  isContentNode: Scalars['Boolean']['output'];
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Whether the node is a Term */
-  isTermNode: Scalars['Boolean'];
+  isTermNode: Scalars['Boolean']['output'];
   /** The link to the term */
-  link?: Maybe<Scalars['String']>;
+  link?: Maybe<Scalars['String']['output']>;
   /** The human friendly name of the object. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** An alphanumeric identifier for the object unique to its type. */
-  slug?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']['output']>;
   /** The name of the taxonomy that the object is associated with */
-  taxonomyName?: Maybe<Scalars['String']>;
+  taxonomyName?: Maybe<Scalars['String']['output']>;
   /** The ID of the term group that this term object belongs to */
-  termGroupId?: Maybe<Scalars['Int']>;
+  termGroupId?: Maybe<Scalars['Int']['output']>;
   /** The taxonomy ID that the object is associated with */
-  termTaxonomyId?: Maybe<Scalars['Int']>;
+  termTaxonomyId?: Maybe<Scalars['Int']['output']>;
   /** The unique resource identifier path */
-  uri?: Maybe<Scalars['String']>;
+  uri?: Maybe<Scalars['String']['output']>;
 };
 
 /** Terms are nodes within a Taxonomy, used to group and relate other nodes. */
 export type TermNodeEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Terms are nodes within a Taxonomy, used to group and relate other nodes. */
 export type TermNodeEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Connection to TermNode Nodes */
@@ -10449,7 +10598,7 @@ export type TermNodeConnection = {
 /** Edge between a Node and a connected TermNode */
 export type TermNodeConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected TermNode Node */
   node: TermNode;
 };
@@ -10485,7 +10634,7 @@ export type TermNodeToEnqueuedScriptConnectionEdge = Edge &
   EnqueuedScriptConnectionEdge & {
     __typename?: 'TermNodeToEnqueuedScriptConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedScript;
   };
@@ -10507,7 +10656,7 @@ export type TermNodeToEnqueuedStylesheetConnectionEdge = Edge &
   EnqueuedStylesheetConnectionEdge & {
     __typename?: 'TermNodeToEnqueuedStylesheetConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedStylesheet;
   };
@@ -10534,27 +10683,27 @@ export enum TermObjectsConnectionOrderbyEnum {
 export type Theme = Node & {
   __typename?: 'Theme';
   /** Name of the theme author(s), could also be a company name. This field is equivalent to WP_Theme-&gt;get( &quot;Author&quot; ). */
-  author?: Maybe<Scalars['String']>;
+  author?: Maybe<Scalars['String']['output']>;
   /** URI for the author/company website. This field is equivalent to WP_Theme-&gt;get( &quot;AuthorURI&quot; ). */
-  authorUri?: Maybe<Scalars['String']>;
+  authorUri?: Maybe<Scalars['String']['output']>;
   /** The description of the theme. This field is equivalent to WP_Theme-&gt;get( &quot;Description&quot; ). */
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** The globally unique identifier of the theme object. */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** Display name of the theme. This field is equivalent to WP_Theme-&gt;get( &quot;Name&quot; ). */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** The URL of the screenshot for the theme. The screenshot is intended to give an overview of what the theme looks like. This field is equivalent to WP_Theme-&gt;get_screenshot(). */
-  screenshot?: Maybe<Scalars['String']>;
+  screenshot?: Maybe<Scalars['String']['output']>;
   /** The theme slug is used to internally match themes. Theme slugs can have subdirectories like: my-theme/sub-theme. This field is equivalent to WP_Theme-&gt;get_stylesheet(). */
-  slug?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']['output']>;
   /** URI for the author/company website. This field is equivalent to WP_Theme-&gt;get( &quot;Tags&quot; ). */
-  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
+  tags?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** A URI if the theme has a website associated with it. The Theme URI is handy for directing users to a theme site for support etc. This field is equivalent to WP_Theme-&gt;get( &quot;ThemeURI&quot; ). */
-  themeUri?: Maybe<Scalars['String']>;
+  themeUri?: Maybe<Scalars['String']['output']>;
   /** The current version of the theme. This field is equivalent to WP_Theme-&gt;get( &quot;Version&quot; ). */
-  version?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['String']['output']>;
 };
 
 /** Connection to Theme Nodes */
@@ -10568,29 +10717,29 @@ export type ThemeConnection = {
 /** Edge between a Node and a connected Theme */
 export type ThemeConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected Theme Node */
   node: Theme;
 };
 
 export type Time = {
   __typename?: 'Time';
-  description: Scalars['String'];
-  endTime: Scalars['String'];
-  endTimeOnNextDay: Scalars['Boolean'];
-  fullDay: Scalars['Boolean'];
-  name: Scalars['String'];
-  periods: Array<Scalars['Int']>;
+  description: Scalars['String']['output'];
+  endTime: Scalars['String']['output'];
+  endTimeOnNextDay: Scalars['Boolean']['output'];
+  fullDay: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  periods: Array<Scalars['Int']['output']>;
   resourceState: ResourceState;
-  startTime: Scalars['String'];
+  startTime: Scalars['String']['output'];
 };
 
 /** any kind of description answering the question "when". */
 export type TimeDescription = {
   __typename?: 'TimeDescription';
-  ending?: Maybe<Scalars['DateTime']>;
+  ending?: Maybe<Scalars['DateTime']['output']>;
   otherTime?: Maybe<TimeDescription>;
-  starting?: Maybe<Scalars['DateTime']>;
+  starting?: Maybe<Scalars['DateTime']['output']>;
 };
 
 /** The translation type */
@@ -10606,51 +10755,51 @@ export type Translation = ContentNode &
     /** Connection between the ContentNode type and the ContentType type */
     contentType?: Maybe<ContentNodeToContentTypeConnectionEdge>;
     /** The name of the Content Type the node belongs to */
-    contentTypeName: Scalars['String'];
+    contentTypeName: Scalars['String']['output'];
     /** The unique identifier stored in the database */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Post publishing date. */
-    date?: Maybe<Scalars['String']>;
+    date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
-    dateGmt?: Maybe<Scalars['String']>;
+    dateGmt?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
-    desiredSlug?: Maybe<Scalars['String']>;
+    desiredSlug?: Maybe<Scalars['String']['output']>;
     /** If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds */
     editingLockedBy?: Maybe<ContentNodeToEditLockConnectionEdge>;
     /** The RSS enclosure for the object */
-    enclosure?: Maybe<Scalars['String']>;
+    enclosure?: Maybe<Scalars['String']['output']>;
     /** Connection between the ContentNode type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<ContentNodeToEnqueuedScriptConnection>;
     /** Connection between the ContentNode type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<ContentNodeToEnqueuedStylesheetConnection>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
-    guid?: Maybe<Scalars['String']>;
+    guid?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier of the translation-cpt object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is a node in the preview state */
-    isPreview?: Maybe<Scalars['Boolean']>;
+    isPreview?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** True if the node is a revision of another node */
-    isRevision?: Maybe<Scalars['Boolean']>;
+    isRevision?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
     /** The permalink of the post */
-    link?: Maybe<Scalars['String']>;
+    link?: Maybe<Scalars['String']['output']>;
     /** The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time. */
-    modified?: Maybe<Scalars['String']>;
+    modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
-    modifiedGmt?: Maybe<Scalars['String']>;
+    modifiedGmt?: Maybe<Scalars['String']['output']>;
     /** Connection between the Translation type and the translation type */
     preview?: Maybe<TranslationToPreviewConnectionEdge>;
     /** The database id of the preview node */
-    previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
+    previewRevisionDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Whether the object is a node in the preview state */
-    previewRevisionId?: Maybe<Scalars['ID']>;
+    previewRevisionId?: Maybe<Scalars['ID']['output']>;
     /** If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node. */
     revisionOf?: Maybe<NodeWithRevisionsToContentNodeConnectionEdge>;
     /** Connection between the Translation type and the translation type */
@@ -10658,46 +10807,46 @@ export type Translation = ContentNode &
     /** The SEO Framework data of the translation */
     seo?: Maybe<Seo>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The current status of the object */
-    status?: Maybe<Scalars['String']>;
+    status?: Maybe<Scalars['String']['output']>;
     /** The template assigned to the node */
     template?: Maybe<ContentTemplate>;
     /** The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made. */
-    title?: Maybe<Scalars['String']>;
+    title?: Maybe<Scalars['String']['output']>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
      * @deprecated Deprecated in favor of the databaseId field
      */
-    translationId: Scalars['Int'];
+    translationId: Scalars['Int']['output'];
     /** Translations */
     translations?: Maybe<Array<Maybe<TranslationResponse>>>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
   };
 
 /** The translation type */
 export type TranslationEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The translation type */
 export type TranslationEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** The translation type */
 export type TranslationRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TranslationToRevisionConnectionWhereArgs>;
 };
 
@@ -10717,7 +10866,7 @@ export type TranslationConnection = {
 /** Edge between a Node and a connected translation */
 export type TranslationConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected translation Node */
   node: Translation;
 };
@@ -10738,18 +10887,18 @@ export enum TranslationIdType {
 export type TranslationItems = {
   __typename?: 'TranslationItems';
   /** Translation string */
-  en?: Maybe<Scalars['String']>;
+  en?: Maybe<Scalars['String']['output']>;
   /** Translation string */
-  fi?: Maybe<Scalars['String']>;
+  fi?: Maybe<Scalars['String']['output']>;
   /** Translation string */
-  sv?: Maybe<Scalars['String']>;
+  sv?: Maybe<Scalars['String']['output']>;
 };
 
 /** Translation response contains translation key and translations */
 export type TranslationResponse = {
   __typename?: 'TranslationResponse';
   /** Translation key for frontend */
-  key?: Maybe<Scalars['String']>;
+  key?: Maybe<Scalars['String']['output']>;
   /** Translations for frontend */
   translations?: Maybe<TranslationItems>;
 };
@@ -10760,7 +10909,7 @@ export type TranslationToPreviewConnectionEdge = Edge &
   TranslationConnectionEdge & {
     __typename?: 'TranslationToPreviewConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The node of the connection, without the edges */
     node: Translation;
   };
@@ -10782,7 +10931,7 @@ export type TranslationToRevisionConnectionEdge = Edge &
   TranslationConnectionEdge & {
     __typename?: 'TranslationToRevisionConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Translation;
   };
@@ -10792,37 +10941,37 @@ export type TranslationToRevisionConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 export enum UnifiedSearchLanguage {
@@ -10853,9 +11002,9 @@ export enum UnifiedSearchResultCategory {
  */
 export type UnifiedSearchVenue = {
   __typename?: 'UnifiedSearchVenue';
-  accessibilityProfile?: Maybe<AccessibilityProfile>;
-  additionalInfo?: Maybe<Scalars['String']>;
-  arrivalInstructions?: Maybe<Scalars['String']>;
+  accessibility?: Maybe<Accessibility>;
+  additionalInfo?: Maybe<Scalars['String']['output']>;
+  arrivalInstructions?: Maybe<Scalars['String']['output']>;
   contactDetails?: Maybe<ContactInfo>;
   description?: Maybe<LanguageString>;
   descriptionResources?: Maybe<DescriptionResources>;
@@ -10869,37 +11018,40 @@ export type UnifiedSearchVenue = {
   openingHours?: Maybe<OpeningHours>;
   partOf?: Maybe<UnifiedSearchVenue>;
   reservationPolicy?: Maybe<VenueReservationPolicy>;
+  resources: Array<Resource>;
+  serviceOwner?: Maybe<ServiceOwner>;
+  targetGroups?: Maybe<Array<Maybe<TargetGroup>>>;
 };
 
 /** Any node that has a URI */
 export type UniformResourceIdentifiable = {
   /** The unique resource identifier path */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the node is a Content Node */
-  isContentNode: Scalars['Boolean'];
+  isContentNode: Scalars['Boolean']['output'];
   /** Whether the node is a Term */
-  isTermNode: Scalars['Boolean'];
+  isTermNode: Scalars['Boolean']['output'];
   /** The unique resource identifier path */
-  uri?: Maybe<Scalars['String']>;
+  uri?: Maybe<Scalars['String']['output']>;
 };
 
 /** Input for the updateCategory mutation. */
 export type UpdateCategoryInput = {
   /** The slug that the category will be an alias of */
-  aliasOf?: InputMaybe<Scalars['String']>;
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The description of the category object */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the category object to update */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** The name of the category object to mutate */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the category that should be set as the parent */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
   /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateCategory mutation. */
@@ -10908,35 +11060,35 @@ export type UpdateCategoryPayload = {
   /** The created category */
   category?: Maybe<Category>;
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
 };
 
 /** Input for the updateCollection mutation. */
 export type UpdateCollectionInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the collection object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateCollection mutation. */
 export type UpdateCollectionPayload = {
   __typename?: 'UpdateCollectionPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   collection?: Maybe<Collection>;
 };
@@ -10944,68 +11096,68 @@ export type UpdateCollectionPayload = {
 /** Input for the updateComment mutation. */
 export type UpdateCommentInput = {
   /** The approval status of the comment. */
-  approved?: InputMaybe<Scalars['String']>;
+  approved?: InputMaybe<Scalars['String']['input']>;
   /** The name of the comment's author. */
-  author?: InputMaybe<Scalars['String']>;
+  author?: InputMaybe<Scalars['String']['input']>;
   /** The email of the comment's author. */
-  authorEmail?: InputMaybe<Scalars['String']>;
+  authorEmail?: InputMaybe<Scalars['String']['input']>;
   /** The url of the comment's author. */
-  authorUrl?: InputMaybe<Scalars['String']>;
+  authorUrl?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The database ID of the post object the comment belongs to. */
-  commentOn?: InputMaybe<Scalars['Int']>;
+  commentOn?: InputMaybe<Scalars['Int']['input']>;
   /** Content of the comment. */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the comment being updated. */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   /** Parent comment ID of current comment. */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** The approval status of the comment */
   status?: InputMaybe<CommentStatusEnum>;
   /** Type of comment. */
-  type?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateComment mutation. */
 export type UpdateCommentPayload = {
   __typename?: 'UpdateCommentPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The comment that was created */
   comment?: Maybe<Comment>;
   /** Whether the mutation succeeded. If the comment is not approved, the server will not return the comment to a non authenticated user, but a success message can be returned if the create succeeded, and the client can optimistically add the comment to the client cache */
-  success?: Maybe<Scalars['Boolean']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Input for the updateContact mutation. */
 export type UpdateContactInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the contact object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateContact mutation. */
 export type UpdateContactPayload = {
   __typename?: 'UpdateContactPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   contact?: Maybe<Contact>;
 };
@@ -11013,29 +11165,29 @@ export type UpdateContactPayload = {
 /** Input for the updateLandingPage mutation. */
 export type UpdateLandingPageInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the landingPage object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateLandingPage mutation. */
 export type UpdateLandingPagePayload = {
   __typename?: 'UpdateLandingPagePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   landingPage?: Maybe<LandingPage>;
 };
@@ -11043,45 +11195,45 @@ export type UpdateLandingPagePayload = {
 /** Input for the updateMediaItem mutation. */
 export type UpdateMediaItemInput = {
   /** Alternative text to display when mediaItem is not displayed */
-  altText?: InputMaybe<Scalars['String']>;
+  altText?: InputMaybe<Scalars['String']['input']>;
   /** The userId to assign as the author of the mediaItem */
-  authorId?: InputMaybe<Scalars['ID']>;
+  authorId?: InputMaybe<Scalars['ID']['input']>;
   /** The caption for the mediaItem */
-  caption?: InputMaybe<Scalars['String']>;
+  caption?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The comment status for the mediaItem */
-  commentStatus?: InputMaybe<Scalars['String']>;
+  commentStatus?: InputMaybe<Scalars['String']['input']>;
   /** The date of the mediaItem */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The date (in GMT zone) of the mediaItem */
-  dateGmt?: InputMaybe<Scalars['String']>;
+  dateGmt?: InputMaybe<Scalars['String']['input']>;
   /** Description of the mediaItem */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The file name of the mediaItem */
-  filePath?: InputMaybe<Scalars['String']>;
+  filePath?: InputMaybe<Scalars['String']['input']>;
   /** The file type of the mediaItem */
   fileType?: InputMaybe<MimeTypeEnum>;
   /** The ID of the mediaItem object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** The ID of the parent object */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
   /** The ping status for the mediaItem */
-  pingStatus?: InputMaybe<Scalars['String']>;
+  pingStatus?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the mediaItem */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the mediaItem */
   status?: InputMaybe<MediaItemStatusEnum>;
   /** The title of the mediaItem */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateMediaItem mutation. */
 export type UpdateMediaItemPayload = {
   __typename?: 'UpdateMediaItemPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The MediaItem object mutation type. */
   mediaItem?: Maybe<MediaItem>;
 };
@@ -11089,35 +11241,35 @@ export type UpdateMediaItemPayload = {
 /** Input for the updatePage mutation. */
 export type UpdatePageInput = {
   /** The userId to assign as the author of the object */
-  authorId?: InputMaybe<Scalars['ID']>;
+  authorId?: InputMaybe<Scalars['ID']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the page object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The ID of the parent object */
-  parentId?: InputMaybe<Scalars['ID']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updatePage mutation. */
 export type UpdatePagePayload = {
   __typename?: 'UpdatePagePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   page?: Maybe<Page>;
 };
@@ -11125,24 +11277,24 @@ export type UpdatePagePayload = {
 /** Input for the updatePostFormat mutation. */
 export type UpdatePostFormatInput = {
   /** The slug that the post_format will be an alias of */
-  aliasOf?: InputMaybe<Scalars['String']>;
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The description of the post_format object */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the postFormat object to update */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   /** The name of the post_format object to mutate */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updatePostFormat mutation. */
 export type UpdatePostFormatPayload = {
   __typename?: 'UpdatePostFormatPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The created post_format */
   postFormat?: Maybe<PostFormat>;
 };
@@ -11150,39 +11302,39 @@ export type UpdatePostFormatPayload = {
 /** Input for the updatePost mutation. */
 export type UpdatePostInput = {
   /** The userId to assign as the author of the object */
-  authorId?: InputMaybe<Scalars['ID']>;
+  authorId?: InputMaybe<Scalars['ID']['input']>;
   /** Set connections between the post and categories */
   categories?: InputMaybe<PostCategoriesInput>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the post object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Set connections between the post and postFormats */
   postFormats?: InputMaybe<PostPostFormatsInput>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** Set connections between the post and tags */
   tags?: InputMaybe<PostTagsInput>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updatePost mutation. */
 export type UpdatePostPayload = {
   __typename?: 'UpdatePostPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   post?: Maybe<Post>;
 };
@@ -11190,31 +11342,31 @@ export type UpdatePostPayload = {
 /** Input for the updateRelease mutation. */
 export type UpdateReleaseInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
-  content?: InputMaybe<Scalars['String']>;
+  content?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the release object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateRelease mutation. */
 export type UpdateReleasePayload = {
   __typename?: 'UpdateReleasePayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   release?: Maybe<Release>;
 };
@@ -11222,39 +11374,41 @@ export type UpdateReleasePayload = {
 /** Input for the updateSettings mutation. */
 export type UpdateSettingsInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Salli uusien artikkelien kommentointi. */
-  discussionSettingsDefaultCommentStatus?: InputMaybe<Scalars['String']>;
+  discussionSettingsDefaultCommentStatus?: InputMaybe<
+    Scalars['String']['input']
+  >;
   /** Salli linkki-ilmoitukset muista blogeista (pingback ja trackback) uusiin artikkeleihin. */
-  discussionSettingsDefaultPingStatus?: InputMaybe<Scalars['String']>;
+  discussionSettingsDefaultPingStatus?: InputMaybe<Scalars['String']['input']>;
   /** Muoto kaikille päivämäärän merkkijonoille. */
-  generalSettingsDateFormat?: InputMaybe<Scalars['String']>;
+  generalSettingsDateFormat?: InputMaybe<Scalars['String']['input']>;
   /** Sivuston kuvaus. */
-  generalSettingsDescription?: InputMaybe<Scalars['String']>;
+  generalSettingsDescription?: InputMaybe<Scalars['String']['input']>;
   /** WordPressin kieli- ja maakoodi. */
-  generalSettingsLanguage?: InputMaybe<Scalars['String']>;
+  generalSettingsLanguage?: InputMaybe<Scalars['String']['input']>;
   /** Viikonpäivän numero josta viikko alkaa. */
-  generalSettingsStartOfWeek?: InputMaybe<Scalars['Int']>;
+  generalSettingsStartOfWeek?: InputMaybe<Scalars['Int']['input']>;
   /** Muoto kaikille kellonajan merkkijonoille. */
-  generalSettingsTimeFormat?: InputMaybe<Scalars['String']>;
+  generalSettingsTimeFormat?: InputMaybe<Scalars['String']['input']>;
   /** Kaupunki samalla aikavyöhykkeellä kuin sinä. */
-  generalSettingsTimezone?: InputMaybe<Scalars['String']>;
+  generalSettingsTimezone?: InputMaybe<Scalars['String']['input']>;
   /** Sivuston otsikko. */
-  generalSettingsTitle?: InputMaybe<Scalars['String']>;
+  generalSettingsTitle?: InputMaybe<Scalars['String']['input']>;
   /** Tunniste sivusta, joka näyttää uusimmat artikkelit */
-  readingSettingsPageForPosts?: InputMaybe<Scalars['Int']>;
+  readingSettingsPageForPosts?: InputMaybe<Scalars['Int']['input']>;
   /** Tunniste sivusta, joka näytetään etusivulla */
-  readingSettingsPageOnFront?: InputMaybe<Scalars['Int']>;
+  readingSettingsPageOnFront?: InputMaybe<Scalars['Int']['input']>;
   /** Näytä enintään */
-  readingSettingsPostsPerPage?: InputMaybe<Scalars['Int']>;
+  readingSettingsPostsPerPage?: InputMaybe<Scalars['Int']['input']>;
   /** Mitä näytetään etusivulla */
-  readingSettingsShowOnFront?: InputMaybe<Scalars['String']>;
+  readingSettingsShowOnFront?: InputMaybe<Scalars['String']['input']>;
   /** Oletuskategoria artikkeleille. */
-  writingSettingsDefaultCategory?: InputMaybe<Scalars['Int']>;
+  writingSettingsDefaultCategory?: InputMaybe<Scalars['Int']['input']>;
   /** Artikkelisivujen oletusmuoto. */
-  writingSettingsDefaultPostFormat?: InputMaybe<Scalars['String']>;
+  writingSettingsDefaultPostFormat?: InputMaybe<Scalars['String']['input']>;
   /** Muunna hymiöt kuviksi. */
-  writingSettingsUseSmilies?: InputMaybe<Scalars['Boolean']>;
+  writingSettingsUseSmilies?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** The payload for the updateSettings mutation. */
@@ -11263,7 +11417,7 @@ export type UpdateSettingsPayload = {
   /** Update all settings. */
   allSettings?: Maybe<Settings>;
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** Update the DiscussionSettings setting. */
   discussionSettings?: Maybe<DiscussionSettings>;
   /** Update the GeneralSettings setting. */
@@ -11277,25 +11431,25 @@ export type UpdateSettingsPayload = {
 /** Input for the updateTag mutation. */
 export type UpdateTagInput = {
   /** The slug that the post_tag will be an alias of */
-  aliasOf?: InputMaybe<Scalars['String']>;
+  aliasOf?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The description of the post_tag object */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the tag object to update */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   language?: InputMaybe<LanguageCodeEnum>;
   /** The name of the post_tag object to mutate */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** If this argument exists then the slug will be checked to see if it is not an existing valid term. If that check succeeds (it is not a valid term), then it is added and the term id is given. If it fails, then a check is made to whether the taxonomy is hierarchical and the parent argument is not empty. If the second check succeeds, the term will be inserted and the term id will be given. If the slug argument is empty, then it will be calculated from the term name. */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateTag mutation. */
 export type UpdateTagPayload = {
   __typename?: 'UpdateTagPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The created post_tag */
   tag?: Maybe<Tag>;
 };
@@ -11303,28 +11457,28 @@ export type UpdateTagPayload = {
 /** Input for the updateTranslation mutation. */
 export type UpdateTranslationInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
-  date?: InputMaybe<Scalars['String']>;
+  date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the translation object */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
-  menuOrder?: InputMaybe<Scalars['Int']>;
+  menuOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The password used to protect the content of the object */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The slug of the object */
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   /** The status of the object */
   status?: InputMaybe<PostStatusEnum>;
   /** The title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateTranslation mutation. */
 export type UpdateTranslationPayload = {
   __typename?: 'UpdateTranslationPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The Post object mutation type. */
   translation?: Maybe<Translation>;
 };
@@ -11332,48 +11486,48 @@ export type UpdateTranslationPayload = {
 /** Input for the updateUser mutation. */
 export type UpdateUserInput = {
   /** User's AOL IM account. */
-  aim?: InputMaybe<Scalars['String']>;
+  aim?: InputMaybe<Scalars['String']['input']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: InputMaybe<Scalars['String']>;
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** A string containing content about the user. */
-  description?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   /** A string that will be shown on the site. Defaults to user's username. It is likely that you will want to change this, for both appearance and security through obscurity (that is if you dont use and delete the default admin user). */
-  displayName?: InputMaybe<Scalars['String']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   /** A string containing the user's email address. */
-  email?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']['input']>;
   /** 	The user's first name. */
-  firstName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the user */
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   /** User's Jabber account. */
-  jabber?: InputMaybe<Scalars['String']>;
+  jabber?: InputMaybe<Scalars['String']['input']>;
   /** The user's last name. */
-  lastName?: InputMaybe<Scalars['String']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
   /** User's locale. */
-  locale?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains a URL-friendly name for the user. The default is the user's username. */
-  nicename?: InputMaybe<Scalars['String']>;
+  nicename?: InputMaybe<Scalars['String']['input']>;
   /** The user's nickname, defaults to the user's username. */
-  nickname?: InputMaybe<Scalars['String']>;
+  nickname?: InputMaybe<Scalars['String']['input']>;
   /** A string that contains the plain text password for the user. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** The date the user registered. Format is Y-m-d H:i:s. */
-  registered?: InputMaybe<Scalars['String']>;
+  registered?: InputMaybe<Scalars['String']['input']>;
   /** A string for whether to enable the rich editor or not. False if not empty. */
-  richEditing?: InputMaybe<Scalars['String']>;
+  richEditing?: InputMaybe<Scalars['String']['input']>;
   /** An array of roles to be assigned to the user. */
-  roles?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  roles?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** A string containing the user's URL for the user's web site. */
-  websiteUrl?: InputMaybe<Scalars['String']>;
+  websiteUrl?: InputMaybe<Scalars['String']['input']>;
   /** User's Yahoo IM account. */
-  yim?: InputMaybe<Scalars['String']>;
+  yim?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The payload for the updateUser mutation. */
 export type UpdateUserPayload = {
   __typename?: 'UpdateUserPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: Maybe<Scalars['String']>;
+  clientMutationId?: Maybe<Scalars['String']['output']>;
   /** The User object mutation type. */
   user?: Maybe<User>;
 };
@@ -11387,144 +11541,144 @@ export type User = Commenter &
     /** Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument. */
     avatar?: Maybe<Avatar>;
     /** User metadata option name. Usually it will be &quot;wp_capabilities&quot;. */
-    capKey?: Maybe<Scalars['String']>;
+    capKey?: Maybe<Scalars['String']['output']>;
     /** A list of capabilities (permissions) granted to the user */
-    capabilities?: Maybe<Array<Maybe<Scalars['String']>>>;
+    capabilities?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
     /** Connection between the User type and the Comment type */
     comments?: Maybe<UserToCommentConnection>;
     /** Identifies the primary key from the database. */
-    databaseId: Scalars['Int'];
+    databaseId: Scalars['Int']['output'];
     /** Description of the user. */
-    description?: Maybe<Scalars['String']>;
+    description?: Maybe<Scalars['String']['output']>;
     /** Email address of the user. This is equivalent to the WP_User-&gt;user_email property. */
-    email?: Maybe<Scalars['String']>;
+    email?: Maybe<Scalars['String']['output']>;
     /** Connection between the User type and the EnqueuedScript type */
     enqueuedScripts?: Maybe<UserToEnqueuedScriptConnection>;
     /** Connection between the User type and the EnqueuedStylesheet type */
     enqueuedStylesheets?: Maybe<UserToEnqueuedStylesheetConnection>;
     /** A complete list of capabilities including capabilities inherited from a role. This is equivalent to the array keys of WP_User-&gt;allcaps. */
-    extraCapabilities?: Maybe<Array<Maybe<Scalars['String']>>>;
+    extraCapabilities?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
     /** First name of the user. This is equivalent to the WP_User-&gt;user_first_name property. */
-    firstName?: Maybe<Scalars['String']>;
+    firstName?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier for the user object. */
-    id: Scalars['ID'];
+    id: Scalars['ID']['output'];
     /** Whether the node is a Content Node */
-    isContentNode: Scalars['Boolean'];
+    isContentNode: Scalars['Boolean']['output'];
     /** Whether the object is restricted from the current viewer */
-    isRestricted?: Maybe<Scalars['Boolean']>;
+    isRestricted?: Maybe<Scalars['Boolean']['output']>;
     /** Whether the node is a Term */
-    isTermNode: Scalars['Boolean'];
+    isTermNode: Scalars['Boolean']['output'];
     /** Last name of the user. This is equivalent to the WP_User-&gt;user_last_name property. */
-    lastName?: Maybe<Scalars['String']>;
+    lastName?: Maybe<Scalars['String']['output']>;
     /** The preferred language locale set for the user. Value derived from get_user_locale(). */
-    locale?: Maybe<Scalars['String']>;
+    locale?: Maybe<Scalars['String']['output']>;
     /** Connection between the User type and the mediaItem type */
     mediaItems?: Maybe<UserToMediaItemConnection>;
     /** Display name of the user. This is equivalent to the WP_User-&gt;dispaly_name property. */
-    name?: Maybe<Scalars['String']>;
+    name?: Maybe<Scalars['String']['output']>;
     /** The nicename for the user. This field is equivalent to WP_User-&gt;user_nicename */
-    nicename?: Maybe<Scalars['String']>;
+    nicename?: Maybe<Scalars['String']['output']>;
     /** Nickname of the user. */
-    nickname?: Maybe<Scalars['String']>;
+    nickname?: Maybe<Scalars['String']['output']>;
     /** Connection between the User type and the page type */
     pages?: Maybe<UserToPageConnection>;
     /** Connection between the User type and the post type */
     posts?: Maybe<UserToPostConnection>;
     /** The date the user registered or was created. The field follows a full ISO8601 date string format. */
-    registeredDate?: Maybe<Scalars['String']>;
+    registeredDate?: Maybe<Scalars['String']['output']>;
     /** Connection between the User and Revisions authored by the user */
     revisions?: Maybe<UserToRevisionsConnection>;
     /** Connection between the User type and the UserRole type */
     roles?: Maybe<UserToUserRoleConnection>;
     /** The slug for the user. This field is equivalent to WP_User-&gt;user_nicename */
-    slug?: Maybe<Scalars['String']>;
+    slug?: Maybe<Scalars['String']['output']>;
     /** The unique resource identifier path */
-    uri?: Maybe<Scalars['String']>;
+    uri?: Maybe<Scalars['String']['output']>;
     /** A website url that is associated with the user. */
-    url?: Maybe<Scalars['String']>;
+    url?: Maybe<Scalars['String']['output']>;
     /**
      * The Id of the user. Equivalent to WP_User-&gt;ID
      * @deprecated Deprecated in favor of the databaseId field
      */
-    userId?: Maybe<Scalars['Int']>;
+    userId?: Maybe<Scalars['Int']['output']>;
     /** Username for the user. This field is equivalent to WP_User-&gt;user_login. */
-    username?: Maybe<Scalars['String']>;
+    username?: Maybe<Scalars['String']['output']>;
   };
 
 /** A User object */
 export type UserAvatarArgs = {
-  forceDefault?: InputMaybe<Scalars['Boolean']>;
+  forceDefault?: InputMaybe<Scalars['Boolean']['input']>;
   rating?: InputMaybe<AvatarRatingEnum>;
-  size?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** A User object */
 export type UserCommentsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<UserToCommentConnectionWhereArgs>;
 };
 
 /** A User object */
 export type UserEnqueuedScriptsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** A User object */
 export type UserEnqueuedStylesheetsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** A User object */
 export type UserMediaItemsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<UserToMediaItemConnectionWhereArgs>;
 };
 
 /** A User object */
 export type UserPagesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<UserToPageConnectionWhereArgs>;
 };
 
 /** A User object */
 export type UserPostsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<UserToPostConnectionWhereArgs>;
 };
 
 /** A User object */
 export type UserRevisionsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<UserToRevisionsConnectionWhereArgs>;
 };
 
 /** A User object */
 export type UserRolesArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Connection to User Nodes */
@@ -11538,7 +11692,7 @@ export type UserConnection = {
 /** Edge between a Node and a connected User */
 export type UserConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected User Node */
   node: User;
 };
@@ -11563,15 +11717,15 @@ export enum UserNodeIdTypeEnum {
 export type UserRole = Node & {
   __typename?: 'UserRole';
   /** The capabilities that belong to this role */
-  capabilities?: Maybe<Array<Maybe<Scalars['String']>>>;
+  capabilities?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The display name of the role */
-  displayName?: Maybe<Scalars['String']>;
+  displayName?: Maybe<Scalars['String']['output']>;
   /** The globally unique identifier for the user role object. */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Whether the object is restricted from the current viewer */
-  isRestricted?: Maybe<Scalars['Boolean']>;
+  isRestricted?: Maybe<Scalars['Boolean']['output']>;
   /** The registered name of the role */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 /** Connection to UserRole Nodes */
@@ -11585,7 +11739,7 @@ export type UserRoleConnection = {
 /** Edge between a Node and a connected UserRole */
 export type UserRoleConnectionEdge = {
   /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
-  cursor?: Maybe<Scalars['String']>;
+  cursor?: Maybe<Scalars['String']['output']>;
   /** The connected UserRole Node */
   node: UserRole;
 };
@@ -11629,7 +11783,7 @@ export type UserToCommentConnectionEdge = CommentConnectionEdge &
   Edge & {
     __typename?: 'UserToCommentConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Comment;
   };
@@ -11637,63 +11791,63 @@ export type UserToCommentConnectionEdge = CommentConnectionEdge &
 /** Arguments for filtering the UserToCommentConnection connection */
 export type UserToCommentConnectionWhereArgs = {
   /** Comment author email address. */
-  authorEmail?: InputMaybe<Scalars['String']>;
+  authorEmail?: InputMaybe<Scalars['String']['input']>;
   /** Array of author IDs to include comments for. */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to exclude comments for. */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Comment author URL. */
-  authorUrl?: InputMaybe<Scalars['String']>;
+  authorUrl?: InputMaybe<Scalars['String']['input']>;
   /** Array of comment IDs to include. */
-  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of IDs of users whose unapproved comments will be returned by the query regardless of status. */
-  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  commentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Include comments of a given type. */
-  commentType?: InputMaybe<Scalars['String']>;
+  commentType?: InputMaybe<Scalars['String']['input']>;
   /** Include comments from a given array of comment types. */
-  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  commentTypeIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Exclude comments from a given array of comment types. */
-  commentTypeNotIn?: InputMaybe<Scalars['String']>;
+  commentTypeNotIn?: InputMaybe<Scalars['String']['input']>;
   /** Content object author ID to limit results by. */
-  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthor?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs to retrieve comments for. */
-  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of author IDs *not* to retrieve comments for. */
-  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentAuthorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Limit results to those affiliated with a given content object ID. */
-  contentId?: InputMaybe<Scalars['ID']>;
+  contentId?: InputMaybe<Scalars['ID']['input']>;
   /** Array of content object IDs to include affiliated comments for. */
-  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of content object IDs to exclude affiliated comments for. */
-  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  contentIdNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Content object name (i.e. slug ) to retrieve affiliated comments for. */
-  contentName?: InputMaybe<Scalars['String']>;
+  contentName?: InputMaybe<Scalars['String']['input']>;
   /** Content Object parent ID to retrieve affiliated comments for. */
-  contentParent?: InputMaybe<Scalars['Int']>;
+  contentParent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of content object statuses to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentStatus?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Content object type or array of types to retrieve affiliated comments for. Pass 'any' to match any value. */
   contentType?: InputMaybe<Array<InputMaybe<ContentTypeEnum>>>;
   /** Array of IDs or email addresses of users whose unapproved comments will be returned by the query regardless of $status. Default empty */
-  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  includeUnapproved?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Karma score to retrieve matching comments for. */
-  karma?: InputMaybe<Scalars['Int']>;
+  karma?: InputMaybe<Scalars['Int']['input']>;
   /** The cardinality of the order of the connection */
   order?: InputMaybe<OrderEnum>;
   /** Field to order the comments by. */
   orderby?: InputMaybe<CommentsConnectionOrderbyEnum>;
   /** Parent ID of comment to retrieve children of. */
-  parent?: InputMaybe<Scalars['Int']>;
+  parent?: InputMaybe<Scalars['Int']['input']>;
   /** Array of parent IDs of comments to retrieve children for. */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of parent IDs of comments *not* to retrieve children for. */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Search term(s) to retrieve matching comments for. */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Comment status to limit results by. */
-  status?: InputMaybe<Scalars['String']>;
+  status?: InputMaybe<Scalars['String']['input']>;
   /** Include comments for a specific user ID. */
-  userId?: InputMaybe<Scalars['ID']>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Connection between the User type and the EnqueuedScript type */
@@ -11713,7 +11867,7 @@ export type UserToEnqueuedScriptConnectionEdge = Edge &
   EnqueuedScriptConnectionEdge & {
     __typename?: 'UserToEnqueuedScriptConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedScript;
   };
@@ -11735,7 +11889,7 @@ export type UserToEnqueuedStylesheetConnectionEdge = Edge &
   EnqueuedStylesheetConnectionEdge & {
     __typename?: 'UserToEnqueuedStylesheetConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: EnqueuedStylesheet;
   };
@@ -11757,7 +11911,7 @@ export type UserToMediaItemConnectionEdge = Edge &
   MediaItemConnectionEdge & {
     __typename?: 'UserToMediaItemConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: MediaItem;
   };
@@ -11765,47 +11919,47 @@ export type UserToMediaItemConnectionEdge = Edge &
 /** Arguments for filtering the UserToMediaItemConnection connection */
 export type UserToMediaItemConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the User type and the page type */
@@ -11825,7 +11979,7 @@ export type UserToPageConnectionEdge = Edge &
   PageConnectionEdge & {
     __typename?: 'UserToPageConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Page;
   };
@@ -11833,47 +11987,47 @@ export type UserToPageConnectionEdge = Edge &
 /** Arguments for filtering the UserToPageConnection connection */
 export type UserToPageConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the User type and the post type */
@@ -11893,7 +12047,7 @@ export type UserToPostConnectionEdge = Edge &
   PostConnectionEdge & {
     __typename?: 'UserToPostConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: Post;
   };
@@ -11901,67 +12055,67 @@ export type UserToPostConnectionEdge = Edge &
 /** Arguments for filtering the UserToPostConnection connection */
 export type UserToPostConnectionWhereArgs = {
   /** The user that's connected as the author of the object. Use the userId for the author object. */
-  author?: InputMaybe<Scalars['Int']>;
+  author?: InputMaybe<Scalars['Int']['input']>;
   /** Find objects connected to author(s) in the array of author's userIds */
-  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Find objects connected to the author by the author's nicename */
-  authorName?: InputMaybe<Scalars['String']>;
+  authorName?: InputMaybe<Scalars['String']['input']>;
   /** Find objects NOT connected to author(s) in the array of author's userIds */
-  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Category ID */
-  categoryId?: InputMaybe<Scalars['Int']>;
+  categoryId?: InputMaybe<Scalars['Int']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Use Category Slug */
-  categoryName?: InputMaybe<Scalars['String']>;
+  categoryName?: InputMaybe<Scalars['String']['input']>;
   /** Array of category IDs, used to display objects from one category OR another */
-  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  categoryNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Tag Slug */
-  tag?: InputMaybe<Scalars['String']>;
+  tag?: InputMaybe<Scalars['String']['input']>;
   /** Use Tag ID */
-  tagId?: InputMaybe<Scalars['String']>;
+  tagId?: InputMaybe<Scalars['String']['input']>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag IDs, used to display objects from one tag OR another */
-  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Array of tag slugs, used to display objects from one tag AND another */
-  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Array of tag slugs, used to include objects in ANY specified tags */
-  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the User type and the ContentNode type */
@@ -11981,7 +12135,7 @@ export type UserToRevisionsConnectionEdge = ContentNodeConnectionEdge &
   Edge & {
     __typename?: 'UserToRevisionsConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: ContentNode;
   };
@@ -11993,37 +12147,37 @@ export type UserToRevisionsConnectionWhereArgs = {
   /** Filter the connection based on dates */
   dateQuery?: InputMaybe<DateQueryInput>;
   /** True for objects with passwords; False for objects without passwords; null for all objects with or without passwords */
-  hasPassword?: InputMaybe<Scalars['Boolean']>;
+  hasPassword?: InputMaybe<Scalars['Boolean']['input']>;
   /** Specific database ID of the object */
-  id?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Array of IDs for the objects to retrieve */
-  in?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Get objects with a specific mimeType property */
   mimeType?: InputMaybe<MimeTypeEnum>;
   /** Slug / post_name of the object */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** Specify objects to retrieve. Use slugs */
-  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  nameIn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored */
-  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** What paramater to use to order the objects by. */
   orderby?: InputMaybe<Array<InputMaybe<PostObjectsConnectionOrderbyInput>>>;
   /** Use ID to return only children. Use 0 to return only top-level items */
-  parent?: InputMaybe<Scalars['ID']>;
+  parent?: InputMaybe<Scalars['ID']['input']>;
   /** Specify objects whose parent is in an array */
-  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Specify posts whose parent is not in an array */
-  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  parentNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Show posts with a specific password. */
-  password?: InputMaybe<Scalars['String']>;
+  password?: InputMaybe<Scalars['String']['input']>;
   /** Show Posts based on a keyword search */
-  search?: InputMaybe<Scalars['String']>;
+  search?: InputMaybe<Scalars['String']['input']>;
   /** Retrieve posts where post status is in an array. */
   stati?: InputMaybe<Array<InputMaybe<PostStatusEnum>>>;
   /** Show posts with a specific status. */
   status?: InputMaybe<PostStatusEnum>;
   /** Title of the object */
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Connection between the User type and the UserRole type */
@@ -12043,7 +12197,7 @@ export type UserToUserRoleConnectionEdge = Edge &
   UserRoleConnectionEdge & {
     __typename?: 'UserToUserRoleConnectionEdge';
     /** A cursor for use in pagination */
-    cursor?: Maybe<Scalars['String']>;
+    cursor?: Maybe<Scalars['String']['output']>;
     /** The item at the end of the edge */
     node: UserRole;
   };
@@ -12093,20 +12247,20 @@ export enum UsersConnectionSearchColumnEnum {
 export type Venue = {
   __typename?: 'Venue';
   accessibilitySentences: Array<Maybe<AccessibilitySentences>>;
-  addressLocality?: Maybe<Scalars['String']>;
+  addressLocality?: Maybe<Scalars['String']['output']>;
   connections: Array<Maybe<VenueConnection>>;
-  dataSource?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  email?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  image?: Maybe<Scalars['String']>;
-  infoUrl?: Maybe<Scalars['String']>;
+  dataSource?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  infoUrl?: Maybe<Scalars['String']['output']>;
   /**
    * This field is currently disabled because the Hauki integration is not enabled
    * @deprecated Hauki integration is currently disabled so this field can not be accessed
    */
-  isOpen?: Maybe<Scalars['Boolean']>;
-  name?: Maybe<Scalars['String']>;
+  isOpen?: Maybe<Scalars['Boolean']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
   ontologyTree: Array<Maybe<Ontology>>;
   ontologyWords: Array<Maybe<Ontology>>;
   /**
@@ -12115,17 +12269,17 @@ export type Venue = {
    */
   openingHours?: Maybe<Array<OpeningHour>>;
   position?: Maybe<Point>;
-  postalCode?: Maybe<Scalars['String']>;
-  streetAddress?: Maybe<Scalars['String']>;
-  telephone?: Maybe<Scalars['String']>;
+  postalCode?: Maybe<Scalars['String']['output']>;
+  streetAddress?: Maybe<Scalars['String']['output']>;
+  telephone?: Maybe<Scalars['String']['output']>;
 };
 
 export type VenueConnection = {
   __typename?: 'VenueConnection';
-  name?: Maybe<Scalars['String']>;
-  phone?: Maybe<Scalars['String']>;
-  sectionType?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
+  phone?: Maybe<Scalars['String']['output']>;
+  sectionType?: Maybe<Scalars['String']['output']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** TODO: combine beta.kultus Venue stuff with respa equipment type */
@@ -12133,37 +12287,37 @@ export type VenueFacility = {
   __typename?: 'VenueFacility';
   categories?: Maybe<Array<KeywordString>>;
   meta?: Maybe<NodeMeta>;
-  name: Scalars['String'];
+  name: Scalars['String']['output'];
 };
 
 /** TODO: this comes from respa resource/unit types */
 export type VenueReservationPolicy = {
   __typename?: 'VenueReservationPolicy';
-  todo?: Maybe<Scalars['String']>;
+  todo?: Maybe<Scalars['String']['output']>;
 };
 
 /** Information about pagination in a connection. */
 export type WpPageInfo = {
   __typename?: 'WPPageInfo';
   /** When paginating forwards, the cursor to continue. */
-  endCursor?: Maybe<Scalars['String']>;
+  endCursor?: Maybe<Scalars['String']['output']>;
   /** When paginating forwards, are there more items? */
-  hasNextPage: Scalars['Boolean'];
+  hasNextPage: Scalars['Boolean']['output'];
   /** When paginating backwards, are there more items? */
-  hasPreviousPage: Scalars['Boolean'];
+  hasPreviousPage: Scalars['Boolean']['output'];
   /** When paginating backwards, the cursor to continue. */
-  startCursor?: Maybe<Scalars['String']>;
+  startCursor?: Maybe<Scalars['String']['output']>;
 };
 
 /** The writing setting type */
 export type WritingSettings = {
   __typename?: 'WritingSettings';
   /** Oletuskategoria artikkeleille. */
-  defaultCategory?: Maybe<Scalars['Int']>;
+  defaultCategory?: Maybe<Scalars['Int']['output']>;
   /** Artikkelisivujen oletusmuoto. */
-  defaultPostFormat?: Maybe<Scalars['String']>;
+  defaultPostFormat?: Maybe<Scalars['String']['output']>;
   /** Muunna hymiöt kuviksi. */
-  useSmilies?: Maybe<Scalars['Boolean']>;
+  useSmilies?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type LocalizedFieldsFragment = {
@@ -12374,9 +12528,10 @@ export type EventFieldsFragment = {
 };
 
 export type EventDetailsQueryVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   include?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
 }>;
 
@@ -12561,68 +12716,81 @@ export type EventDetailsQuery = {
 };
 
 export type EventListQueryVariables = Exact<{
-  audienceMaxAgeGt?: InputMaybe<Scalars['String']>;
-  audienceMinAgeLt?: InputMaybe<Scalars['String']>;
+  audienceMaxAgeGt?: InputMaybe<Scalars['String']['input']>;
+  audienceMinAgeLt?: InputMaybe<Scalars['String']['input']>;
   eventType?: InputMaybe<
     Array<InputMaybe<EventTypeId>> | InputMaybe<EventTypeId>
   >;
-  internetBased?: InputMaybe<Scalars['Boolean']>;
+  internetBased?: InputMaybe<Scalars['Boolean']['input']>;
   suitableFor?: InputMaybe<
-    Array<InputMaybe<Scalars['Int']>> | InputMaybe<Scalars['Int']>
+    | Array<InputMaybe<Scalars['Int']['input']>>
+    | InputMaybe<Scalars['Int']['input']>
   >;
-  allOngoing?: InputMaybe<Scalars['Boolean']>;
+  allOngoing?: InputMaybe<Scalars['Boolean']['input']>;
   allOngoingAnd?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
   division?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
-  end?: InputMaybe<Scalars['String']>;
-  endsAfter?: InputMaybe<Scalars['String']>;
-  endsBefore?: InputMaybe<Scalars['String']>;
-  inLanguage?: InputMaybe<Scalars['String']>;
+  end?: InputMaybe<Scalars['String']['input']>;
+  endsAfter?: InputMaybe<Scalars['String']['input']>;
+  endsBefore?: InputMaybe<Scalars['String']['input']>;
+  inLanguage?: InputMaybe<Scalars['String']['input']>;
   include?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
-  isFree?: InputMaybe<Scalars['Boolean']>;
+  isFree?: InputMaybe<Scalars['Boolean']['input']>;
   keyword?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
   keywordAnd?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
   keywordOrSet1?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
   keywordOrSet2?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
   keywordOrSet3?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
   keywordNot?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars['String']['input']>;
   localOngoingAnd?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
   location?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
-  page?: InputMaybe<Scalars['Int']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  publisher?: InputMaybe<Scalars['ID']>;
-  sort?: InputMaybe<Scalars['String']>;
-  start?: InputMaybe<Scalars['String']>;
-  startsAfter?: InputMaybe<Scalars['String']>;
-  startsBefore?: InputMaybe<Scalars['String']>;
-  superEvent?: InputMaybe<Scalars['ID']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  publisher?: InputMaybe<Scalars['ID']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['String']['input']>;
+  startsAfter?: InputMaybe<Scalars['String']['input']>;
+  startsBefore?: InputMaybe<Scalars['String']['input']>;
+  superEvent?: InputMaybe<Scalars['ID']['input']>;
   superEventType?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
-  text?: InputMaybe<Scalars['String']>;
-  translation?: InputMaybe<Scalars['String']>;
+  text?: InputMaybe<Scalars['String']['input']>;
+  translation?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 export type EventListQuery = {
@@ -12815,18 +12983,19 @@ export type EventListQuery = {
 };
 
 export type EventsByIdsQueryVariables = Exact<{
-  ids: Array<Scalars['ID']> | Scalars['ID'];
+  ids: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
   eventType?: InputMaybe<
     Array<InputMaybe<EventTypeId>> | InputMaybe<EventTypeId>
   >;
   include?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
-  sort?: InputMaybe<Scalars['String']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  page?: InputMaybe<Scalars['Int']>;
-  start?: InputMaybe<Scalars['String']>;
-  end?: InputMaybe<Scalars['String']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  start?: InputMaybe<Scalars['String']['input']>;
+  end?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 export type EventsByIdsQuery = {
@@ -13033,7 +13202,7 @@ export type KeywordFieldsFragment = {
 };
 
 export type KeywordDetailsQueryVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 }>;
 
 export type KeywordDetailsQuery = {
@@ -13054,13 +13223,13 @@ export type KeywordDetailsQuery = {
 };
 
 export type KeywordListQueryVariables = Exact<{
-  dataSource?: InputMaybe<Scalars['String']>;
-  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']>;
-  page?: InputMaybe<Scalars['Int']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  showAllKeywords?: InputMaybe<Scalars['Boolean']>;
-  sort?: InputMaybe<Scalars['String']>;
-  text?: InputMaybe<Scalars['String']>;
+  dataSource?: InputMaybe<Scalars['String']['input']>;
+  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  showAllKeywords?: InputMaybe<Scalars['Boolean']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  text?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 export type KeywordListQuery = {
@@ -13121,7 +13290,7 @@ export type OrganizationFieldsFragment = {
 };
 
 export type OrganizationDetailsQueryVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 }>;
 
 export type OrganizationDetailsQuery = {
@@ -13187,7 +13356,7 @@ export type PlaceFieldsFragment = {
 };
 
 export type PlaceDetailsQueryVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 }>;
 
 export type PlaceDetailsQuery = {
@@ -13247,16 +13416,17 @@ export type PlaceDetailsQuery = {
 };
 
 export type PlaceListQueryVariables = Exact<{
-  dataSource?: InputMaybe<Scalars['String']>;
+  dataSource?: InputMaybe<Scalars['String']['input']>;
   divisions?: InputMaybe<
-    Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>
+    | Array<InputMaybe<Scalars['String']['input']>>
+    | InputMaybe<Scalars['String']['input']>
   >;
-  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']>;
-  page?: InputMaybe<Scalars['Int']>;
-  pageSize?: InputMaybe<Scalars['Int']>;
-  showAllPlaces?: InputMaybe<Scalars['Boolean']>;
-  sort?: InputMaybe<Scalars['String']>;
-  text?: InputMaybe<Scalars['String']>;
+  hasUpcomingEvents?: InputMaybe<Scalars['Boolean']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
+  showAllPlaces?: InputMaybe<Scalars['Boolean']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  text?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 export type PlaceListQuery = {
@@ -13344,7 +13514,7 @@ export type AdministrativeDivisionsQuery = {
 };
 
 export type OntologyTreeQueryVariables = Exact<{
-  rootId?: InputMaybe<Scalars['ID']>;
+  rootId?: InputMaybe<Scalars['ID']['input']>;
 }>;
 
 export type OntologyTreeQuery = {
@@ -13362,7 +13532,7 @@ export type OntologyTreeQuery = {
 };
 
 export type OntologyWordsQueryVariables = Exact<{
-  ids?: InputMaybe<Array<Scalars['ID']> | Scalars['ID']>;
+  ids?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
 }>;
 
 export type OntologyWordsQuery = {
@@ -13380,7 +13550,7 @@ export type OntologyWordsQuery = {
 };
 
 export type UnifiedSearchCompletionSuggestionsQueryVariables = Exact<{
-  prefix?: InputMaybe<Scalars['String']>;
+  prefix?: InputMaybe<Scalars['String']['input']>;
   language: UnifiedSearchLanguage;
 }>;
 
@@ -13393,17 +13563,23 @@ export type UnifiedSearchCompletionSuggestionsQuery = {
 };
 
 export type SearchListQueryVariables = Exact<{
-  q?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  after?: InputMaybe<Scalars['String']>;
+  q?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
   language: UnifiedSearchLanguage;
-  administrativeDivisionIds?: InputMaybe<Array<Scalars['ID']> | Scalars['ID']>;
-  ontologyTreeIds?: InputMaybe<Array<Scalars['ID']> | Scalars['ID']>;
-  ontologyWordIds?: InputMaybe<Array<Scalars['ID']> | Scalars['ID']>;
-  openAt?: InputMaybe<Scalars['String']>;
+  administrativeDivisionIds?: InputMaybe<
+    Array<Scalars['ID']['input']> | Scalars['ID']['input']
+  >;
+  ontologyTreeIds?: InputMaybe<
+    Array<Scalars['ID']['input']> | Scalars['ID']['input']
+  >;
+  ontologyWordIds?: InputMaybe<
+    Array<Scalars['ID']['input']> | Scalars['ID']['input']
+  >;
+  openAt?: InputMaybe<Scalars['String']['input']>;
   orderByDistance?: InputMaybe<OrderByDistance>;
   orderByName?: InputMaybe<OrderByName>;
-  includeHaukiFields?: InputMaybe<Scalars['Boolean']>;
+  includeHaukiFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type SearchListQuery = {
@@ -13513,13 +13689,17 @@ export type SearchListQuery = {
 };
 
 export type SearchMapQueryVariables = Exact<{
-  q?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  after?: InputMaybe<Scalars['String']>;
+  q?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
   language: UnifiedSearchLanguage;
-  administrativeDivisionIds?: InputMaybe<Array<Scalars['ID']> | Scalars['ID']>;
-  ontologyTreeIds?: InputMaybe<Array<Scalars['ID']> | Scalars['ID']>;
-  openAt?: InputMaybe<Scalars['String']>;
+  administrativeDivisionIds?: InputMaybe<
+    Array<Scalars['ID']['input']> | Scalars['ID']['input']
+  >;
+  ontologyTreeIds?: InputMaybe<
+    Array<Scalars['ID']['input']> | Scalars['ID']['input']
+  >;
+  openAt?: InputMaybe<Scalars['String']['input']>;
   orderByDistance?: InputMaybe<OrderByDistance>;
   orderByName?: InputMaybe<OrderByName>;
 }>;
@@ -13619,8 +13799,8 @@ export type VenueFieldsFragment = {
 };
 
 export type VenueQueryVariables = Exact<{
-  id: Scalars['ID'];
-  includeHaukiFields?: InputMaybe<Scalars['Boolean']>;
+  id: Scalars['ID']['input'];
+  includeHaukiFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type VenueQuery = {
@@ -13677,8 +13857,8 @@ export type VenueQuery = {
 };
 
 export type VenuesByIdsQueryVariables = Exact<{
-  ids?: InputMaybe<Array<Scalars['ID']> | Scalars['ID']>;
-  includeHaukiFields?: InputMaybe<Scalars['Boolean']>;
+  ids?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
+  includeHaukiFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type VenuesByIdsQuery = {


### PR DESCRIPTION
## Description

### chore: update generated GraphQL types after PR #403 router schema change

what was done:
```bash
cd apps/sports-helsinki/
yarn generate:graphql
cp ./src/components/domain/graphql/generated/graphql.tsx \
    ../../packages/components/src/types/generated/
cd ../../
npx prettier ./packages/components/src/types/generated/graphql.tsx -w
```

Made sure that FEDERATION_ROUTER_ENDPOINT was set to
https://events-graphql-federation-sports.test.hel.ninja/

refs LIIKUNTA-511 (testing unified search changes)

## Issues

**[LIIKUNTA-511](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-511)**

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes

The diff without the extra changes:
 - removed `\['(output|input)'\]`
 - replaced `\{ input: (\w+); output: \1 \}` with `$1`
 - replaced `\<\n(\s+)\|\s*` with `<`
 - ran npx prettier on both graphql.tsx files to be diffed
 - fixed remaining whitespace changes manually

Result:

```diff
@@ -1,59 +1,107 @@
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]?: Maybe<T[SubKey]>;
 };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
   String: string;
   Boolean: boolean;
   Int: number;
   Float: number;
   DateTime: any;
   GeoJSONCoordinates: any;
   JSONObject: any;
 };
 
-/** TODO: take this from service map / TPREK */
-export type AccessibilityProfile = {
-  __typename?: 'AccessibilityProfile';
-  meta?: Maybe<NodeMeta>;
-  todo?: Maybe<Scalars['String']>;
+export type Accessibility = {
+  __typename?: 'Accessibility';
+  email?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  sentences?: Maybe<Array<Maybe<AccessibilitySentence>>>;
+  shortcomings?: Maybe<Array<Maybe<AccessibilityShortcoming>>>;
+  viewpoints?: Maybe<Array<Maybe<AccessibilityViewpoint>>>;
+  www?: Maybe<Scalars['String']>;
+};
+
+export enum AccessibilityProfile {
+  HearingAid = 'hearing_aid',
+  ReducedMobility = 'reduced_mobility',
+  Rollator = 'rollator',
+  Stroller = 'stroller',
+  VisuallyImpaired = 'visually_impaired',
+  Wheelchair = 'wheelchair',
+}
+
+export type AccessibilitySentence = {
+  __typename?: 'AccessibilitySentence';
+  sentence?: Maybe<LanguageString>;
+  sentenceGroup?: Maybe<LanguageString>;
+  sentenceGroupName?: Maybe<Scalars['String']>;
 };
 
 export type AccessibilitySentences = {
   __typename?: 'AccessibilitySentences';
   groupName?: Maybe<Scalars['String']>;
   sentences?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
+export type AccessibilityShortcoming = {
+  __typename?: 'AccessibilityShortcoming';
+  count?: Maybe<Scalars['Int']>;
+  profile?: Maybe<AccessibilityProfile>;
+};
+
+export type AccessibilityViewpoint = {
+  __typename?: 'AccessibilityViewpoint';
+  id?: Maybe<Scalars['ID']>;
+  name?: Maybe<LanguageString>;
+  shortages?: Maybe<Array<Maybe<LanguageString>>>;
+  value?: Maybe<AccessibilityViewpointValue>;
+};
+
+export enum AccessibilityViewpointValue {
+  Green = 'green',
+  Red = 'red',
+  Unknown = 'unknown',
+}
+
 /** TODO: give real structure */
 export type Address = {
   __typename?: 'Address';
   city?: Maybe<LanguageString>;
   postalCode?: Maybe<Scalars['String']>;
   streetAddress?: Maybe<LanguageString>;
 };
 
 export type AdministrativeDivision = {
   __typename?: 'AdministrativeDivision';
   id?: Maybe<Scalars['ID']>;
   municipality?: Maybe<Scalars['String']>;
   name?: Maybe<LanguageString>;
   type?: Maybe<Scalars['String']>;
 };
 
 export type Audience = {
   __typename?: 'Audience';
   id?: Maybe<Scalars['ID']>;
   internalContext?: Maybe<Scalars['String']>;
@@ -7258,40 +7306,54 @@
   /** Label for the media frame filter. */
   uploadedToThisItem?: Maybe<Scalars['String']>;
   /** Label in the media frame for using a featured image. */
   useFeaturedImage?: Maybe<Scalars['String']>;
   /** Label for viewing a singular item. */
   viewItem?: Maybe<Scalars['String']>;
   /** Label for viewing post type archives. */
   viewItems?: Maybe<Scalars['String']>;
 };
 
 /** Nodes that can be seen in a preview (unpublished) state. */
 export type Previewable = {
   /** Whether the object is a node in the preview state */
   isPreview?: Maybe<Scalars['Boolean']>;
   /** The database id of the preview node */
   previewRevisionDatabaseId?: Maybe<Scalars['Int']>;
   /** Whether the object is a node in the preview state */
   previewRevisionId?: Maybe<Scalars['ID']>;
 };
 
+export enum ProviderType {
+  Association = 'ASSOCIATION',
+  ContractSchool = 'CONTRACT_SCHOOL',
+  Municipality = 'MUNICIPALITY',
+  OtherProductionMethod = 'OTHER_PRODUCTION_METHOD',
+  PaymentCommitment = 'PAYMENT_COMMITMENT',
+  PrivateCompany = 'PRIVATE_COMPANY',
+  PurchasedService = 'PURCHASED_SERVICE',
+  SelfProduced = 'SELF_PRODUCED',
+  SupportedOperations = 'SUPPORTED_OPERATIONS',
+  UnknownProductionMethod = 'UNKNOWN_PRODUCTION_METHOD',
+  VoucherService = 'VOUCHER_SERVICE',
+}
+
 /** The root entry point into the Graph */
 export type Query = {
   __typename?: 'Query';
   _empty?: Maybe<Scalars['String']>;
   administrativeDivisions?: Maybe<Array<Maybe<AdministrativeDivision>>>;
   /** Entry point to get all settings for the site */
   allSettings?: Maybe<Settings>;
   /** Connection between the RootQuery type and the category type */
   categories?: Maybe<RootQueryToCategoryConnection>;
   /** A 0bject */
   category?: Maybe<Category>;
   /** An object of the collection Type. Collections */
   collection?: Maybe<Collection>;
   /**
    * A collection object
    * @deprecated Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)
    */
   collectionBy?: Maybe<Collection>;
   /** Connection between the RootQuery type and the collection type */
   collections?: Maybe<RootQueryToCollectionConnection>;
@@ -7999,56 +8061,61 @@
 
 /** The root entry point into the Graph */
 export type QueryTranslationByArgs = {
   id?: InputMaybe<Scalars['ID']>;
   slug?: InputMaybe<Scalars['String']>;
   translationId?: InputMaybe<Scalars['Int']>;
   uri?: InputMaybe<Scalars['String']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryTranslationsArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<RootQueryToTranslationConnectionWhereArgs>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUnifiedSearchArgs = {
+  accessibilityProfilesWithoutShortcomings?: InputMaybe<Array<InputMaybe<AccessibilityProfile>>>;
   administrativeDivisionId?: InputMaybe<Scalars['ID']>;
   administrativeDivisionIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   index?: InputMaybe<Scalars['String']>;
   languages?: Array<UnifiedSearchLanguage>;
   last?: InputMaybe<Scalars['Int']>;
+  mustHaveReservableResource?: InputMaybe<Scalars['Boolean']>;
   ontology?: InputMaybe<Scalars['String']>;
   ontologyTreeId?: InputMaybe<Scalars['ID']>;
   ontologyTreeIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   ontologyWordIds?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   openAt?: InputMaybe<Scalars['String']>;
   orderByDistance?: InputMaybe<OrderByDistance>;
   orderByName?: InputMaybe<OrderByName>;
+  providerTypes?: InputMaybe<Array<InputMaybe<ProviderType>>>;
   q?: InputMaybe<Scalars['String']>;
+  serviceOwnerTypes?: InputMaybe<Array<InputMaybe<ServiceOwnerType>>>;
+  targetGroups?: InputMaybe<Array<InputMaybe<TargetGroup>>>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUnifiedSearchCompletionSuggestionsArgs = {
   index?: InputMaybe<Scalars['String']>;
   languages?: Array<UnifiedSearchLanguage>;
   prefix?: InputMaybe<Scalars['String']>;
   size?: InputMaybe<Scalars['Int']>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUserArgs = {
   id: Scalars['ID'];
   idType?: InputMaybe<UserNodeIdTypeEnum>;
 };
 
 /** The root entry point into the Graph */
 export type QueryUserRoleArgs = {
   id: Scalars['ID'];
 };
@@ -8388,54 +8455,88 @@
 export type ResetUserPasswordInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']>;
   /** Password reset key */
   key?: InputMaybe<Scalars['String']>;
   /** The user's login (username). */
   login?: InputMaybe<Scalars['String']>;
   /** The new password. */
   password?: InputMaybe<Scalars['String']>;
 };
 
 /** The payload for the resetUserPassword mutation. */
 export type ResetUserPasswordPayload = {
   __typename?: 'ResetUserPasswordPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: Maybe<Scalars['String']>;
   /** The User object mutation type. */
   user?: Maybe<User>;
 };
 
+export type Resource = {
+  __typename?: 'Resource';
+  description?: Maybe<LanguageString>;
+  externalReservationUrl?: Maybe<Scalars['String']>;
+  genericTerms?: Maybe<LanguageString>;
+  id?: Maybe<Scalars['ID']>;
+  name?: Maybe<LanguageString>;
+  paymentTerms?: Maybe<LanguageString>;
+  reservable?: Maybe<Scalars['Boolean']>;
+  reservationInfo?: Maybe<LanguageString>;
+  responsibleContactInfo?: Maybe<LanguageString>;
+  specificTerms?: Maybe<LanguageString>;
+  type?: Maybe<ResourceType>;
+  userPermissions?: Maybe<ResourceUserPermissions>;
+};
+
+export enum ResourceMainType {
+  Item = 'item',
+  Person = 'person',
+  Space = 'space',
+}
+
 export enum ResourceState {
   Closed = 'closed',
   EnterOnly = 'enter_only',
   ExitOnly = 'exit_only',
   Open = 'open',
   OpenAndReservable = 'open_and_reservable',
   SelfService = 'self_service',
   Undefined = 'undefined',
   WeatherPermitting = 'weather_permitting',
   WithKey = 'with_key',
   WithKeyAndReservation = 'with_key_and_reservation',
   WithReservation = 'with_reservation',
 }
 
+export type ResourceType = {
+  __typename?: 'ResourceType';
+  id?: Maybe<Scalars['ID']>;
+  mainType?: Maybe<ResourceMainType>;
+  name?: Maybe<LanguageString>;
+};
+
+export type ResourceUserPermissions = {
+  __typename?: 'ResourceUserPermissions';
+  canMakeReservations?: Maybe<Scalars['Boolean']>;
+};
+
 /** Input for the restoreComment mutation. */
 export type RestoreCommentInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']>;
   /** The ID of the comment to be restored */
   id: Scalars['ID'];
 };
 
 /** The payload for the restoreComment mutation. */
 export type RestoreCommentPayload = {
   __typename?: 'RestoreCommentPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: Maybe<Scalars['String']>;
   /** The restored comment object */
   comment?: Maybe<Comment>;
   /** The ID of the restored comment */
   restoredId?: Maybe<Scalars['ID']>;
 };
 
 /** Connection between the RootQuery type and the category type */
@@ -9857,40 +9958,65 @@
 /** The payload for the sendPasswordResetEmail mutation. */
 export type SendPasswordResetEmailPayload = {
   __typename?: 'SendPasswordResetEmailPayload';
   /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: Maybe<Scalars['String']>;
   /** Whether the mutation completed successfully. This does NOT necessarily mean that an email was sent. */
   success?: Maybe<Scalars['Boolean']>;
   /**
    * The user that the password reset email was sent to
    * @deprecated This field will be removed in a future version of WPGraphQL
    */
   user?: Maybe<User>;
 };
 
 export type SeoSettings = {
   __typename?: 'SeoSettings';
   /** Title separator setting for seo titles */
   separator?: Maybe<Scalars['String']>;
 };
 
+export type ServiceOwner = {
+  __typename?: 'ServiceOwner';
+  name?: Maybe<LanguageString>;
+  providerType?: Maybe<ProviderType>;
+  type?: Maybe<ServiceOwnerType>;
+};
+
+export enum ServiceOwnerType {
+  MunicipalService = 'MUNICIPAL_SERVICE',
+  NotDisplayed = 'NOT_DISPLAYED',
+  PrivateContractSchool = 'PRIVATE_CONTRACT_SCHOOL',
+  PrivateService = 'PRIVATE_SERVICE',
+  PurchasedService = 'PURCHASED_SERVICE',
+  ServiceByJointMunicipalAuthority = 'SERVICE_BY_JOINT_MUNICIPAL_AUTHORITY',
+  ServiceByMunicipallyOwnedCompany = 'SERVICE_BY_MUNICIPALLY_OWNED_COMPANY',
+  ServiceByMunicipalGroupEntity = 'SERVICE_BY_MUNICIPAL_GROUP_ENTITY',
+  ServiceByOtherMunicipality = 'SERVICE_BY_OTHER_MUNICIPALITY',
+  ServiceByRegionalCooperationOrganization = 'SERVICE_BY_REGIONAL_COOPERATION_ORGANIZATION',
+  ServiceByWellbeingArea = 'SERVICE_BY_WELLBEING_AREA',
+  StateContractSchool = 'STATE_CONTRACT_SCHOOL',
+  StateService = 'STATE_SERVICE',
+  SupportedOperations = 'SUPPORTED_OPERATIONS',
+  VoucherService = 'VOUCHER_SERVICE',
+}
+
 /** All of the registered settings */
 export type Settings = {
   __typename?: 'Settings';
   /** Settings of the the string Settings Group */
   discussionSettingsDefaultCommentStatus?: Maybe<Scalars['String']>;
   /** Settings of the the string Settings Group */
   discussionSettingsDefaultPingStatus?: Maybe<Scalars['String']>;
   /** Settings of the the string Settings Group */
   generalSettingsDateFormat?: Maybe<Scalars['String']>;
   /** Settings of the the string Settings Group */
   generalSettingsDescription?: Maybe<Scalars['String']>;
   /** Settings of the the string Settings Group */
   generalSettingsLanguage?: Maybe<Scalars['String']>;
   /** Settings of the the integer Settings Group */
   generalSettingsStartOfWeek?: Maybe<Scalars['Int']>;
   /** Settings of the the string Settings Group */
   generalSettingsTimeFormat?: Maybe<Scalars['String']>;
   /** Settings of the the string Settings Group */
   generalSettingsTimezone?: Maybe<Scalars['String']>;
   /** Settings of the the string Settings Group */
@@ -10254,40 +10380,51 @@
   tagNotIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   /** Array of tag slugs, used to display objects from one tag AND another */
   tagSlugAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   /** Array of tag slugs, used to include objects in ANY specified tags */
   tagSlugIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   /** Title of the object */
   title?: InputMaybe<Scalars['String']>;
 };
 
 /** Connection between the Tag type and the Taxonomy type */
 export type TagToTaxonomyConnectionEdge = Edge &
   OneToOneConnection &
   TaxonomyConnectionEdge & {
     __typename?: 'TagToTaxonomyConnectionEdge';
     /** Opaque reference to the nodes position in the connection. Value can be used with pagination args. */
     cursor?: Maybe<Scalars['String']>;
     /** The node of the connection, without the edges */
     node: Taxonomy;
   };
 
+export enum TargetGroup {
+  Associations = 'ASSOCIATIONS',
+  ChildrenAndFamilies = 'CHILDREN_AND_FAMILIES',
+  Disabled = 'DISABLED',
+  ElderlyPeople = 'ELDERLY_PEOPLE',
+  Enterprises = 'ENTERPRISES',
+  Immigrants = 'IMMIGRANTS',
+  Individuals = 'INDIVIDUALS',
+  Youth = 'YOUTH',
+}
+
 /** A taxonomy object */
 export type Taxonomy = Node & {
   __typename?: 'Taxonomy';
   /** List of Content Types associated with the Taxonomy */
   connectedContentTypes?: Maybe<TaxonomyToContentTypeConnection>;
   /** Description of the taxonomy. This field is equivalent to WP_Taxonomy-&gt;description */
   description?: Maybe<Scalars['String']>;
   /** The plural name of the post type within the GraphQL Schema. */
   graphqlPluralName?: Maybe<Scalars['String']>;
   /** The singular name of the post type within the GraphQL Schema. */
   graphqlSingleName?: Maybe<Scalars['String']>;
   /** Whether the taxonomy is hierarchical */
   hierarchical?: Maybe<Scalars['Boolean']>;
   /** The globally unique identifier of the taxonomy object. */
   id: Scalars['ID'];
   /** Whether the object is restricted from the current viewer */
   isRestricted?: Maybe<Scalars['Boolean']>;
   /** Name of the taxonomy shown in the menu. Usually plural. */
   label?: Maybe<Scalars['String']>;
   /** The display name of the taxonomy. This field is equivalent to WP_Taxonomy-&gt;label */
@@ -10836,56 +10973,59 @@
   Fi = 'FI',
 }
 
 export enum UnifiedSearchResultCategory {
   Article = 'ARTICLE',
   Artwork = 'ARTWORK',
   Enrollable = 'ENROLLABLE',
   Event = 'EVENT',
   PointOfInterest = 'POINT_OF_INTEREST',
   Reservable = 'RESERVABLE',
   Service = 'SERVICE',
 }
 
 /**
  * A place that forms a unit and can be used for some specific purpose -
  * respa unit or resource, service map unit, beta.kultus venue, linked
  * events place, Kukkuu venue
  */
 export type UnifiedSearchVenue = {
   __typename?: 'UnifiedSearchVenue';
-  accessibilityProfile?: Maybe<AccessibilityProfile>;
+  accessibility?: Maybe<Accessibility>;
   additionalInfo?: Maybe<Scalars['String']>;
   arrivalInstructions?: Maybe<Scalars['String']>;
   contactDetails?: Maybe<ContactInfo>;
   description?: Maybe<LanguageString>;
   descriptionResources?: Maybe<DescriptionResources>;
   facilities?: Maybe<Array<VenueFacility>>;
   images?: Maybe<Array<Maybe<LocationImage>>>;
   location?: Maybe<LocationDescription>;
   manager?: Maybe<LegalEntity>;
   meta?: Maybe<NodeMeta>;
   name?: Maybe<LanguageString>;
   ontologyWords?: Maybe<Array<Maybe<OntologyWord>>>;
   openingHours?: Maybe<OpeningHours>;
   partOf?: Maybe<UnifiedSearchVenue>;
   reservationPolicy?: Maybe<VenueReservationPolicy>;
+  resources: Array<Resource>;
+  serviceOwner?: Maybe<ServiceOwner>;
+  targetGroups?: Maybe<Array<Maybe<TargetGroup>>>;
 };
 
 /** Any node that has a URI */
 export type UniformResourceIdentifiable = {
   /** The unique resource identifier path */
   id: Scalars['ID'];
   /** Whether the node is a Content Node */
   isContentNode: Scalars['Boolean'];
   /** Whether the node is a Term */
   isTermNode: Scalars['Boolean'];
   /** The unique resource identifier path */
   uri?: Maybe<Scalars['String']>;
 };
 
 /** Input for the updateCategory mutation. */
 export type UpdateCategoryInput = {
   /** The slug that the category will be an alias of */
   aliasOf?: InputMaybe<Scalars['String']>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']>;
```


[LIIKUNTA-511]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ