### PR TITLE
fix(components): fix types (i.e. 3x TS2322 errors)

### DIFF
--- a/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -112,20 +112,9 @@ const renderComponent = ({
   mocks?: MockedResponse[];
   event?: EventFieldsFragment;
 } = {}) =>
-  render(
-    <OtherEventTimes
-      event={event}
-      getEventListLinkUrl={jest
-        .fn()
-        .mockImplementation(
-          (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
-            `/kurssit/${event.id}`
-        )}
-    />,
-    {
-      mocks,
-    }
-  );
+  render(<OtherEventTimes event={event} />, {
+    mocks,
+  });
 
 const getDateRangeStrProps = (event: EventDetails) => ({
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/components/src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
+++ b/packages/components/src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
@@ -98,7 +98,6 @@ describe('similar events', () => {
     render(
       <SimilarEvents
         event={event as EventFieldsFragment}
-        getCardUrl={jest.fn().mockReturnValue('https://tapahtumat.hel.fi')}
         eventFilters={similarEventFilters}
       />,
       {
@@ -128,7 +127,6 @@ describe('similar events', () => {
     render(
       <SimilarEvents
         event={event as EventFieldsFragment}
-        getCardUrl={jest.fn().mockReturnValue('https://tapahtumat.hel.fi')}
         eventFilters={similarEventFilters}
       />,
       {


### PR DESCRIPTION
## Description

### fix(components): fix types (i.e. 3x TS2322 errors)

OtherEventTimes.test.tsx:
 - TS2322 error:
   - Property 'getEventListLinkUrl' does not exist on type
      IntrinsicAttributes & { event: EventFieldsFragment; }

SimilarEvents.test.tsx:
  - 2x TS2322 error:
    - Property 'getCardUrl' does not exist on type
      IntrinsicAttributes & SimilarEventsProps

refs LIIKUNTA-511 (noticed while testing)

## Issues

### Closes

### Related

**[LIIKUNTA-511](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-511)** (noticed while testing)

## Testing

### Automated tests

### Manual testing

`yarn test` passes locally under packages/components:
```
Test Suites: 59 passed, 59 total
Tests:       2 skipped, 203 passed, 205 total
Snapshots:   28 passed, 28 total
Time:        71.631 s
```

`yarn typecheck` passes (i.e. returns empty) locally under packages/components.

## Screenshots

## Additional notes


[LIIKUNTA-511]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ