### PR TITLE
LIIKUNTA-509, LIIKUNTA-510 | feat(sports): add "Helsinki only" filter to venue/event/hobby search

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
@@ -33,6 +33,10 @@ export const searchAdapterForType: Record<SearchType, SearchAdapterType> = {
   venue: VenueSearchAdapter,
 };
 
+function toBoolean(input?: string | boolean | null): boolean {
+  return ['true', '1', 'yes'].includes(input?.toString().toLowerCase() ?? '');
+}
+
 class CombinedSearchFormAdapter
   implements
     CombinedSearchAdapterInput,
@@ -52,6 +56,7 @@ class CombinedSearchFormAdapter
   courseOrderBy?: string | null;
   sportsCategories: string[];
   targetGroups: string[];
+  helsinkiOnly?: boolean | string | null;
   organization?: string | null;
   place?: string | null;
   keywords: string[];
@@ -93,6 +98,8 @@ class CombinedSearchFormAdapter
       initialCombinedSearchFormValues.courseOrderBy;
     this.sportsCategories = input.getAll('sportsCategories');
     this.targetGroups = input.getAll('targetGroups');
+    this.helsinkiOnly =
+      input.get('helsinkiOnly') ?? initialCombinedSearchFormValues.helsinkiOnly;
     this.organization =
       input.get('organization') ??
       input.get('publisher') ??
@@ -209,6 +216,10 @@ class CombinedSearchFormAdapter
 
   public cleanTargetGroups() {
     return;
+  }
+
+  public cleanHelsinkOnly() {
+    this.helsinkiOnly = toBoolean(this.helsinkiOnly);
   }
 
   public cleanOrganization() {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
@@ -1,3 +1,4 @@
+import { CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID } from '@events-helsinki/components';
 import { EventTypeId } from '@events-helsinki/components/types';
 import {
   SPORT_COURSES_KEYWORDS,
@@ -33,6 +34,7 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
   eventType: EventSearchParams['eventType'];
   superEventType: EventSearchParams['superEventType'];
   publisher: EventSearchParams['publisher'];
+  publisherAncestor: EventSearchParams['publisherAncestor'];
   page: EventSearchParams['page'];
   pageSize: EventSearchParams['pageSize'];
 
@@ -64,6 +66,9 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
         : input.courseOrderBy) ?? initialEventSearchAdapterValues.sort;
     this.publisher =
       input.organization ?? initialEventSearchAdapterValues.publisher;
+    this.publisherAncestor = input.helsinkiOnly
+      ? CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID
+      : initialEventSearchAdapterValues.publisherAncestor;
   }
 
   public getSportsKeywords({ sportsCategories }: CombinedSearchAdapterInput) {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
@@ -11,7 +11,11 @@ import type {
   TARGET_GROUPS,
   TargetGroup as UnifiedSearchTargetGroup,
 } from '@events-helsinki/components/types';
-import { SortOrder } from '@events-helsinki/components/types';
+import {
+  SortOrder,
+  ProviderType,
+  ServiceOwnerType,
+} from '@events-helsinki/components/types';
 import { appToUnifiedSearchLanguageMap } from '../../eventSearch/types';
 import { initialVenueSearchAdapterValues } from '../constants';
 import type {
@@ -30,6 +34,8 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
   q: VenueSearchParams['q'];
   ontologyTreeIds: VenueSearchParams['ontologyWordIds'];
   ontologyWordIds: VenueSearchParams['ontologyWordIds'];
+  providerTypes: VenueSearchParams['providerTypes'];
+  serviceOwnerTypes: VenueSearchParams['serviceOwnerTypes'];
   targetGroups: VenueSearchParams['targetGroups'];
   openAt?: VenueSearchParams['openAt'];
   administrativeDivisionIds?: VenueSearchParams['administrativeDivisionIds'];
@@ -57,6 +63,12 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
     this.q = input.text || initialVenueSearchAdapterValues.q;
     this.ontologyTreeIds = this.getOntologyTreeIds(input);
     this.targetGroups = this.getTargetGroups(input);
+    this.providerTypes = input.helsinkiOnly
+      ? [ProviderType.SelfProduced]
+      : initialVenueSearchAdapterValues.providerTypes;
+    this.serviceOwnerTypes = input.helsinkiOnly
+      ? [ServiceOwnerType.MunicipalService]
+      : initialVenueSearchAdapterValues.serviceOwnerTypes;
     if (input.venueOrderBy?.includes('name')) {
       this.orderByName = input.venueOrderBy.startsWith('-')
         ? { order: SortOrder.Descending }

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -105,6 +105,7 @@ describe('CombinedSearchFormAdapter', () => {
           location: [],
           pageSize: 10,
           publisher: null,
+          publisherAncestor: null,
           include: ['keywords', 'location'],
           superEventType: ['umbrella', 'none'],
         },

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
@@ -14,6 +14,7 @@ describe('EventSearchAdapter', () => {
           venueOrderBy: null,
           sportsCategories: [],
           targetGroups: [TARGET_GROUPS.SENIORS, TARGET_GROUPS.YOUTH],
+          helsinkiOnly: true,
           organization: null,
           keywords: [],
         };
@@ -66,6 +67,7 @@ describe('EventSearchAdapter', () => {
           location: [],
           pageSize: 10,
           publisher: null,
+          publisherAncestor: 'ahjo:00001',
           include: ['keywords', 'location'],
           superEventType: ['umbrella', 'none'],
           sort:

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`CombinedSearchProvider reads the context properly 1`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;
@@ -35,17 +35,17 @@ exports[`CombinedSearchProvider reads the context properly 2`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;
@@ -60,17 +60,17 @@ exports[`CombinedSearchProvider reads the context properly 3`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":"testorg","pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
@@ -22,6 +22,7 @@ export const initialCombinedSearchFormValues: CombinedSearchAdapterInput = {
   courseOrderBy: undefined,
   sportsCategories: [],
   targetGroups: [],
+  helsinkiOnly: undefined,
   organization: undefined,
   place: undefined,
   keywords: [],
@@ -34,6 +35,8 @@ export const initialVenueSearchAdapterValues: VenueSearchParams = {
   ontologyWordIds: [],
   targetGroups: [],
   administrativeDivisionIds: [HELSINKI_OCD_DIVISION_ID],
+  providerTypes: undefined,
+  serviceOwnerTypes: undefined,
   openAt: null,
   after: '',
   first: 10,
@@ -53,5 +56,6 @@ export const initialEventSearchAdapterValues: EventSearchParams = {
   eventType: EventTypeId.General,
   superEventType: ['umbrella', 'none'],
   publisher: null,
+  publisherAncestor: null,
   pageSize: 10,
 };

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -57,6 +57,7 @@ export type CombinedSearchAdapterInput = {
   sportsCategories: string[];
   targetGroups: string[];
   organization?: string | null;
+  helsinkiOnly?: boolean | string | null;
   place?: string | null;
   keywords: string[];
 } & CombinedSearchAdapterInputForVenues &
@@ -84,6 +85,7 @@ export type EventSearchParams = Pick<
   | 'eventType'
   | 'superEventType'
   | 'publisher'
+  | 'publisherAncestor'
   | 'page'
   | 'pageSize'
 >;
@@ -96,6 +98,8 @@ export type VenueSearchParams = Pick<
   | 'q'
   | 'ontologyTreeIds'
   | 'ontologyWordIds'
+  | 'providerTypes'
+  | 'serviceOwnerTypes'
   | 'targetGroups'
   | 'administrativeDivisionIds'
   | 'openAt'

--- a/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
@@ -1,5 +1,6 @@
 import {
   useLocale,
+  HelsinkiOnlyFilter,
   PublisherFilter,
   FilterButton,
   translateValue,
@@ -30,6 +31,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
     sportsCategories,
     targetGroups,
     organization: publisher,
+    helsinkiOnly,
     text: q,
     place,
   } = formValues;
@@ -64,6 +66,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
   const hasFilters =
     !!sportsCategories.length ||
     !!targetGroups.length ||
+    !!helsinkiOnly ||
     !!publisher ||
     !!place ||
     !!q?.length;
@@ -103,6 +106,11 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
         <PublisherFilter
           id={publisher}
           onRemove={() => handleFilterRemove('organization', publisher)}
+        />
+      )}
+      {helsinkiOnly && (
+        <HelsinkiOnlyFilter
+          onRemove={() => handleFilterRemove('helsinkiOnly', 'true')}
         />
       )}
       {place && (

--- a/packages/common-i18n/src/locales/en/common.json
+++ b/packages/common-i18n/src/locales/en/common.json
@@ -1,4 +1,5 @@
 {
+  "cityOfHelsinki": "City of Helsinki",
   "opens_in_new_tab": "Opens in a new tab.",
   "notification": {
     "labelClose": "Close notification"

--- a/packages/common-i18n/src/locales/fi/common.json
+++ b/packages/common-i18n/src/locales/fi/common.json
@@ -1,4 +1,5 @@
 {
+  "cityOfHelsinki": "Helsingin kaupunki",
   "opens_in_new_tab": "Avautuu uudessa välilehdessä.",
   "notification": {
     "labelClose": "Sulje ilmoitus"

--- a/packages/common-i18n/src/locales/sv/common.json
+++ b/packages/common-i18n/src/locales/sv/common.json
@@ -1,4 +1,5 @@
 {
+  "cityOfHelsinki": "Helsingfors stad",
   "opens_in_new_tab": "Öppnas i ett nytt mellanblad.",
   "notification": {
     "labelClose": "Stäng anmälan"

--- a/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -15,7 +15,6 @@ import {
   createOtherEventTimesRequestAndResultMocks,
   createOtherEventTimesRequestThrowsErrorMocks,
 } from '@/test-utils/mocks/eventListMocks';
-import type { EventFields } from '../../../../../types/event-types';
 import type {
   EventDetails,
   EventFieldsFragment,
@@ -24,7 +23,6 @@ import type {
   Meta,
 } from '../../../../../types/generated/graphql';
 import { EventTypeId } from '../../../../../types/generated/graphql';
-import type { AppLanguage } from '../../../../../types/types';
 import getDateRangeStr from '../../../../../utils/getDateRangeStr';
 import OtherEventTimes from '../OtherEventTimes';
 

--- a/packages/components/src/components/domain/eventSearch/query.ts
+++ b/packages/components/src/components/domain/eventSearch/query.ts
@@ -28,6 +28,7 @@ export const QUERY_EVENT_LIST = gql`
     $page: Int
     $pageSize: Int
     $publisher: ID
+    $publisherAncestor: ID
     $sort: String
     $start: String
     $startsAfter: String
@@ -64,6 +65,7 @@ export const QUERY_EVENT_LIST = gql`
       page: $page
       pageSize: $pageSize
       publisher: $publisher
+      publisherAncestor: $publisherAncestor
       sort: $sort
       start: $start
       startsAfter: $startsAfter

--- a/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
+++ b/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
@@ -9,6 +9,8 @@ export const SEARCH_LIST_QUERY = gql`
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
     $ontologyWordIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -24,6 +26,8 @@ export const SEARCH_LIST_QUERY = gql`
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
       ontologyWordIds: $ontologyWordIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -97,6 +101,15 @@ export const SEARCH_LIST_QUERY = gql`
                 sv
                 en
               }
+            }
+            serviceOwner {
+              name {
+                fi
+                sv
+                en
+              }
+              providerType
+              type
             }
             targetGroups
           }

--- a/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchMap.query.ts
+++ b/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchMap.query.ts
@@ -8,6 +8,8 @@ export const SEARCH_MAP_QUERY = gql`
     $language: UnifiedSearchLanguage!
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -21,6 +23,8 @@ export const SEARCH_MAP_QUERY = gql`
       languages: [$language]
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance

--- a/packages/components/src/components/filterButton/types.ts
+++ b/packages/components/src/components/filterButton/types.ts
@@ -6,6 +6,7 @@ export type FilterType =
   | 'hobbyType'
   | 'sportsCategory'
   | 'targetGroup'
+  | 'helsinkiOnly'
   | 'date'
   | 'dateType'
   | 'division'

--- a/packages/components/src/components/filters/HelsinkiOnlyFilter.tsx
+++ b/packages/components/src/components/filters/HelsinkiOnlyFilter.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useCommonTranslation } from '../../hooks';
+import { FilterButton } from '../filterButton';
+import type { FilterType } from '../filterButton';
+
+interface Props {
+  onRemove: (value: string, type: FilterType) => void;
+}
+
+const HelsinkiOnlyFilter: React.FC<Props> = ({ onRemove }) => {
+  const { t } = useCommonTranslation();
+
+  return (
+    <FilterButton
+      onRemove={onRemove}
+      text={t('common:cityOfHelsinki')}
+      type="helsinkiOnly"
+      value={'true'}
+    />
+  );
+};
+
+export default HelsinkiOnlyFilter;

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -45,6 +45,7 @@ export { default as MatomoWrapper } from './matomoWrapper/MatomoWrapper';
 export { default as Document } from './document/Document';
 export { default as AgeFilter } from './filters/AgeFilter';
 export { default as DateFilter } from './filters/DateFilter';
+export { default as HelsinkiOnlyFilter } from './filters/HelsinkiOnlyFilter';
 export { default as PlaceFilter } from './filters/PlaceFilter';
 export { default as PublisherFilter } from './filters/PublisherFilter';
 export { default as TextFilter } from './filters/TextFilter';

--- a/packages/components/src/constants/event-constants.ts
+++ b/packages/components/src/constants/event-constants.ts
@@ -66,3 +66,7 @@ export enum EVENT_SEARCH_FILTERS {
   MAX_AGE = 'audienceMaxAgeGt',
   SUITABLE = 'suitableFor',
 }
+
+// City of Helsinki's organization ID in Linked Events
+// See https://api.hel.fi/linkedevents/v1/organization/ahjo:00001/
+export const CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID = 'ahjo:00001';

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -7695,6 +7695,7 @@ export type QueryEventListArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   publisher?: InputMaybe<Scalars['ID']['input']>;
+  publisherAncestor?: InputMaybe<Scalars['ID']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
   start?: InputMaybe<Scalars['String']['input']>;
   startsAfter?: InputMaybe<Scalars['String']['input']>;
@@ -12780,6 +12781,7 @@ export type EventListQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   publisher?: InputMaybe<Scalars['ID']['input']>;
+  publisherAncestor?: InputMaybe<Scalars['ID']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
   start?: InputMaybe<Scalars['String']['input']>;
   startsAfter?: InputMaybe<Scalars['String']['input']>;
@@ -13576,6 +13578,12 @@ export type SearchListQueryVariables = Exact<{
   ontologyWordIds?: InputMaybe<
     Array<Scalars['ID']['input']> | Scalars['ID']['input']
   >;
+  providerTypes?: InputMaybe<
+    Array<InputMaybe<ProviderType>> | InputMaybe<ProviderType>
+  >;
+  serviceOwnerTypes?: InputMaybe<
+    Array<InputMaybe<ServiceOwnerType>> | InputMaybe<ServiceOwnerType>
+  >;
   targetGroups?: InputMaybe<
     Array<InputMaybe<TargetGroup>> | InputMaybe<TargetGroup>
   >;
@@ -13686,6 +13694,17 @@ export type SearchListQuery = {
               en?: string | null;
             } | null;
           } | null> | null;
+          serviceOwner?: {
+            __typename?: 'ServiceOwner';
+            providerType?: ProviderType | null;
+            type?: ServiceOwnerType | null;
+            name?: {
+              __typename?: 'LanguageString';
+              fi?: string | null;
+              sv?: string | null;
+              en?: string | null;
+            } | null;
+          } | null;
         } | null;
       };
     }>;
@@ -13702,6 +13721,12 @@ export type SearchMapQueryVariables = Exact<{
   >;
   ontologyTreeIds?: InputMaybe<
     Array<Scalars['ID']['input']> | Scalars['ID']['input']
+  >;
+  providerTypes?: InputMaybe<
+    Array<InputMaybe<ProviderType>> | InputMaybe<ProviderType>
+  >;
+  serviceOwnerTypes?: InputMaybe<
+    Array<InputMaybe<ServiceOwnerType>> | InputMaybe<ServiceOwnerType>
   >;
   targetGroups?: InputMaybe<
     Array<InputMaybe<TargetGroup>> | InputMaybe<TargetGroup>
@@ -14212,6 +14237,7 @@ export const EventListDocument = gql`
     $page: Int
     $pageSize: Int
     $publisher: ID
+    $publisherAncestor: ID
     $sort: String
     $start: String
     $startsAfter: String
@@ -14248,6 +14274,7 @@ export const EventListDocument = gql`
       page: $page
       pageSize: $pageSize
       publisher: $publisher
+      publisherAncestor: $publisherAncestor
       sort: $sort
       start: $start
       startsAfter: $startsAfter
@@ -14308,6 +14335,7 @@ export const EventListDocument = gql`
  *      page: // value for 'page'
  *      pageSize: // value for 'pageSize'
  *      publisher: // value for 'publisher'
+ *      publisherAncestor: // value for 'publisherAncestor'
  *      sort: // value for 'sort'
  *      start: // value for 'start'
  *      startsAfter: // value for 'startsAfter'
@@ -15121,6 +15149,8 @@ export const SearchListDocument = gql`
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
     $ontologyWordIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -15136,6 +15166,8 @@ export const SearchListDocument = gql`
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
       ontologyWordIds: $ontologyWordIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -15210,6 +15242,15 @@ export const SearchListDocument = gql`
                 en
               }
             }
+            serviceOwner {
+              name {
+                fi
+                sv
+                en
+              }
+              providerType
+              type
+            }
             targetGroups
           }
         }
@@ -15237,6 +15278,8 @@ export const SearchListDocument = gql`
  *      administrativeDivisionIds: // value for 'administrativeDivisionIds'
  *      ontologyTreeIds: // value for 'ontologyTreeIds'
  *      ontologyWordIds: // value for 'ontologyWordIds'
+ *      providerTypes: // value for 'providerTypes'
+ *      serviceOwnerTypes: // value for 'serviceOwnerTypes'
  *      targetGroups: // value for 'targetGroups'
  *      openAt: // value for 'openAt'
  *      orderByDistance: // value for 'orderByDistance'
@@ -15285,6 +15328,8 @@ export const SearchMapDocument = gql`
     $language: UnifiedSearchLanguage!
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -15298,6 +15343,8 @@ export const SearchMapDocument = gql`
       languages: [$language]
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -15347,6 +15394,8 @@ export const SearchMapDocument = gql`
  *      language: // value for 'language'
  *      administrativeDivisionIds: // value for 'administrativeDivisionIds'
  *      ontologyTreeIds: // value for 'ontologyTreeIds'
+ *      providerTypes: // value for 'providerTypes'
+ *      serviceOwnerTypes: // value for 'serviceOwnerTypes'
  *      targetGroups: // value for 'targetGroups'
  *      openAt: // value for 'openAt'
  *      orderByDistance: // value for 'orderByDistance'


### PR DESCRIPTION
NOTE:
 - No UI support yet except through FilterSummary i.e. the tags under the search bar
 - `helsinkiOnly=true` **query parameter must be added manually** into the **URL** to test out this functionality

## Description

### feat(sports): add "Helsinki only" filter to venue/event/hobby search 

`helsinkiOnly=true` query parameter will filter all searches with city of
Helsinki

refs LIIKUNTA-509, LIIKUNTA-510

## Issues

### Closes

**[LIIKUNTA-509](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-509)**
**[LIIKUNTA-510](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-510)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Without `helsinkiOnly=true` query parameter

https://liikunta-pr410.dev.hel.ninja/fi/search?searchType=Venue

![1](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/3a1887fe-d086-4f69-99b7-0012c0ca1c87)

### With `helsinkiOnly=true` query parameter

https://liikunta-pr410.dev.hel.ninja/fi/search?searchType=Venue&helsinkiOnly=true

![2](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/983032ee-54b6-45cc-9b79-6efa6f1b0b9e)

## Additional notes


[LIIKUNTA-509]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIIKUNTA-510]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ