### PR TITLE
LIIKUNTA-510 | feat(events-graphql-proxy): add publisherAncestor parameter to eventList

### DIFF
--- a/proxies/events-graphql-proxy/src/__tests__/eventIntegration.test.ts
+++ b/proxies/events-graphql-proxy/src/__tests__/eventIntegration.test.ts
@@ -193,6 +193,7 @@ it('sends REST request correctly with query params (course)', async () => {
       page: 10,
       pageSize: 10,
       publisher: 'publisher',
+      publisherAncestor: 'ahjo:123',
       sort: 'asc',
       start: '10.10.2021',
       startsBefore: '10.10.2022',
@@ -208,7 +209,7 @@ it('sends REST request correctly with query params (course)', async () => {
   expect(getMock).toHaveBeenCalledTimes(1);
   expect(getMock.mock.calls[0][0]).toMatchInlineSnapshot(
     // eslint-disable-next-line max-len
-    `"event?event_type=Course&internet_based=true&all_ongoing=true&all_ongoing_AND=asd&division=division1,division2&end=end&ends_after=09.10.2020&ends_before=10.10.2020&include=include&in_language=fi&is_free=true&keyword=keyword1,keyword2&keyword_AND=keywordAnd,keywordAnd2&keyword!=keywordNot&language=fi&location=location2,location3&page=10&page_size=10&publisher=publisher&sort=asc&start=10.10.2021&starts_after=10.20.2021&starts_before=10.10.2022&super_event=123aasd&super_event_type=course,event&text=testText&translation=translation"`
+    `"event?event_type=Course&internet_based=true&all_ongoing=true&all_ongoing_AND=asd&division=division1,division2&end=end&ends_after=09.10.2020&ends_before=10.10.2020&include=include&in_language=fi&is_free=true&keyword=keyword1,keyword2&keyword_AND=keywordAnd,keywordAnd2&keyword!=keywordNot&language=fi&location=location2,location3&page=10&page_size=10&publisher=publisher&publisher_ancestor=ahjo:123&sort=asc&start=10.10.2021&starts_after=10.20.2021&starts_before=10.10.2022&super_event=123aasd&super_event_type=course,event&text=testText&translation=translation"`
   );
 });
 
@@ -261,6 +262,7 @@ const EVENTS_QUERY = gql`
     $page: Int
     $pageSize: Int
     $publisher: ID
+    $publisherAncestor: ID
     $sort: String
     $start: String
     $startsAfter: String
@@ -292,6 +294,7 @@ const EVENTS_QUERY = gql`
       page: $page
       pageSize: $pageSize
       publisher: $publisher
+      publisherAncestor: $publisherAncestor
       sort: $sort
       start: $start
       startsAfter: $startsAfter

--- a/proxies/events-graphql-proxy/src/schema/event/typeDefs.ts
+++ b/proxies/events-graphql-proxy/src/schema/event/typeDefs.ts
@@ -46,6 +46,7 @@ const typeDefs = gql`
       page: Int
       pageSize: Int
       publisher: ID
+      publisherAncestor: ID
       sort: String
       start: String
       startsAfter: String

--- a/proxies/events-graphql-proxy/src/schema/event/utils.ts
+++ b/proxies/events-graphql-proxy/src/schema/event/utils.ts
@@ -37,6 +37,7 @@ export const buildEventListQuery = (params: QueryEventListArgs) => {
     { key: 'page', value: params.page },
     { key: 'page_size', value: params.pageSize },
     { key: 'publisher', value: params.publisher },
+    { key: 'publisher_ancestor', value: params.publisherAncestor },
     { key: 'sort', value: params.sort },
     { key: 'start', value: params.start },
     { key: 'starts_after', value: params.startsAfter },

--- a/proxies/events-graphql-proxy/src/types/types.ts
+++ b/proxies/events-graphql-proxy/src/types/types.ts
@@ -459,6 +459,7 @@ export type QueryEventListArgs = {
   page?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
   publisher?: Maybe<Scalars['ID']>;
+  publisherAncestor?: Maybe<Scalars['ID']>;
   sort?: Maybe<Scalars['String']>;
   start?: Maybe<Scalars['String']>;
   startsAfter?: Maybe<Scalars['String']>;


### PR DESCRIPTION
## Description

### feat(events-graphql-proxy): add publisherAncestor parameter to eventList

publisherAncestor is mapped to published_ancestor parameter in Linked
Events event search e.g.
https://api.hel.fi/linkedevents/v1/event/?publisher_ancestor=ahjo%3A00001
for showing city of Helsinki's events

refs LIIKUNTA-510

## Issues

### Closes

### Related

**[LIIKUNTA-510](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-510)**

## Testing

### Automated tests

### Manual testing

https://events-graphql-proxy-pr411.dev.hel.ninja/proxy/graphql
with query
```graphql
query EventList {
  eventList(publisherAncestor: "ahjo:u48040030") {
    data {
      name {
        fi
      }
      provider {
        fi
      }
    }
  }
}
```
returned data
```json
{
  "data": {
    "eventList": {
      "data": [
        {
          "name": {
            "fi": "Drag on myös nuorten laji"
          },
          "provider": {
            "fi": "Seta"
          }
        },
        {
          "name": {
            "fi": "Neonya!! Party - Hardcore Heat"
          },
          "provider": {
            "fi": "Neonya!! Party "
          }
        },
        {
          "name": {
            "fi": "Nuorten puistoalue Helsinki Pride -puistojuhlassa"
          },
          "provider": {
            "fi": "Helsingin kaupungin nuorisopalvelut ja Helsinki Pride -yhteisö ry."
          }
        },
...
```

## Screenshots

## Additional notes


[LIIKUNTA-510]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ