### PR TITLE
fix: event hero padding right removed

### DIFF
--- a/packages/components/src/components/eventHero/eventHero.module.scss
+++ b/packages/components/src/components/eventHero/eventHero.module.scss
@@ -91,6 +91,7 @@ $logoWidth: 5.5rem;
 
       @include respond_above(m) {
         padding: var(--spacing-xl);
+        padding-right: 0;
         width: unset;
       }
 


### PR DESCRIPTION
## Description
In addition to venue hero, same style fixes applied to the event hero

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
