### PR TITLE
chore: rename events-graphql-proxy Image to EventImage, update supergraph

### DIFF
--- a/apps/events-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/events-helsinki/config/jest/mockDataUtils.ts
@@ -8,7 +8,7 @@ import type {
   EventFields,
   EventListResponse,
   ExternalLink,
-  Image,
+  EventImage,
   InLanguage,
   Keyword,
   KeywordListResponse,
@@ -53,7 +53,7 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       provider: fakeLocalizedObject(),
       shortDescription: fakeLocalizedObject(),
       description: fakeLocalizedObject(),
-      images: [fakeImage()],
+      images: [fakeEventImage()],
       infoUrl: fakeLocalizedObject(),
       inLanguage: [fakeInLanguage()],
       audience: [],
@@ -121,7 +121,7 @@ export const fakeExternalLink = (
     overrides
   );
 
-export const fakeImage = (overrides?: Partial<Image>): Image =>
+export const fakeEventImage = (overrides?: Partial<EventImage>): EventImage =>
   merge(
     {
       id: faker.string.uuid(),
@@ -131,7 +131,7 @@ export const fakeImage = (overrides?: Partial<Image>): Image =>
       url: 'https://api.hel.fi/linkedevents-test/media/images/test.png',
       cropping: '59,0,503,444',
       photographerName: faker.person.firstName(),
-      __typename: 'Image',
+      __typename: 'EventImage',
     },
     overrides
   );

--- a/apps/events-helsinki/src/domain/event/__tests__/EventUtils.test.ts
+++ b/apps/events-helsinki/src/domain/event/__tests__/EventUtils.test.ts
@@ -16,7 +16,7 @@ import map from 'lodash/map';
 
 import {
   fakeEvent,
-  fakeImage,
+  fakeEventImage,
   fakeKeyword,
   fakeKeywords,
   fakePlace,
@@ -71,7 +71,7 @@ describe('getEventSomeImageUrl function', () => {
   it('should return default placeholder image if image is not defined', () => {
     const event = fakeEvent({
       id: 'helsinki:221',
-      images: [fakeImage({ url: '' })],
+      images: [fakeEventImage({ url: '' })],
     }) as EventFieldsFragment;
     expect(getEventSomeImageUrl(event)).toBe(
       '/images/activities_SoMe-share.jpg'

--- a/apps/hobbies-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/hobbies-helsinki/config/jest/mockDataUtils.ts
@@ -8,7 +8,7 @@ import type {
   EventFields,
   EventListResponse,
   ExternalLink,
-  Image,
+  EventImage,
   InLanguage,
   Keyword,
   KeywordListResponse,
@@ -53,7 +53,7 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       provider: fakeLocalizedObject(),
       shortDescription: fakeLocalizedObject(),
       description: fakeLocalizedObject(),
-      images: [fakeImage()],
+      images: [fakeEventImage()],
       infoUrl: fakeLocalizedObject(),
       inLanguage: [fakeInLanguage()],
       audience: [],
@@ -121,7 +121,7 @@ export const fakeExternalLink = (
     overrides
   );
 
-export const fakeImage = (overrides?: Partial<Image>): Image =>
+export const fakeEventImage = (overrides?: Partial<EventImage>): EventImage =>
   merge(
     {
       id: faker.string.uuid(),
@@ -131,7 +131,7 @@ export const fakeImage = (overrides?: Partial<Image>): Image =>
       url: 'https://api.hel.fi/linkedevents-test/media/images/test.png',
       cropping: '59,0,503,444',
       photographerName: faker.person.firstName(),
-      __typename: 'Image',
+      __typename: 'EventImage',
     },
     overrides
   );

--- a/apps/sports-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/sports-helsinki/config/jest/mockDataUtils.ts
@@ -8,7 +8,7 @@ import type {
   EventFields,
   EventListResponse,
   ExternalLink,
-  Image,
+  EventImage,
   InLanguage,
   Keyword,
   KeywordListResponse,
@@ -57,7 +57,7 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       provider: fakeLocalizedObject(),
       shortDescription: fakeLocalizedObject(),
       description: fakeLocalizedObject(),
-      images: [fakeImage()],
+      images: [fakeEventImage()],
       infoUrl: fakeLocalizedObject(),
       inLanguage: [fakeInLanguage()],
       audience: [],
@@ -125,7 +125,7 @@ export const fakeExternalLink = (
     overrides
   );
 
-export const fakeImage = (overrides?: Partial<Image>): Image =>
+export const fakeEventImage = (overrides?: Partial<EventImage>): EventImage =>
   merge(
     {
       id: faker.string.uuid(),
@@ -135,7 +135,7 @@ export const fakeImage = (overrides?: Partial<Image>): Image =>
       url: 'https://api.hel.fi/linkedevents-test/media/images/test.png',
       cropping: '59,0,503,444',
       photographerName: faker.person.firstName(),
-      __typename: 'Image',
+      __typename: 'EventImage',
     },
     overrides
   );

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
@@ -33,6 +33,10 @@ export const searchAdapterForType: Record<SearchType, SearchAdapterType> = {
   venue: VenueSearchAdapter,
 };
 
+function toBoolean(input?: string | boolean | null): boolean {
+  return ['true', '1', 'yes'].includes(input?.toString().toLowerCase() ?? '');
+}
+
 class CombinedSearchFormAdapter
   implements
     CombinedSearchAdapterInput,
@@ -52,6 +56,7 @@ class CombinedSearchFormAdapter
   courseOrderBy?: string | null;
   sportsCategories: string[];
   targetGroups: string[];
+  helsinkiOnly?: boolean | string | null;
   organization?: string | null;
   place?: string | null;
   keywords: string[];
@@ -93,6 +98,8 @@ class CombinedSearchFormAdapter
       initialCombinedSearchFormValues.courseOrderBy;
     this.sportsCategories = input.getAll('sportsCategories');
     this.targetGroups = input.getAll('targetGroups');
+    this.helsinkiOnly =
+      input.get('helsinkiOnly') ?? initialCombinedSearchFormValues.helsinkiOnly;
     this.organization =
       input.get('organization') ??
       input.get('publisher') ??
@@ -209,6 +216,10 @@ class CombinedSearchFormAdapter
 
   public cleanTargetGroups() {
     return;
+  }
+
+  public cleanHelsinkOnly() {
+    this.helsinkiOnly = toBoolean(this.helsinkiOnly);
   }
 
   public cleanOrganization() {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
@@ -1,3 +1,4 @@
+import { CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID } from '@events-helsinki/components';
 import { EventTypeId } from '@events-helsinki/components/types';
 import {
   SPORT_COURSES_KEYWORDS,
@@ -33,6 +34,7 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
   eventType: EventSearchParams['eventType'];
   superEventType: EventSearchParams['superEventType'];
   publisher: EventSearchParams['publisher'];
+  publisherAncestor: EventSearchParams['publisherAncestor'];
   page: EventSearchParams['page'];
   pageSize: EventSearchParams['pageSize'];
 
@@ -64,6 +66,9 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
         : input.courseOrderBy) ?? initialEventSearchAdapterValues.sort;
     this.publisher =
       input.organization ?? initialEventSearchAdapterValues.publisher;
+    this.publisherAncestor = input.helsinkiOnly
+      ? CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID
+      : initialEventSearchAdapterValues.publisherAncestor;
   }
 
   public getSportsKeywords({ sportsCategories }: CombinedSearchAdapterInput) {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
@@ -11,7 +11,11 @@ import type {
   TARGET_GROUPS,
   TargetGroup as UnifiedSearchTargetGroup,
 } from '@events-helsinki/components/types';
-import { SortOrder } from '@events-helsinki/components/types';
+import {
+  SortOrder,
+  ProviderType,
+  ServiceOwnerType,
+} from '@events-helsinki/components/types';
 import { appToUnifiedSearchLanguageMap } from '../../eventSearch/types';
 import { initialVenueSearchAdapterValues } from '../constants';
 import type {
@@ -30,6 +34,8 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
   q: VenueSearchParams['q'];
   ontologyTreeIds: VenueSearchParams['ontologyWordIds'];
   ontologyWordIds: VenueSearchParams['ontologyWordIds'];
+  providerTypes: VenueSearchParams['providerTypes'];
+  serviceOwnerTypes: VenueSearchParams['serviceOwnerTypes'];
   targetGroups: VenueSearchParams['targetGroups'];
   openAt?: VenueSearchParams['openAt'];
   administrativeDivisionIds?: VenueSearchParams['administrativeDivisionIds'];
@@ -57,6 +63,12 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
     this.q = input.text || initialVenueSearchAdapterValues.q;
     this.ontologyTreeIds = this.getOntologyTreeIds(input);
     this.targetGroups = this.getTargetGroups(input);
+    this.providerTypes = input.helsinkiOnly
+      ? [ProviderType.SelfProduced]
+      : initialVenueSearchAdapterValues.providerTypes;
+    this.serviceOwnerTypes = input.helsinkiOnly
+      ? [ServiceOwnerType.MunicipalService]
+      : initialVenueSearchAdapterValues.serviceOwnerTypes;
     if (input.venueOrderBy?.includes('name')) {
       this.orderByName = input.venueOrderBy.startsWith('-')
         ? { order: SortOrder.Descending }

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -105,6 +105,7 @@ describe('CombinedSearchFormAdapter', () => {
           location: [],
           pageSize: 10,
           publisher: null,
+          publisherAncestor: null,
           include: ['keywords', 'location'],
           superEventType: ['umbrella', 'none'],
         },

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
@@ -14,6 +14,7 @@ describe('EventSearchAdapter', () => {
           venueOrderBy: null,
           sportsCategories: [],
           targetGroups: [TARGET_GROUPS.SENIORS, TARGET_GROUPS.YOUTH],
+          helsinkiOnly: true,
           organization: null,
           keywords: [],
         };
@@ -66,6 +67,7 @@ describe('EventSearchAdapter', () => {
           location: [],
           pageSize: 10,
           publisher: null,
+          publisherAncestor: 'ahjo:00001',
           include: ['keywords', 'location'],
           superEventType: ['umbrella', 'none'],
           sort:

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`CombinedSearchProvider reads the context properly 1`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;
@@ -35,17 +35,17 @@ exports[`CombinedSearchProvider reads the context properly 2`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;
@@ -60,17 +60,17 @@ exports[`CombinedSearchProvider reads the context properly 3`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":"testorg","pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
@@ -22,6 +22,7 @@ export const initialCombinedSearchFormValues: CombinedSearchAdapterInput = {
   courseOrderBy: undefined,
   sportsCategories: [],
   targetGroups: [],
+  helsinkiOnly: undefined,
   organization: undefined,
   place: undefined,
   keywords: [],
@@ -34,6 +35,8 @@ export const initialVenueSearchAdapterValues: VenueSearchParams = {
   ontologyWordIds: [],
   targetGroups: [],
   administrativeDivisionIds: [HELSINKI_OCD_DIVISION_ID],
+  providerTypes: undefined,
+  serviceOwnerTypes: undefined,
   openAt: null,
   after: '',
   first: 10,
@@ -53,5 +56,6 @@ export const initialEventSearchAdapterValues: EventSearchParams = {
   eventType: EventTypeId.General,
   superEventType: ['umbrella', 'none'],
   publisher: null,
+  publisherAncestor: null,
   pageSize: 10,
 };

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -57,6 +57,7 @@ export type CombinedSearchAdapterInput = {
   sportsCategories: string[];
   targetGroups: string[];
   organization?: string | null;
+  helsinkiOnly?: boolean | string | null;
   place?: string | null;
   keywords: string[];
 } & CombinedSearchAdapterInputForVenues &
@@ -84,6 +85,7 @@ export type EventSearchParams = Pick<
   | 'eventType'
   | 'superEventType'
   | 'publisher'
+  | 'publisherAncestor'
   | 'page'
   | 'pageSize'
 >;
@@ -96,6 +98,8 @@ export type VenueSearchParams = Pick<
   | 'q'
   | 'ontologyTreeIds'
   | 'ontologyWordIds'
+  | 'providerTypes'
+  | 'serviceOwnerTypes'
   | 'targetGroups'
   | 'administrativeDivisionIds'
   | 'openAt'

--- a/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
@@ -1,5 +1,6 @@
 import {
   useLocale,
+  HelsinkiOnlyFilter,
   PublisherFilter,
   FilterButton,
   translateValue,
@@ -30,6 +31,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
     sportsCategories,
     targetGroups,
     organization: publisher,
+    helsinkiOnly,
     text: q,
     place,
   } = formValues;
@@ -64,6 +66,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
   const hasFilters =
     !!sportsCategories.length ||
     !!targetGroups.length ||
+    !!helsinkiOnly ||
     !!publisher ||
     !!place ||
     !!q?.length;
@@ -103,6 +106,11 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
         <PublisherFilter
           id={publisher}
           onRemove={() => handleFilterRemove('organization', publisher)}
+        />
+      )}
+      {helsinkiOnly && (
+        <HelsinkiOnlyFilter
+          onRemove={() => handleFilterRemove('helsinkiOnly', 'true')}
         />
       )}
       {place && (

--- a/packages/common-i18n/src/locales/en/common.json
+++ b/packages/common-i18n/src/locales/en/common.json
@@ -1,4 +1,5 @@
 {
+  "cityOfHelsinki": "City of Helsinki",
   "opens_in_new_tab": "Opens in a new tab.",
   "notification": {
     "labelClose": "Close notification"

--- a/packages/common-i18n/src/locales/fi/common.json
+++ b/packages/common-i18n/src/locales/fi/common.json
@@ -1,4 +1,5 @@
 {
+  "cityOfHelsinki": "Helsingin kaupunki",
   "opens_in_new_tab": "Avautuu uudessa välilehdessä.",
   "notification": {
     "labelClose": "Sulje ilmoitus"

--- a/packages/common-i18n/src/locales/sv/common.json
+++ b/packages/common-i18n/src/locales/sv/common.json
@@ -1,4 +1,5 @@
 {
+  "cityOfHelsinki": "Helsingfors stad",
   "opens_in_new_tab": "Öppnas i ett nytt mellanblad.",
   "notification": {
     "labelClose": "Stäng anmälan"

--- a/packages/components/config/tests/mockDataUtils.ts
+++ b/packages/components/config/tests/mockDataUtils.ts
@@ -14,7 +14,7 @@ import type {
   EventDetails,
   EventListResponse,
   ExternalLink,
-  Image,
+  EventImage,
   InLanguage,
   Keyword,
   KeywordListResponse,
@@ -54,7 +54,7 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       provider: fakeLocalizedObject(),
       shortDescription: fakeLocalizedObject(),
       description: fakeLocalizedObject(),
-      images: [fakeImage()],
+      images: [fakeEventImage()],
       infoUrl: fakeLocalizedObject(),
       inLanguage: [fakeInLanguage()],
       audience: [],
@@ -122,7 +122,7 @@ export const fakeExternalLink = (
     overrides
   );
 
-export const fakeImage = (overrides?: Partial<Image>): Image =>
+export const fakeEventImage = (overrides?: Partial<EventImage>): EventImage =>
   merge(
     {
       id: faker.string.uuid(),
@@ -132,7 +132,7 @@ export const fakeImage = (overrides?: Partial<Image>): Image =>
       url: 'https://api.hel.fi/linkedevents-test/media/images/test.png',
       cropping: '59,0,503,444',
       photographerName: faker.person.firstName(),
-      __typename: 'Image',
+      __typename: 'EventImage',
     },
     overrides
   );

--- a/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { configure, render, screen, waitFor } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
-import { fakeEvent, fakeImage } from '@/test-utils/mockDataUtils';
+import { fakeEvent, fakeEventImage } from '@/test-utils/mockDataUtils';
 import type { EventFieldsFragment } from '../../../../../types';
 import EventContent from '../EventContent';
 
@@ -32,7 +32,7 @@ const event = fakeEvent({
     name: { fi: locationName },
     streetAddress: { fi: streetAddress },
   },
-  images: [fakeImage({ photographerName })],
+  images: [fakeEventImage({ photographerName })],
 }) as EventFieldsFragment;
 
 it('should render event content fields', async () => {

--- a/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -15,7 +15,6 @@ import {
   createOtherEventTimesRequestAndResultMocks,
   createOtherEventTimesRequestThrowsErrorMocks,
 } from '@/test-utils/mocks/eventListMocks';
-import type { EventFields } from '../../../../../types/event-types';
 import type {
   EventDetails,
   EventFieldsFragment,
@@ -24,7 +23,6 @@ import type {
   Meta,
 } from '../../../../../types/generated/graphql';
 import { EventTypeId } from '../../../../../types/generated/graphql';
-import type { AppLanguage } from '../../../../../types/types';
 import getDateRangeStr from '../../../../../utils/getDateRangeStr';
 import OtherEventTimes from '../OtherEventTimes';
 

--- a/packages/components/src/components/domain/eventSearch/query.ts
+++ b/packages/components/src/components/domain/eventSearch/query.ts
@@ -28,6 +28,7 @@ export const QUERY_EVENT_LIST = gql`
     $page: Int
     $pageSize: Int
     $publisher: ID
+    $publisherAncestor: ID
     $sort: String
     $start: String
     $startsAfter: String
@@ -64,6 +65,7 @@ export const QUERY_EVENT_LIST = gql`
       page: $page
       pageSize: $pageSize
       publisher: $publisher
+      publisherAncestor: $publisherAncestor
       sort: $sort
       start: $start
       startsAfter: $startsAfter

--- a/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
+++ b/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
@@ -9,6 +9,8 @@ export const SEARCH_LIST_QUERY = gql`
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
     $ontologyWordIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -24,6 +26,8 @@ export const SEARCH_LIST_QUERY = gql`
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
       ontologyWordIds: $ontologyWordIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -97,6 +101,15 @@ export const SEARCH_LIST_QUERY = gql`
                 sv
                 en
               }
+            }
+            serviceOwner {
+              name {
+                fi
+                sv
+                en
+              }
+              providerType
+              type
             }
             targetGroups
           }

--- a/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchMap.query.ts
+++ b/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchMap.query.ts
@@ -8,6 +8,8 @@ export const SEARCH_MAP_QUERY = gql`
     $language: UnifiedSearchLanguage!
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -21,6 +23,8 @@ export const SEARCH_MAP_QUERY = gql`
       languages: [$language]
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance

--- a/packages/components/src/components/filterButton/types.ts
+++ b/packages/components/src/components/filterButton/types.ts
@@ -6,6 +6,7 @@ export type FilterType =
   | 'hobbyType'
   | 'sportsCategory'
   | 'targetGroup'
+  | 'helsinkiOnly'
   | 'date'
   | 'dateType'
   | 'division'

--- a/packages/components/src/components/filters/HelsinkiOnlyFilter.tsx
+++ b/packages/components/src/components/filters/HelsinkiOnlyFilter.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useCommonTranslation } from '../../hooks';
+import { FilterButton } from '../filterButton';
+import type { FilterType } from '../filterButton';
+
+interface Props {
+  onRemove: (value: string, type: FilterType) => void;
+}
+
+const HelsinkiOnlyFilter: React.FC<Props> = ({ onRemove }) => {
+  const { t } = useCommonTranslation();
+
+  return (
+    <FilterButton
+      onRemove={onRemove}
+      text={t('common:cityOfHelsinki')}
+      type="helsinkiOnly"
+      value={'true'}
+    />
+  );
+};
+
+export default HelsinkiOnlyFilter;

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -45,6 +45,7 @@ export { default as MatomoWrapper } from './matomoWrapper/MatomoWrapper';
 export { default as Document } from './document/Document';
 export { default as AgeFilter } from './filters/AgeFilter';
 export { default as DateFilter } from './filters/DateFilter';
+export { default as HelsinkiOnlyFilter } from './filters/HelsinkiOnlyFilter';
 export { default as PlaceFilter } from './filters/PlaceFilter';
 export { default as PublisherFilter } from './filters/PublisherFilter';
 export { default as TextFilter } from './filters/TextFilter';

--- a/packages/components/src/constants/event-constants.ts
+++ b/packages/components/src/constants/event-constants.ts
@@ -66,3 +66,7 @@ export enum EVENT_SEARCH_FILTERS {
   MAX_AGE = 'audienceMaxAgeGt',
   SUITABLE = 'suitableFor',
 }
+
+// City of Helsinki's organization ID in Linked Events
+// See https://api.hel.fi/linkedevents/v1/organization/ahjo:00001/
+export const CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID = 'ahjo:00001';

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -2892,7 +2892,7 @@ export type EventDetails = {
   eventStatus?: Maybe<Scalars['String']['output']>;
   externalLinks: Array<ExternalLink>;
   id: Scalars['ID']['output'];
-  images: Array<Image>;
+  images: Array<EventImage>;
   inLanguage: Array<InLanguage>;
   infoUrl?: Maybe<LocalizedObject>;
   internalContext?: Maybe<Scalars['String']['output']>;
@@ -2916,6 +2916,23 @@ export type EventDetails = {
   superEvent?: Maybe<InternalIdObject>;
   superEventType?: Maybe<Scalars['String']['output']>;
   typeId?: Maybe<EventTypeId>;
+};
+
+export type EventImage = {
+  __typename?: 'EventImage';
+  createdTime?: Maybe<Scalars['String']['output']>;
+  cropping?: Maybe<Scalars['String']['output']>;
+  dataSource?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
+  internalContext?: Maybe<Scalars['String']['output']>;
+  internalId: Scalars['String']['output'];
+  internalType?: Maybe<Scalars['String']['output']>;
+  lastModifiedTime?: Maybe<Scalars['String']['output']>;
+  license?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  photographerName?: Maybe<Scalars['String']['output']>;
+  publisher?: Maybe<Scalars['String']['output']>;
+  url: Scalars['String']['output'];
 };
 
 export type EventListResponse = {
@@ -3059,6 +3076,25 @@ export type ExternalLink = {
   language?: Maybe<Scalars['String']['output']>;
   link?: Maybe<Scalars['String']['output']>;
   name?: Maybe<Scalars['String']['output']>;
+};
+
+/** Gallery Image */
+export type GalleryImage = {
+  __typename?: 'GalleryImage';
+  /** Caption of the image */
+  caption?: Maybe<Scalars['String']['output']>;
+  /** Description of the image */
+  description?: Maybe<Scalars['String']['output']>;
+  /** The url of the large image */
+  large?: Maybe<Scalars['String']['output']>;
+  /** The url of the medium image */
+  medium?: Maybe<Scalars['String']['output']>;
+  /** The url of the medium large image */
+  medium_large?: Maybe<Scalars['String']['output']>;
+  /** The url of the thumbnail image */
+  thumbnail?: Maybe<Scalars['String']['output']>;
+  /** Title of the image */
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** The general setting type */
@@ -3579,21 +3615,23 @@ export enum IdentificationStrength {
   Unidentified = 'UNIDENTIFIED',
 }
 
+/** Image */
 export type Image = {
   __typename?: 'Image';
-  createdTime?: Maybe<Scalars['String']['output']>;
-  cropping?: Maybe<Scalars['String']['output']>;
-  dataSource?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['ID']['output']>;
-  internalContext?: Maybe<Scalars['String']['output']>;
-  internalId: Scalars['String']['output'];
-  internalType?: Maybe<Scalars['String']['output']>;
-  lastModifiedTime?: Maybe<Scalars['String']['output']>;
-  license?: Maybe<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-  photographerName?: Maybe<Scalars['String']['output']>;
-  publisher?: Maybe<Scalars['String']['output']>;
-  url: Scalars['String']['output'];
+  /** Caption of the image */
+  caption?: Maybe<Scalars['String']['output']>;
+  /** Description of the image */
+  description?: Maybe<Scalars['String']['output']>;
+  /** The url of the large image */
+  large?: Maybe<Scalars['String']['output']>;
+  /** The url of the medium image */
+  medium?: Maybe<Scalars['String']['output']>;
+  /** The url of the medium large image */
+  medium_large?: Maybe<Scalars['String']['output']>;
+  /** The url of the thumbnail image */
+  thumbnail?: Maybe<Scalars['String']['output']>;
+  /** Title of the image */
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 export type InLanguage = {
@@ -3620,7 +3658,7 @@ export type Keyword = {
   deprecated?: Maybe<Scalars['Boolean']['output']>;
   hasUpcomingEvents?: Maybe<Scalars['Boolean']['output']>;
   id?: Maybe<Scalars['ID']['output']>;
-  image?: Maybe<Image>;
+  image?: Maybe<EventImage>;
   internalContext?: Maybe<Scalars['String']['output']>;
   internalId: Scalars['String']['output'];
   internalType?: Maybe<Scalars['String']['output']>;
@@ -4201,6 +4239,23 @@ export type LayoutArticlesCarousel = {
   title?: Maybe<Scalars['String']['output']>;
 };
 
+/** Layout: LayoutCard */
+export type LayoutCard = {
+  __typename?: 'LayoutCard';
+  /** Alignment */
+  alignment?: Maybe<Scalars['String']['output']>;
+  /** Background Color */
+  backgroundColor?: Maybe<Scalars['String']['output']>;
+  /** Description */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Image */
+  image?: Maybe<Image>;
+  /** Link */
+  link?: Maybe<Link>;
+  /** Title */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 /** Layout: LayoutCards */
 export type LayoutCards = {
   __typename?: 'LayoutCards';
@@ -4235,6 +4290,26 @@ export type LayoutContent = {
   content?: Maybe<Scalars['String']['output']>;
   /** Title */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Layout: LayoutImage */
+export type LayoutImage = {
+  __typename?: 'LayoutImage';
+  /** Border */
+  border?: Maybe<Scalars['Boolean']['output']>;
+  /** Image */
+  image?: Maybe<Image>;
+  /** Photographer name (overwrite) */
+  photographer_name?: Maybe<Scalars['String']['output']>;
+  /** Lightbox */
+  show_on_lightbox?: Maybe<Scalars['Boolean']['output']>;
+};
+
+/** Layout: LayoutImageGallery */
+export type LayoutImageGallery = {
+  __typename?: 'LayoutImageGallery';
+  /** Gallery */
+  gallery?: Maybe<Array<Maybe<GalleryImage>>>;
 };
 
 /** Layout: LayoutLinkList */
@@ -4282,6 +4357,32 @@ export type LayoutPagesCarousel = {
   pages?: Maybe<Array<Maybe<Page>>>;
   /** Title */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Layout: LayoutSocialMediaFeed */
+export type LayoutSocialMediaFeed = {
+  __typename?: 'LayoutSocialMediaFeed';
+  /** Anchor */
+  anchor?: Maybe<Scalars['String']['output']>;
+  /** Script */
+  script?: Maybe<Scalars['String']['output']>;
+  /** Title */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Layout: LayoutSteps */
+export type LayoutSteps = {
+  __typename?: 'LayoutSteps';
+  /** Color */
+  color?: Maybe<Scalars['String']['output']>;
+  /** Description */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Steps */
+  steps?: Maybe<Array<Maybe<Step>>>;
+  /** Title */
+  title?: Maybe<Scalars['String']['output']>;
+  /** Type */
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type LegalEntity = Organisation | Person;
@@ -5939,12 +6040,17 @@ export type PageModulesUnionType =
   | LayoutArticleHighlights
   | LayoutArticles
   | LayoutArticlesCarousel
+  | LayoutCard
   | LayoutCards
   | LayoutCollection
   | LayoutContact
   | LayoutContent
+  | LayoutImage
+  | LayoutImageGallery
   | LayoutPages
   | LayoutPagesCarousel
+  | LayoutSocialMediaFeed
+  | LayoutSteps
   | LocationsSelected
   | LocationsSelectedCarousel;
 
@@ -6116,7 +6222,7 @@ export type Place = {
   email?: Maybe<Scalars['String']['output']>;
   hasUpcomingEvents?: Maybe<Scalars['Boolean']['output']>;
   id?: Maybe<Scalars['ID']['output']>;
-  image?: Maybe<Image>;
+  image?: Maybe<EventImage>;
   infoUrl?: Maybe<LocalizedObject>;
   internalContext?: Maybe<Scalars['String']['output']>;
   internalId: Scalars['String']['output'];
@@ -6746,12 +6852,17 @@ export type PostModulesUnionType =
   | LayoutArticleHighlights
   | LayoutArticles
   | LayoutArticlesCarousel
+  | LayoutCard
   | LayoutCards
   | LayoutCollection
   | LayoutContact
   | LayoutContent
+  | LayoutImage
+  | LayoutImageGallery
   | LayoutPages
   | LayoutPagesCarousel
+  | LayoutSocialMediaFeed
+  | LayoutSteps
   | LocationsSelected
   | LocationsSelectedCarousel;
 
@@ -10112,6 +10223,15 @@ export type StaticPage = {
   urlPath?: Maybe<Scalars['String']['output']>;
 };
 
+/** Step field */
+export type Step = {
+  __typename?: 'Step';
+  /** The content of the step */
+  content?: Maybe<Scalars['String']['output']>;
+  /** The title of the step */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 export type Subscription = {
   __typename?: 'Subscription';
   _empty?: Maybe<Scalars['String']['output']>;
@@ -12241,7 +12361,7 @@ export enum UsersConnectionSearchColumnEnum {
   Login = 'LOGIN',
   /** A URL-friendly name for the user. The default is the user's username. */
   Nicename = 'NICENAME',
-  /** The URL of the users website. */
+  /** The URL of the user's website. */
   Url = 'URL',
 }
 
@@ -12370,7 +12490,7 @@ export type EventFieldsFragment = {
     link?: string | null;
   }>;
   images: Array<{
-    __typename?: 'Image';
+    __typename?: 'EventImage';
     id?: string | null;
     name: string;
     url: string;
@@ -12557,7 +12677,7 @@ export type EventDetailsQuery = {
       link?: string | null;
     }>;
     images: Array<{
-      __typename?: 'Image';
+      __typename?: 'EventImage';
       id?: string | null;
       name: string;
       url: string;
@@ -12824,7 +12944,7 @@ export type EventListQuery = {
         link?: string | null;
       }>;
       images: Array<{
-        __typename?: 'Image';
+        __typename?: 'EventImage';
         id?: string | null;
         name: string;
         url: string;
@@ -13023,7 +13143,7 @@ export type EventsByIdsQuery = {
         link?: string | null;
       }>;
       images: Array<{
-        __typename?: 'Image';
+        __typename?: 'EventImage';
         id?: string | null;
         name: string;
         url: string;

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -7695,6 +7695,7 @@ export type QueryEventListArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   publisher?: InputMaybe<Scalars['ID']['input']>;
+  publisherAncestor?: InputMaybe<Scalars['ID']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
   start?: InputMaybe<Scalars['String']['input']>;
   startsAfter?: InputMaybe<Scalars['String']['input']>;
@@ -12780,6 +12781,7 @@ export type EventListQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   publisher?: InputMaybe<Scalars['ID']['input']>;
+  publisherAncestor?: InputMaybe<Scalars['ID']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
   start?: InputMaybe<Scalars['String']['input']>;
   startsAfter?: InputMaybe<Scalars['String']['input']>;
@@ -13576,6 +13578,12 @@ export type SearchListQueryVariables = Exact<{
   ontologyWordIds?: InputMaybe<
     Array<Scalars['ID']['input']> | Scalars['ID']['input']
   >;
+  providerTypes?: InputMaybe<
+    Array<InputMaybe<ProviderType>> | InputMaybe<ProviderType>
+  >;
+  serviceOwnerTypes?: InputMaybe<
+    Array<InputMaybe<ServiceOwnerType>> | InputMaybe<ServiceOwnerType>
+  >;
   targetGroups?: InputMaybe<
     Array<InputMaybe<TargetGroup>> | InputMaybe<TargetGroup>
   >;
@@ -13686,6 +13694,17 @@ export type SearchListQuery = {
               en?: string | null;
             } | null;
           } | null> | null;
+          serviceOwner?: {
+            __typename?: 'ServiceOwner';
+            providerType?: ProviderType | null;
+            type?: ServiceOwnerType | null;
+            name?: {
+              __typename?: 'LanguageString';
+              fi?: string | null;
+              sv?: string | null;
+              en?: string | null;
+            } | null;
+          } | null;
         } | null;
       };
     }>;
@@ -13702,6 +13721,12 @@ export type SearchMapQueryVariables = Exact<{
   >;
   ontologyTreeIds?: InputMaybe<
     Array<Scalars['ID']['input']> | Scalars['ID']['input']
+  >;
+  providerTypes?: InputMaybe<
+    Array<InputMaybe<ProviderType>> | InputMaybe<ProviderType>
+  >;
+  serviceOwnerTypes?: InputMaybe<
+    Array<InputMaybe<ServiceOwnerType>> | InputMaybe<ServiceOwnerType>
   >;
   targetGroups?: InputMaybe<
     Array<InputMaybe<TargetGroup>> | InputMaybe<TargetGroup>
@@ -14212,6 +14237,7 @@ export const EventListDocument = gql`
     $page: Int
     $pageSize: Int
     $publisher: ID
+    $publisherAncestor: ID
     $sort: String
     $start: String
     $startsAfter: String
@@ -14248,6 +14274,7 @@ export const EventListDocument = gql`
       page: $page
       pageSize: $pageSize
       publisher: $publisher
+      publisherAncestor: $publisherAncestor
       sort: $sort
       start: $start
       startsAfter: $startsAfter
@@ -14308,6 +14335,7 @@ export const EventListDocument = gql`
  *      page: // value for 'page'
  *      pageSize: // value for 'pageSize'
  *      publisher: // value for 'publisher'
+ *      publisherAncestor: // value for 'publisherAncestor'
  *      sort: // value for 'sort'
  *      start: // value for 'start'
  *      startsAfter: // value for 'startsAfter'
@@ -15121,6 +15149,8 @@ export const SearchListDocument = gql`
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
     $ontologyWordIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -15136,6 +15166,8 @@ export const SearchListDocument = gql`
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
       ontologyWordIds: $ontologyWordIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -15210,6 +15242,15 @@ export const SearchListDocument = gql`
                 en
               }
             }
+            serviceOwner {
+              name {
+                fi
+                sv
+                en
+              }
+              providerType
+              type
+            }
             targetGroups
           }
         }
@@ -15237,6 +15278,8 @@ export const SearchListDocument = gql`
  *      administrativeDivisionIds: // value for 'administrativeDivisionIds'
  *      ontologyTreeIds: // value for 'ontologyTreeIds'
  *      ontologyWordIds: // value for 'ontologyWordIds'
+ *      providerTypes: // value for 'providerTypes'
+ *      serviceOwnerTypes: // value for 'serviceOwnerTypes'
  *      targetGroups: // value for 'targetGroups'
  *      openAt: // value for 'openAt'
  *      orderByDistance: // value for 'orderByDistance'
@@ -15285,6 +15328,8 @@ export const SearchMapDocument = gql`
     $language: UnifiedSearchLanguage!
     $administrativeDivisionIds: [ID!]
     $ontologyTreeIds: [ID!]
+    $providerTypes: [ProviderType]
+    $serviceOwnerTypes: [ServiceOwnerType]
     $targetGroups: [TargetGroup]
     $openAt: String
     $orderByDistance: OrderByDistance
@@ -15298,6 +15343,8 @@ export const SearchMapDocument = gql`
       languages: [$language]
       administrativeDivisionIds: $administrativeDivisionIds
       ontologyTreeIds: $ontologyTreeIds
+      providerTypes: $providerTypes
+      serviceOwnerTypes: $serviceOwnerTypes
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -15347,6 +15394,8 @@ export const SearchMapDocument = gql`
  *      language: // value for 'language'
  *      administrativeDivisionIds: // value for 'administrativeDivisionIds'
  *      ontologyTreeIds: // value for 'ontologyTreeIds'
+ *      providerTypes: // value for 'providerTypes'
+ *      serviceOwnerTypes: // value for 'serviceOwnerTypes'
  *      targetGroups: // value for 'targetGroups'
  *      openAt: // value for 'openAt'
  *      orderByDistance: // value for 'orderByDistance'

--- a/proxies/events-graphql-federation/subgraphs/cms/cms.graphql
+++ b/proxies/events-graphql-federation/subgraphs/cms/cms.graphql
@@ -11,77 +11,74 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToCategoryConnectionWhereArgs
   ): RootQueryToCategoryConnection
   "A 0bject"
   category(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
     idType: CategoryIdType
   ): Category
   "An object of the collection Type. Collections"
   collection(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: CollectionIdType
+    idType: CollectionIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): Collection
   "A collection object"
   collectionBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the collection by its database ID"
-    collectionId: Int
+    collectionId: Int,
     "Get the collection by its uri"
-    uri: String
+    uri: String,
     "Get the collection by its slug (only available for non-hierarchical types)"
     slug: String
-  ): Collection
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Collection @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "Connection between the RootQuery type and the collection type"
   collections(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToCollectionConnectionWhereArgs
   ): RootQueryToCollectionConnection
   "Returns a Comment"
   comment(
     "Unique identifier for the comment node."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a comment by. Default is Global ID"
     idType: CommentNodeIdTypeEnum
   ): Comment
@@ -90,76 +87,73 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToCommentConnectionWhereArgs
   ): RootQueryToCommentConnection
   "An object of the contact Type. Contacts"
   contact(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: ContactIdType
+    idType: ContactIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): Contact
   "A contact object"
   contactBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the contact by its database ID"
-    contactId: Int
+    contactId: Int,
     "Get the contact by its uri"
-    uri: String
+    uri: String,
     "Get the contact by its slug (only available for non-hierarchical types)"
     slug: String
-  ): Contact
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Contact @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "Connection between the RootQuery type and the contact type"
   contacts(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToContactConnectionWhereArgs
   ): RootQueryToContactConnection
   "A node used to manage content"
   contentNode(
     "Unique identifier for the content node."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a content node by. Default is Global ID"
-    idType: ContentNodeIdTypeEnum
+    idType: ContentNodeIdTypeEnum,
     """
     The content type the node is used for. Required when idType is set to "name" or "slug"
     """
-    contentType: ContentTypeEnum
+    contentType: ContentTypeEnum,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): ContentNode
@@ -168,26 +162,26 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToContentNodeConnectionWhereArgs
   ): RootQueryToContentNodeConnection
   "Fetch a Content Type node by unique Identifier"
   contentType(
     "Unique Identifier for the Content Type node."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a content type by. Default is Global ID"
     idType: ContentTypeIdTypeEnum
   ): ContentType
@@ -196,15 +190,15 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -221,44 +215,41 @@ type RootQuery {
   "An object of the landingPage Type. Landing Pages"
   landingPage(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: LandingPageIdType
+    idType: LandingPageIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): LandingPage
   "A landingPage object"
   landingPageBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the landingPage by its database ID"
-    landingPageId: Int
+    landingPageId: Int,
     "Get the landingPage by its uri"
-    uri: String
+    uri: String,
     "Get the landingPage by its slug (only available for non-hierarchical types)"
     slug: String
-  ): LandingPage
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): LandingPage @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "Connection between the RootQuery type and the landingPage type"
   landingPages(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToLandingPageConnectionWhereArgs
   ): RootQueryToLandingPageConnection
@@ -267,58 +258,55 @@ type RootQuery {
   "An object of the mediaItem Type. "
   mediaItem(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: MediaItemIdType
+    idType: MediaItemIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): MediaItem
   "A mediaItem object"
   mediaItemBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the mediaItem by its database ID"
-    mediaItemId: Int
+    mediaItemId: Int,
     "Get the mediaItem by its uri"
-    uri: String
+    uri: String,
     "Get the mediaItem by its slug (only available for non-hierarchical types)"
     slug: String
-  ): MediaItem
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): MediaItem @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "Connection between the RootQuery type and the mediaItem type"
   mediaItems(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToMediaItemConnectionWhereArgs
   ): RootQueryToMediaItemConnection
   "A WordPress navigation menu"
   menu(
     "The globally unique identifier of the menu."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a menu by. Default is Global ID"
     idType: MenuNodeIdTypeEnum
   ): Menu
   "A WordPress navigation menu item"
   menuItem(
     "The globally unique identifier of the menu item."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a menu item by. Default is Global ID"
     idType: MenuItemNodeIdTypeEnum
   ): MenuItem
@@ -327,19 +315,19 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToMenuItemConnectionWhereArgs
   ): RootQueryToMenuItemConnection
@@ -348,24 +336,27 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToMenuConnectionWhereArgs
   ): RootQueryToMenuConnection
   "Fetches an object given its ID"
-  node("The unique identifier of the node" id: ID): Node
+  node(
+    "The unique identifier of the node"
+    id: ID
+  ): Node
   "Fetches an object given its Unique Resource Identifier"
   nodeByUri(
     """
@@ -378,24 +369,21 @@ type RootQuery {
   "An object of the page Type. "
   page(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: PageIdType
+    idType: PageIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): Page
   "A page object"
   pageBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the page by its database ID"
-    pageId: Int
+    pageId: Int,
     "Get the page by its uri"
     uri: String
-  ): Page
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Page @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "Returns ID of page that uses the given template"
   pageByTemplate(language: String, template: TemplateEnum): Page
   "Connection between the RootQuery type and the page type"
@@ -403,72 +391,72 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToPageConnectionWhereArgs
   ): RootQueryToPageConnection
   "A WordPress plugin"
-  plugin("The globally unique identifier of the plugin." id: ID!): Plugin
+  plugin(
+    "The globally unique identifier of the plugin."
+    id: ID!
+  ): Plugin
   "Connection between the RootQuery type and the Plugin type"
   plugins(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToPluginConnectionWhereArgs
   ): RootQueryToPluginConnection
   "An object of the post Type. "
   post(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: PostIdType
+    idType: PostIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): Post
   "A post object"
   postBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the post by its database ID"
-    postId: Int
+    postId: Int,
     "Get the post by its uri"
-    uri: String
+    uri: String,
     "Get the post by its slug (only available for non-hierarchical types)"
     slug: String
-  ): Post
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Post @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "A 0bject"
   postFormat(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
     idType: PostFormatIdType
   ): PostFormat
@@ -477,19 +465,19 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToPostFormatConnectionWhereArgs
   ): RootQueryToPostFormatConnection
@@ -498,19 +486,19 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToPostConnectionWhereArgs
   ): RootQueryToPostConnection
@@ -521,15 +509,15 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -540,15 +528,15 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -557,44 +545,41 @@ type RootQuery {
   "An object of the release Type. Releases"
   release(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: ReleaseIdType
+    idType: ReleaseIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): Release
   "A release object"
   releaseBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the release by its database ID"
-    releaseId: Int
+    releaseId: Int,
     "Get the release by its uri"
-    uri: String
+    uri: String,
     "Get the release by its slug (only available for non-hierarchical types)"
     slug: String
-  ): Release
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Release @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "Connection between the RootQuery type and the release type"
   releases(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToReleaseConnectionWhereArgs
   ): RootQueryToReleaseConnection
@@ -603,19 +588,19 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToRevisionsConnectionWhereArgs
   ): RootQueryToRevisionsConnection
@@ -626,7 +611,7 @@ type RootQuery {
   "A 0bject"
   tag(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
     idType: TagIdType
   ): Tag
@@ -635,19 +620,19 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToTagConnectionWhereArgs
   ): RootQueryToTagConnection
@@ -656,15 +641,15 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -673,16 +658,16 @@ type RootQuery {
   "Fetch a Taxonomy node by unique Identifier"
   taxonomy(
     "Unique Identifier for the Taxonomy node."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a taxonomy by. Default is Global ID"
     idType: TaxonomyIdTypeEnum
   ): Taxonomy
   "A node in a taxonomy used to group and relate content nodes"
   termNode(
     "Unique identifier for the term node."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a term node by. Default is Global ID"
-    idType: TermNodeIdTypeEnum
+    idType: TermNodeIdTypeEnum,
     """
     The taxonomy of the tern node. Required when idType is set to "name" or "slug"
     """
@@ -693,38 +678,41 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToTermNodeConnectionWhereArgs
   ): RootQueryToTermNodeConnection
   "A Theme object"
-  theme("The globally unique identifier of the theme." id: ID!): Theme
+  theme(
+    "The globally unique identifier of the theme."
+    id: ID!
+  ): Theme
   "Connection between the RootQuery type and the Theme type"
   themes(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -735,51 +723,48 @@ type RootQuery {
   "An object of the translation Type. Translations"
   translation(
     "The globally unique identifier of the object."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch by. Default is Global ID"
-    idType: TranslationIdType
+    idType: TranslationIdType,
     "Whether to return the node as a preview instance"
     asPreview: Boolean
   ): Translation
   "A translation object"
   translationBy(
     "Get the object by its global ID"
-    id: ID
+    id: ID,
     "Get the translation by its database ID"
-    translationId: Int
+    translationId: Int,
     "Get the translation by its uri"
-    uri: String
+    uri: String,
     "Get the translation by its slug (only available for non-hierarchical types)"
     slug: String
-  ): Translation
-    @deprecated(
-      reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)"
-    )
+  ): Translation @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
   "Connection between the RootQuery type and the translation type"
   translations(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToTranslationConnectionWhereArgs
   ): RootQueryToTranslationConnection
   "Returns a user"
   user(
     "The globally unique identifier of the user."
-    id: ID!
+    id: ID!,
     "Type of unique identifier to fetch a user by. Default is Global ID"
     idType: UserNodeIdTypeEnum
   ): User
@@ -793,15 +778,15 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -812,19 +797,19 @@ type RootQuery {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: RootQueryToUserConnectionWhereArgs
   ): RootQueryToUserConnection
@@ -884,15 +869,15 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -905,19 +890,19 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: CategoryToCategoryConnectionWhereArgs
   ): CategoryToCategoryConnection
@@ -926,19 +911,19 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: CategoryToContentNodeConnectionWhereArgs
   ): CategoryToContentNodeConnection
@@ -953,15 +938,15 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -972,15 +957,15 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -1011,19 +996,19 @@ type Category implements Node & TermNode & UniformResourceIdentifiable & Databas
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: CategoryToPostConnectionWhereArgs
   ): CategoryToPostConnection
@@ -1178,15 +1163,15 @@ type ContentType implements Node & UniformResourceIdentifiable {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -1197,19 +1182,19 @@ type ContentType implements Node & UniformResourceIdentifiable {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: ContentTypeToContentNodeConnectionWhereArgs
   ): ContentTypeToContentNodeConnection
@@ -1288,15 +1273,15 @@ type Taxonomy implements Node {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -1447,9 +1432,9 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
   "Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument."
   avatar(
     "The size attribute of the avatar field can be used to fetch avatars of different sizes. The value corresponds to the dimension in pixels to fetch. The default is 96 pixels."
-    size: Int = 96
+    size: Int = 96,
     "Whether to always show the default image, never the Gravatar. Default false"
-    forceDefault: Boolean
+    forceDefault: Boolean,
     "The rating level of the avatar."
     rating: AvatarRatingEnum
   ): Avatar
@@ -1462,19 +1447,19 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: UserToCommentConnectionWhereArgs
   ): UserToCommentConnection
@@ -1489,15 +1474,15 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -1508,15 +1493,15 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -1543,19 +1528,19 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: UserToMediaItemConnectionWhereArgs
   ): UserToMediaItemConnection
@@ -1570,19 +1555,19 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: UserToPageConnectionWhereArgs
   ): UserToPageConnection
@@ -1591,19 +1576,19 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: UserToPostConnectionWhereArgs
   ): UserToPostConnection
@@ -1614,19 +1599,19 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: UserToRevisionsConnectionWhereArgs
   ): UserToRevisionsConnection
@@ -1635,15 +1620,15 @@ type User implements Node & UniformResourceIdentifiable & Commenter & DatabaseId
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -1699,8 +1684,7 @@ type Comment implements Node & DatabaseIdentifier {
   "User agent used to post the comment. This field is equivalent to WP_Comment-&gt;comment_agent and the value matching the &quot;comment_agent&quot; column in SQL."
   agent: String
   "The approval status of the comment. This field is equivalent to WP_Comment-&gt;comment_approved and the value matching the &quot;comment_approved&quot; column in SQL."
-  approved: Boolean
-    @deprecated(reason: "Deprecated in favor of the `status` field")
+  approved: Boolean @deprecated(reason: "Deprecated in favor of the `status` field")
   "The author of the comment"
   author: CommentToCommenterConnectionEdge
   "IP address for the author. This field is equivalent to WP_Comment-&gt;comment_author_IP and the value matching the &quot;comment_author_IP&quot; column in SQL."
@@ -1740,19 +1724,19 @@ type Comment implements Node & DatabaseIdentifier {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: CommentToCommentConnectionWhereArgs
   ): CommentToCommentConnection
@@ -1855,19 +1839,19 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeAncestorsConnection
@@ -1887,19 +1871,19 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeChildrenConnection
@@ -1929,15 +1913,15 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -1948,22 +1932,25 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
     before: String
   ): ContentNodeToEnqueuedStylesheetConnection
   "The filesize in bytes of the resource"
-  fileSize("Size of the MediaItem to return" size: MediaItemSizeEnum): Int
+  fileSize(
+    "Size of the MediaItem to return"
+    size: MediaItemSizeEnum
+  ): Int
   "The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table."
   guid: String
   "The globally unique identifier of the attachment object."
@@ -1985,8 +1972,7 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   "Details about the mediaItem"
   mediaDetails: MediaDetails
   "The id field matches the WP_Post-&gt;ID field."
-  mediaItemId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  mediaItemId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "Url of the mediaItem"
   mediaItemUrl: String
   "Type of resource"
@@ -2019,7 +2005,10 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   "The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table."
   slug: String
   "Url of the mediaItem"
-  sourceUrl("Size of the MediaItem to return" size: MediaItemSizeEnum): String
+  sourceUrl(
+    "Size of the MediaItem to return"
+    size: MediaItemSizeEnum
+  ): String
   "The srcset attribute specifies the URL of the image to use in different situations. It is a comma separated string of urls and their widths."
   srcSet(
     "Size of the MediaItem to calculate srcSet with"
@@ -2030,7 +2019,10 @@ type MediaItem implements Node & ContentNode & UniformResourceIdentifiable & Dat
   "The template assigned to a node of content"
   template: ContentTemplate
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "Get specific translation version of this object"
   translation(language: LanguageCodeEnum!): MediaItem
   "List all translated versions of this post"
@@ -2149,7 +2141,7 @@ type MediaDetails {
   "The available sizes of the mediaItem"
   sizes(
     "The sizes to exclude. Will take precedence over `include`."
-    exclude: [MediaItemSizeEnum]
+    exclude: [MediaItemSizeEnum],
     "The sizes to include. Can be overridden by `exclude`."
     include: [MediaItemSizeEnum]
   ): [MediaSize]
@@ -2258,19 +2250,19 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeAncestorsConnection
@@ -2285,19 +2277,19 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeChildrenConnection
@@ -2327,15 +2319,15 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -2346,15 +2338,15 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -2407,8 +2399,7 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   "List of modules"
   modules: [PageModulesUnionType]
   "The id field matches the WP_Post-&gt;ID field."
-  pageId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  pageId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "The parent of the node. The parent object can be of various types"
   parent: HierarchicalContentNodeToParentContentNodeConnectionEdge
   "Database id of the parent node"
@@ -2428,19 +2419,19 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PageToRevisionConnectionWhereArgs
   ): PageToRevisionConnection
@@ -2457,7 +2448,10 @@ type Page implements Node & ContentNode & UniformResourceIdentifiable & Database
   "The template assigned to a node of content"
   template: ContentTemplate
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "Get specific translation version of this object"
   translation(language: LanguageCodeEnum!): Page
   "List all translated versions of this post"
@@ -2515,6 +2509,7 @@ type EventSearch {
   Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
                   hakutulosten osoite -link and search params of the module, for example:
                   https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
+
   """
   showAllLink: String
   "Show all -link"
@@ -2555,6 +2550,7 @@ type EventSearchCarousel {
   Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
                                       hakutulosten osoite -link and search params of the module, for example:
                                       https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
+
   """
   showAllLink: String
   "Show all -link"
@@ -2615,8 +2611,7 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   "Background Color"
   backgroundColor: String
   "The id field matches the WP_Post-&gt;ID field."
-  collectionId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  collectionId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "Connection between the ContentNode type and the ContentType type"
   contentType: ContentNodeToContentTypeConnectionEdge
   "The name of the Content Type the node belongs to"
@@ -2640,15 +2635,15 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -2659,15 +2654,15 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -2716,19 +2711,19 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: CollectionToRevisionConnectionWhereArgs
   ): CollectionToRevisionConnection
@@ -2743,7 +2738,10 @@ type Collection implements Node & ContentNode & UniformResourceIdentifiable & Da
   "The template assigned to the node"
   template: ContentTemplate
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "Get specific translation version of this object"
   translation(language: LanguageCodeEnum!): Collection
   "List all translated versions of this post"
@@ -2786,8 +2784,7 @@ type LayoutContact {
 "The contact type"
 type Contact implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & Previewable & NodeWithTitle & NodeWithFeaturedImage & NodeWithRevisions {
   "The id field matches the WP_Post-&gt;ID field."
-  contactId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  contactId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "Connection between the ContentNode type and the ContentType type"
   contentType: ContentNodeToContentTypeConnectionEdge
   "The name of the Content Type the node belongs to"
@@ -2811,15 +2808,15 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -2830,15 +2827,15 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -2893,19 +2890,19 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: ContactToRevisionConnectionWhereArgs
   ): ContactToRevisionConnection
@@ -2918,7 +2915,10 @@ type Contact implements Node & ContentNode & UniformResourceIdentifiable & Datab
   "The template assigned to the node"
   template: ContentTemplate
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "Get specific translation version of this object"
   translation(language: LanguageCodeEnum!): Contact
   "List all translated versions of this post"
@@ -2981,19 +2981,19 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PostToCategoryConnectionWhereArgs
   ): PostToCategoryConnection
@@ -3023,15 +3023,15 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -3042,15 +3042,15 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -3101,25 +3101,24 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PostToPostFormatConnectionWhereArgs
   ): PostToPostFormatConnection
   "The id field matches the WP_Post-&gt;ID field."
-  postId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  postId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "Connection between the Post type and the post type"
   preview: PostToPreviewConnectionEdge
   "The database id of the preview node"
@@ -3133,19 +3132,19 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PostToRevisionConnectionWhereArgs
   ): PostToRevisionConnection
@@ -3162,19 +3161,19 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PostToTagConnectionWhereArgs
   ): PostToTagConnection
@@ -3185,24 +3184,27 @@ type Post implements Node & ContentNode & UniformResourceIdentifiable & Database
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PostToTermNodeConnectionWhereArgs
   ): PostToTermNodeConnection
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "Get specific translation version of this object"
   translation(language: LanguageCodeEnum!): Post
   "List all translated versions of this post"
@@ -3321,6 +3323,100 @@ type Card {
   "Title"
   title: String
 }
+"Layout: LayoutImage"
+type LayoutImage {
+  "Border"
+  border: Boolean
+  "Image"
+  image: Image
+  "Photographer name (overwrite)"
+  photographer_name: String
+  "Lightbox"
+  show_on_lightbox: Boolean
+}
+"Image"
+type Image {
+  "Caption of the image"
+  caption: String
+  "Description of the image"
+  description: String
+  "The url of the large image"
+  large: String
+  "The url of the medium image"
+  medium: String
+  "The url of the medium large image"
+  medium_large: String
+  "The url of the thumbnail image"
+  thumbnail: String
+  "Title of the image"
+  title: String
+}
+"Layout: LayoutCard"
+type LayoutCard {
+  "Alignment"
+  alignment: String
+  "Background Color"
+  backgroundColor: String
+  "Description"
+  description: String
+  "Image"
+  image: Image
+  "Link"
+  link: Link
+  "Title"
+  title: String
+}
+"Layout: LayoutImageGallery"
+type LayoutImageGallery {
+  "Gallery"
+  gallery: [GalleryImage]
+}
+"Gallery Image"
+type GalleryImage {
+  "Caption of the image"
+  caption: String
+  "Description of the image"
+  description: String
+  "The url of the large image"
+  large: String
+  "The url of the medium image"
+  medium: String
+  "The url of the medium large image"
+  medium_large: String
+  "The url of the thumbnail image"
+  thumbnail: String
+  "Title of the image"
+  title: String
+}
+"Layout: LayoutSteps"
+type LayoutSteps {
+  "Color"
+  color: String
+  "Description"
+  description: String
+  "Steps"
+  steps: [Step]
+  "Title"
+  title: String
+  "Type"
+  type: String
+}
+"Step field"
+type Step {
+  "The content of the step"
+  content: String
+  "The title of the step"
+  title: String
+}
+"Layout: LayoutSocialMediaFeed"
+type LayoutSocialMediaFeed {
+  "Anchor"
+  anchor: String
+  "Script"
+  script: String
+  "Title"
+  title: String
+}
 "Connection between the Post type and the postFormat type"
 type PostToPostFormatConnection implements PostFormatConnection & Connection {
   "Edges for the PostToPostFormatConnection connection"
@@ -3337,19 +3433,19 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PostFormatToContentNodeConnectionWhereArgs
   ): PostFormatToContentNodeConnection
@@ -3364,15 +3460,15 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -3383,15 +3479,15 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -3416,19 +3512,19 @@ type PostFormat implements Node & TermNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: PostFormatToPostConnectionWhereArgs
   ): PostFormatToPostConnection
@@ -3543,19 +3639,19 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: TagToContentNodeConnectionWhereArgs
   ): TagToContentNodeConnection
@@ -3570,15 +3666,15 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -3589,15 +3685,15 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -3622,19 +3718,19 @@ type Tag implements Node & TermNode & UniformResourceIdentifiable & DatabaseIden
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: TagToPostConnectionWhereArgs
   ): TagToPostConnection
@@ -3996,19 +4092,19 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: LandingPageToMediaItemConnectionWhereArgs
   ): LandingPageToMediaItemConnection
@@ -4021,15 +4117,15 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -4040,15 +4136,15 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -4059,19 +4155,19 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: LandingPageToFloatImageConnectionWhereArgs
   ): LandingPageToFloatImageConnection
@@ -4092,8 +4188,7 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   "Whether the node is a Term"
   isTermNode: Boolean!
   "The id field matches the WP_Post-&gt;ID field."
-  landingPageId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  landingPageId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "Polylang language"
   language: Language
   "The user that most recently edited the node"
@@ -4105,19 +4200,19 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: LandingPageToMobileImageConnectionWhereArgs
   ): LandingPageToMobileImageConnection
@@ -4140,19 +4235,19 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: LandingPageToRevisionConnectionWhereArgs
   ): LandingPageToRevisionConnection
@@ -4165,7 +4260,10 @@ type LandingPage implements Node & ContentNode & UniformResourceIdentifiable & D
   "The template assigned to the node"
   template: ContentTemplate
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "Get specific translation version of this object"
   translation(language: LanguageCodeEnum!): LandingPage
   "List all translated versions of this post"
@@ -4295,19 +4393,19 @@ type Menu implements Node & DatabaseIdentifier {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: MenuToMenuItemConnectionWhereArgs
   ): MenuToMenuItemConnection
@@ -4332,27 +4430,26 @@ type MenuItem implements Node & DatabaseIdentifier {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: MenuItemToMenuItemConnectionWhereArgs
   ): MenuItemToMenuItemConnection
   "Connection from MenuItem to it&#039;s connected node"
   connectedNode: MenuItemToMenuItemLinkableConnectionEdge
   "The object connected to this menu item."
-  connectedObject: MenuItemObjectUnion
-    @deprecated(reason: "Deprecated in favor of the connectedNode field")
+  connectedObject: MenuItemObjectUnion @deprecated(reason: "Deprecated in favor of the connectedNode field")
   "Class attribute for the menu item link"
   cssClasses: [String]
   "The unique identifier stored in the database"
@@ -4372,8 +4469,7 @@ type MenuItem implements Node & DatabaseIdentifier {
   "The Menu a MenuItem is part of"
   menu: MenuItemToMenuConnectionEdge
   "WP ID of the menu item."
-  menuItemId: Int
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  menuItemId: Int @deprecated(reason: "Deprecated in favor of the databaseId field")
   "Menu item order"
   order: Int
   "The database id of the parent menu item or null if it is the root"
@@ -4633,15 +4729,15 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -4652,15 +4748,15 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -4699,8 +4795,7 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   "Whether the object is a node in the preview state"
   previewRevisionId: ID
   "The id field matches the WP_Post-&gt;ID field."
-  releaseId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  releaseId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node."
   revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
   "Connection between the Release type and the release type"
@@ -4708,19 +4803,19 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: ReleaseToRevisionConnectionWhereArgs
   ): ReleaseToRevisionConnection
@@ -4733,7 +4828,10 @@ type Release implements Node & ContentNode & UniformResourceIdentifiable & Datab
   "The template assigned to the node"
   template: ContentTemplate
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "Get specific translation version of this object"
   translation(language: LanguageCodeEnum!): Release
   "List all translated versions of this post"
@@ -4920,15 +5018,15 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -4939,15 +5037,15 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -4988,19 +5086,19 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: TranslationToRevisionConnectionWhereArgs
   ): TranslationToRevisionConnection
@@ -5013,10 +5111,12 @@ type Translation implements Node & ContentNode & UniformResourceIdentifiable & D
   "The template assigned to the node"
   template: ContentTemplate
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
   "The id field matches the WP_Post-&gt;ID field."
-  translationId: Int!
-    @deprecated(reason: "Deprecated in favor of the databaseId field")
+  translationId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
   "Translations"
   translations: [TranslationResponse]
   "The unique resource identifier path"
@@ -5251,7 +5351,10 @@ type RootMutation {
     input: DeleteUserInput!
   ): DeleteUserPayload
   "Increase the count."
-  increaseCount("The count to increase" count: Int): Int
+  increaseCount(
+    "The count to increase"
+    count: Int
+  ): Int
   "The registerUser mutation"
   registerUser(
     "Input for the registerUser mutation"
@@ -5583,10 +5686,7 @@ type SendPasswordResetEmailPayload {
   "Whether the mutation completed successfully. This does NOT necessarily mean that an email was sent."
   success: Boolean
   "The user that the password reset email was sent to"
-  user: User
-    @deprecated(
-      reason: "This field will be removed in a future version of WPGraphQL"
-    )
+  user: User @deprecated(reason: "This field will be removed in a future version of WPGraphQL")
 }
 "The payload for the updateCategory mutation."
 type UpdateCategoryPayload {
@@ -5701,9 +5801,9 @@ type CommentAuthor implements Node & Commenter & DatabaseIdentifier {
   "Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument."
   avatar(
     "The size attribute of the avatar field can be used to fetch avatars of different sizes. The value corresponds to the dimension in pixels to fetch. The default is 96 pixels."
-    size: Int = 96
+    size: Int = 96,
     "Whether to always show the default image, never the Gravatar. Default false"
-    forceDefault: Boolean
+    forceDefault: Boolean,
     "The rating level of the avatar."
     rating: AvatarRatingEnum
   ): Avatar
@@ -5759,7 +5859,7 @@ interface CategoryConnectionEdge implements Edge {
   node: Category!
 }
 "Terms are nodes within a Taxonomy, used to group and relate other nodes."
-interface TermNode implements Node & UniformResourceIdentifiable {
+interface TermNode implements Node& UniformResourceIdentifiable {
   "The number of objects connected to the object"
   count: Int
   "Identifies the primary key from the database."
@@ -5771,15 +5871,15 @@ interface TermNode implements Node & UniformResourceIdentifiable {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -5790,15 +5890,15 @@ interface TermNode implements Node & UniformResourceIdentifiable {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -5889,7 +5989,7 @@ interface DatabaseIdentifier {
   databaseId: Int!
 }
 "Term node with hierarchical (parent/child) relationships"
-interface HierarchicalTermNode implements Node & TermNode & UniformResourceIdentifiable & DatabaseIdentifier & HierarchicalNode {
+interface HierarchicalTermNode implements Node& TermNode& UniformResourceIdentifiable& DatabaseIdentifier& HierarchicalNode {
   "The number of objects connected to the object"
   count: Int
   "The unique identifier stored in the database"
@@ -5901,15 +6001,15 @@ interface HierarchicalTermNode implements Node & TermNode & UniformResourceIdent
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -5920,15 +6020,15 @@ interface HierarchicalTermNode implements Node & TermNode & UniformResourceIdent
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -5962,7 +6062,7 @@ interface HierarchicalTermNode implements Node & TermNode & UniformResourceIdent
   uri: String
 }
 "Node with hierarchical (parent/child) relationships"
-interface HierarchicalNode implements Node & DatabaseIdentifier {
+interface HierarchicalNode implements Node& DatabaseIdentifier {
   "The unique identifier stored in the database"
   databaseId: Int!
   "The globally unique ID for the object"
@@ -5973,7 +6073,7 @@ interface HierarchicalNode implements Node & DatabaseIdentifier {
   parentId: ID
 }
 "Nodes that can be linked to as Menu Items"
-interface MenuItemLinkable implements Node & UniformResourceIdentifiable & DatabaseIdentifier {
+interface MenuItemLinkable implements Node& UniformResourceIdentifiable& DatabaseIdentifier {
   "The unique identifier stored in the database"
   databaseId: Int!
   "The unique resource identifier path"
@@ -6000,7 +6100,7 @@ interface ContentNodeConnectionEdge implements Edge {
   node: ContentNode!
 }
 "Nodes used to manage content"
-interface ContentNode implements Node & UniformResourceIdentifiable {
+interface ContentNode implements Node& UniformResourceIdentifiable {
   "Connection between the ContentNode type and the ContentType type"
   contentType: ContentNodeToContentTypeConnectionEdge
   "The name of the Content Type the node belongs to"
@@ -6022,15 +6122,15 @@ interface ContentNode implements Node & UniformResourceIdentifiable {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -6041,15 +6141,15 @@ interface ContentNode implements Node & UniformResourceIdentifiable {
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -6131,7 +6231,7 @@ interface UserConnectionEdge implements Edge {
   node: User!
 }
 "The author of a comment"
-interface Commenter implements Node & DatabaseIdentifier {
+interface Commenter implements Node& DatabaseIdentifier {
   "Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument."
   avatar: Avatar
   "Identifies the primary key from the database."
@@ -6199,7 +6299,10 @@ interface NodeWithTitle implements Node {
   "The globally unique ID for the object"
   id: ID!
   "The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made."
-  title("Format of the field output" format: PostObjectFieldFormatEnum): String
+  title(
+    "Format of the field output"
+    format: PostObjectFieldFormatEnum
+  ): String
 }
 "A node that can have an author assigned to it"
 interface NodeWithAuthor implements Node {
@@ -6213,25 +6316,25 @@ interface NodeWithAuthor implements Node {
   id: ID!
 }
 "Content node with hierarchical (parent/child) relationships"
-interface HierarchicalContentNode implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & HierarchicalNode {
+interface HierarchicalContentNode implements Node& ContentNode& UniformResourceIdentifiable& DatabaseIdentifier& HierarchicalNode {
   "Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root)."
   ancestors(
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: HierarchicalContentNodeToContentNodeAncestorsConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeAncestorsConnection
@@ -6240,19 +6343,19 @@ interface HierarchicalContentNode implements Node & ContentNode & UniformResourc
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
-    before: String
+    before: String,
     "Arguments for filtering the connection"
     where: HierarchicalContentNodeToContentNodeChildrenConnectionWhereArgs
   ): HierarchicalContentNodeToContentNodeChildrenConnection
@@ -6277,15 +6380,15 @@ interface HierarchicalContentNode implements Node & ContentNode & UniformResourc
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -6296,15 +6399,15 @@ interface HierarchicalContentNode implements Node & ContentNode & UniformResourc
     """
     The number of items to return after the referenced "after" cursor
     """
-    first: Int
+    first: Int,
     """
     The number of items to return before the referenced "before" cursor
     """
-    last: Int
+    last: Int,
     """
     Cursor used along with the "first" argument to reference where in the dataset to get data
     """
-    after: String
+    after: String,
     """
     Cursor used along with the "last" argument to reference where in the dataset to get data
     """
@@ -6619,55 +6722,11 @@ interface UserConnection implements Connection {
   "A list of connected User Nodes"
   nodes: [User!]!
 }
-union PageModulesUnionType =
-    EventSearch
-  | EventSelected
-  | EventSearchCarousel
-  | EventSelectedCarousel
-  | LocationsSelected
-  | LocationsSelectedCarousel
-  | LayoutCollection
-  | LayoutContact
-  | LayoutArticles
-  | LayoutArticlesCarousel
-  | LayoutArticleHighlights
-  | LayoutPages
-  | LayoutPagesCarousel
-  | LayoutContent
-  | LayoutCards
-union CollectionModulesUnionType =
-    EventSearch
-  | EventSelected
-  | EventSearchCarousel
-  | EventSelectedCarousel
-  | LocationsSelected
-  | LocationsSelectedCarousel
-union PostModulesUnionType =
-    EventSearch
-  | EventSelected
-  | EventSearchCarousel
-  | EventSelectedCarousel
-  | LocationsSelected
-  | LocationsSelectedCarousel
-  | LayoutCollection
-  | LayoutContact
-  | LayoutArticles
-  | LayoutArticlesCarousel
-  | LayoutArticleHighlights
-  | LayoutPages
-  | LayoutPagesCarousel
-  | LayoutContent
-  | LayoutCards
-union PostSidebarUnionType =
-    LayoutLinkList
-  | LayoutArticles
-  | LayoutPages
-  | LayoutCards
-union PageSidebarUnionType =
-    LayoutLinkList
-  | LayoutArticles
-  | LayoutPages
-  | LayoutCards
+union PageModulesUnionType = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel | LayoutContent | LayoutCards | LayoutSocialMediaFeed | LayoutImage | LayoutCard | LayoutSteps | LayoutImageGallery
+union CollectionModulesUnionType = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel
+union PostModulesUnionType = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel | LayoutContent | LayoutCards | LayoutImage | LayoutCard | LayoutImageGallery | LayoutSteps | LayoutSocialMediaFeed
+union PostSidebarUnionType = LayoutLinkList | LayoutArticles | LayoutPages | LayoutCards
+union PageSidebarUnionType = LayoutLinkList | LayoutArticles | LayoutPages | LayoutCards
 "Deprecated in favor of MenuItemLinkeable Interface"
 union MenuItemObjectUnion = Post | Page | Category | Tag
 "Filter item by specific language, default language or list all languages"
@@ -7285,7 +7344,7 @@ enum UsersConnectionSearchColumnEnum {
   LOGIN
   "A URL-friendly name for the user. The default is the user's username."
   NICENAME
-  "The URL of the users website."
+  "The URL of the user's website."
   URL
 }
 "The status of the media item object."
@@ -10557,3 +10616,4 @@ input UpdateUserInput {
   "User's Yahoo IM account."
   yim: String
 }
+

--- a/proxies/events-graphql-federation/subgraphs/events/events.graphql
+++ b/proxies/events-graphql-federation/subgraphs/events/events.graphql
@@ -169,7 +169,7 @@ type EventDetails {
   dataSource: String
   publisher: ID
   subEvents: [InternalIdObject!]!
-  images: [Image!]!
+  images: [EventImage!]!
   inLanguage: [InLanguage!]!
   audience: [Audience!]!
   createdTime: String
@@ -231,7 +231,7 @@ type Offer {
   infoUrl: LocalizedObject
 }
 
-type Image {
+type EventImage {
   id: ID
   license: String
   createdTime: String
@@ -263,7 +263,7 @@ type Keyword
   aggregate: Boolean
   deprecated: Boolean
   nEvents: Int
-  image: Image
+  image: EventImage
   dataSource: String
   publisher: ID
   name: LocalizedObject
@@ -321,7 +321,7 @@ type Place {
   addressCountry: String
   deleted: Boolean
   nEvents: Int
-  image: Image
+  image: EventImage
   dataSource: String
   publisher: ID
   parent: ID

--- a/proxies/events-graphql-federation/supergraph.graphql
+++ b/proxies/events-graphql-federation/supergraph.graphql
@@ -4421,7 +4421,7 @@ type EventDetails
   dataSource: String
   publisher: ID
   subEvents: [InternalIdObject!]!
-  images: [Image!]!
+  images: [EventImage!]!
   inLanguage: [InLanguage!]!
   audience: [Audience!]!
   createdTime: String
@@ -4448,6 +4448,24 @@ type EventDetails
   maximumAttendeeCapacity: Int
   minimumAttendeeCapacity: Int
   remainingAttendeeCapacity: Int
+}
+
+type EventImage
+  @join__type(graph: EVENTS)
+{
+  id: ID
+  license: String
+  createdTime: String
+  lastModifiedTime: String
+  name: String!
+  url: String!
+  cropping: String
+  photographerName: String
+  dataSource: String
+  publisher: String
+  internalId: String!
+  internalContext: String
+  internalType: String
 }
 
 type EventListResponse
@@ -4632,6 +4650,32 @@ type ExternalLink
   name: String
   link: String
   language: String
+}
+
+"""Gallery Image"""
+type GalleryImage
+  @join__type(graph: CMS)
+{
+  """Caption of the image"""
+  caption: String
+
+  """Description of the image"""
+  description: String
+
+  """The url of the large image"""
+  large: String
+
+  """The url of the medium image"""
+  medium: String
+
+  """The url of the medium large image"""
+  medium_large: String
+
+  """The url of the thumbnail image"""
+  thumbnail: String
+
+  """Title of the image"""
+  title: String
 }
 
 """The general setting type"""
@@ -5425,22 +5469,30 @@ enum IdentificationStrength
   LEGALLY_CONNECTED @join__enumValue(graph: UNIFIED_SEARCH)
 }
 
+"""Image"""
 type Image
-  @join__type(graph: EVENTS)
+  @join__type(graph: CMS)
 {
-  id: ID
-  license: String
-  createdTime: String
-  lastModifiedTime: String
-  name: String!
-  url: String!
-  cropping: String
-  photographerName: String
-  dataSource: String
-  publisher: String
-  internalId: String!
-  internalContext: String
-  internalType: String
+  """Caption of the image"""
+  caption: String
+
+  """Description of the image"""
+  description: String
+
+  """The url of the large image"""
+  large: String
+
+  """The url of the medium image"""
+  medium: String
+
+  """The url of the medium large image"""
+  medium_large: String
+
+  """The url of the thumbnail image"""
+  thumbnail: String
+
+  """Title of the image"""
+  title: String
 }
 
 type InLanguage
@@ -5484,7 +5536,7 @@ type Keyword
   aggregate: Boolean
   deprecated: Boolean
   nEvents: Int
-  image: Image
+  image: EventImage
   dataSource: String
   publisher: ID
   name: LocalizedObject
@@ -6362,6 +6414,29 @@ type LayoutArticlesCarousel
   title: String
 }
 
+"""Layout: LayoutCard"""
+type LayoutCard
+  @join__type(graph: CMS)
+{
+  """Alignment"""
+  alignment: String
+
+  """Background Color"""
+  backgroundColor: String
+
+  """Description"""
+  description: String
+
+  """Image"""
+  image: Image
+
+  """Link"""
+  link: Link
+
+  """Title"""
+  title: String
+}
+
 """Layout: LayoutCards"""
 type LayoutCards
   @join__type(graph: CMS)
@@ -6404,6 +6479,31 @@ type LayoutContent
 
   """Title"""
   title: String
+}
+
+"""Layout: LayoutImage"""
+type LayoutImage
+  @join__type(graph: CMS)
+{
+  """Border"""
+  border: Boolean
+
+  """Image"""
+  image: Image
+
+  """Photographer name (overwrite)"""
+  photographer_name: String
+
+  """Lightbox"""
+  show_on_lightbox: Boolean
+}
+
+"""Layout: LayoutImageGallery"""
+type LayoutImageGallery
+  @join__type(graph: CMS)
+{
+  """Gallery"""
+  gallery: [GalleryImage]
 }
 
 """Layout: LayoutLinkList"""
@@ -6467,6 +6567,40 @@ type LayoutPagesCarousel
 
   """Title"""
   title: String
+}
+
+"""Layout: LayoutSocialMediaFeed"""
+type LayoutSocialMediaFeed
+  @join__type(graph: CMS)
+{
+  """Anchor"""
+  anchor: String
+
+  """Script"""
+  script: String
+
+  """Title"""
+  title: String
+}
+
+"""Layout: LayoutSteps"""
+type LayoutSteps
+  @join__type(graph: CMS)
+{
+  """Color"""
+  color: String
+
+  """Description"""
+  description: String
+
+  """Steps"""
+  steps: [Step]
+
+  """Title"""
+  title: String
+
+  """Type"""
+  type: String
 }
 
 union LegalEntity
@@ -8696,7 +8830,12 @@ union PageModulesUnionType
   @join__unionMember(graph: CMS, member: "LayoutPagesCarousel")
   @join__unionMember(graph: CMS, member: "LayoutContent")
   @join__unionMember(graph: CMS, member: "LayoutCards")
- = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel | LayoutContent | LayoutCards
+  @join__unionMember(graph: CMS, member: "LayoutSocialMediaFeed")
+  @join__unionMember(graph: CMS, member: "LayoutImage")
+  @join__unionMember(graph: CMS, member: "LayoutCard")
+  @join__unionMember(graph: CMS, member: "LayoutSteps")
+  @join__unionMember(graph: CMS, member: "LayoutImageGallery")
+ = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel | LayoutContent | LayoutCards | LayoutSocialMediaFeed | LayoutImage | LayoutCard | LayoutSteps | LayoutImageGallery
 
 union PageSidebarUnionType
   @join__type(graph: CMS)
@@ -8915,7 +9054,7 @@ type Place
   addressCountry: String
   deleted: Boolean
   nEvents: Int
-  image: Image
+  image: EventImage
   dataSource: String
   publisher: ID
   parent: ID
@@ -9919,7 +10058,12 @@ union PostModulesUnionType
   @join__unionMember(graph: CMS, member: "LayoutPagesCarousel")
   @join__unionMember(graph: CMS, member: "LayoutContent")
   @join__unionMember(graph: CMS, member: "LayoutCards")
- = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel | LayoutContent | LayoutCards
+  @join__unionMember(graph: CMS, member: "LayoutImage")
+  @join__unionMember(graph: CMS, member: "LayoutCard")
+  @join__unionMember(graph: CMS, member: "LayoutImageGallery")
+  @join__unionMember(graph: CMS, member: "LayoutSteps")
+  @join__unionMember(graph: CMS, member: "LayoutSocialMediaFeed")
+ = EventSearch | EventSelected | EventSearchCarousel | EventSelectedCarousel | LocationsSelected | LocationsSelectedCarousel | LayoutCollection | LayoutContact | LayoutArticles | LayoutArticlesCarousel | LayoutArticleHighlights | LayoutPages | LayoutPagesCarousel | LayoutContent | LayoutCards | LayoutImage | LayoutCard | LayoutImageGallery | LayoutSteps | LayoutSocialMediaFeed
 
 """The format of post field data."""
 enum PostObjectFieldFormatEnum
@@ -14893,6 +15037,17 @@ type StaticPage
   liveRevision: Int
 }
 
+"""Step field"""
+type Step
+  @join__type(graph: CMS)
+{
+  """The content of the step"""
+  content: String
+
+  """The title of the step"""
+  title: String
+}
+
 type Subscription
   @join__type(graph: EVENTS)
 {
@@ -17579,7 +17734,7 @@ enum UsersConnectionSearchColumnEnum
   """A URL-friendly name for the user. The default is the user's username."""
   NICENAME @join__enumValue(graph: CMS)
 
-  """The URL of the users website."""
+  """The URL of the user's website."""
   URL @join__enumValue(graph: CMS)
 }
 

--- a/proxies/events-graphql-proxy/src/schema/event/typeDefs.ts
+++ b/proxies/events-graphql-proxy/src/schema/event/typeDefs.ts
@@ -80,7 +80,7 @@ const typeDefs = gql`
     dataSource: String
     publisher: ID
     subEvents: [InternalIdObject!]!
-    images: [Image!]!
+    images: [EventImage!]!
     inLanguage: [InLanguage!]!
     audience: [Audience!]!
     createdTime: String
@@ -149,7 +149,7 @@ const typeDefs = gql`
     infoUrl: LocalizedObject
   }
 
-  type Image {
+  type EventImage {
     id: ID
     license: String
     createdTime: String

--- a/proxies/events-graphql-proxy/src/schema/keyword/typeDefs.ts
+++ b/proxies/events-graphql-proxy/src/schema/keyword/typeDefs.ts
@@ -28,7 +28,7 @@ export const typeDefs = gql`
     aggregate: Boolean
     deprecated: Boolean
     nEvents: Int
-    image: Image
+    image: EventImage
     dataSource: String
     publisher: ID
     name: LocalizedObject

--- a/proxies/events-graphql-proxy/src/schema/place/typeDefs.ts
+++ b/proxies/events-graphql-proxy/src/schema/place/typeDefs.ts
@@ -35,7 +35,7 @@ const typeDefs = gql`
     addressCountry: String
     deleted: Boolean
     nEvents: Int
-    image: Image
+    image: EventImage
     dataSource: String
     publisher: ID
     parent: ID

--- a/proxies/events-graphql-proxy/src/types/types.ts
+++ b/proxies/events-graphql-proxy/src/types/types.ts
@@ -128,7 +128,7 @@ export type EventDetails = {
   dataSource?: Maybe<Scalars['String']>;
   publisher?: Maybe<Scalars['ID']>;
   subEvents: Array<InternalIdObject>;
-  images: Array<Image>;
+  images: Array<EventImage>;
   inLanguage: Array<InLanguage>;
   audience: Array<Audience>;
   createdTime?: Maybe<Scalars['String']>;
@@ -175,8 +175,8 @@ export type ExternalLink = {
   language?: Maybe<Scalars['String']>;
 };
 
-export type Image = {
-  __typename?: 'Image';
+export type EventImage = {
+  __typename?: 'EventImage';
   id?: Maybe<Scalars['ID']>;
   license?: Maybe<Scalars['String']>;
   createdTime?: Maybe<Scalars['String']>;
@@ -217,7 +217,7 @@ export type Keyword = {
   aggregate?: Maybe<Scalars['Boolean']>;
   deprecated?: Maybe<Scalars['Boolean']>;
   nEvents?: Maybe<Scalars['Int']>;
-  image?: Maybe<Image>;
+  image?: Maybe<EventImage>;
   dataSource?: Maybe<Scalars['String']>;
   publisher?: Maybe<Scalars['ID']>;
   name?: Maybe<LocalizedObject>;
@@ -360,7 +360,7 @@ export type Place = {
   addressCountry?: Maybe<Scalars['String']>;
   deleted?: Maybe<Scalars['Boolean']>;
   nEvents?: Maybe<Scalars['Int']>;
-  image?: Maybe<Image>;
+  image?: Maybe<EventImage>;
   dataSource?: Maybe<Scalars['String']>;
   publisher?: Maybe<Scalars['ID']>;
   parent?: Maybe<Scalars['ID']>;
@@ -682,7 +682,7 @@ export type ResolversTypes = {
   EventListResponse: ResolverTypeWrapper<EventListResponse>;
   EventTypeId: EventTypeId;
   ExternalLink: ResolverTypeWrapper<ExternalLink>;
-  Image: ResolverTypeWrapper<Image>;
+  EventImage: ResolverTypeWrapper<EventImage>;
   InLanguage: ResolverTypeWrapper<InLanguage>;
   InternalIdObject: ResolverTypeWrapper<InternalIdObject>;
   Keyword: ResolverTypeWrapper<Keyword>;
@@ -718,7 +718,7 @@ export type ResolversParentTypes = {
   EventDetails: EventDetails;
   EventListResponse: EventListResponse;
   ExternalLink: ExternalLink;
-  Image: Image;
+  EventImage: EventImage;
   InLanguage: InLanguage;
   InternalIdObject: InternalIdObject;
   Keyword: Keyword;
@@ -907,7 +907,11 @@ export type EventDetailsResolvers<
     ParentType,
     ContextType
   >;
-  images?: Resolver<Array<ResolversTypes['Image']>, ParentType, ContextType>;
+  images?: Resolver<
+    Array<ResolversTypes['EventImage']>,
+    ParentType,
+    ContextType
+  >;
   inLanguage?: Resolver<
     Array<ResolversTypes['InLanguage']>,
     ParentType,
@@ -1056,9 +1060,9 @@ export type ExternalLinkResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ImageResolvers<
+export type EventImageResolvers<
   ContextType = any,
-  ParentType extends ResolversParentTypes['Image'] = ResolversParentTypes['Image']
+  ParentType extends ResolversParentTypes['EventImage'] = ResolversParentTypes['EventImage']
 > = {
   id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   license?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1185,7 +1189,11 @@ export type KeywordResolvers<
     ContextType
   >;
   nEvents?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  image?: Resolver<Maybe<ResolversTypes['Image']>, ParentType, ContextType>;
+  image?: Resolver<
+    Maybe<ResolversTypes['EventImage']>,
+    ParentType,
+    ContextType
+  >;
   dataSource?: Resolver<
     Maybe<ResolversTypes['String']>,
     ParentType,
@@ -1453,7 +1461,11 @@ export type PlaceResolvers<
   >;
   deleted?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   nEvents?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  image?: Resolver<Maybe<ResolversTypes['Image']>, ParentType, ContextType>;
+  image?: Resolver<
+    Maybe<ResolversTypes['EventImage']>,
+    ParentType,
+    ContextType
+  >;
   dataSource?: Resolver<
     Maybe<ResolversTypes['String']>,
     ParentType,
@@ -1698,7 +1710,7 @@ export type Resolvers<ContextType = any> = {
   EventDetails?: EventDetailsResolvers<ContextType>;
   EventListResponse?: EventListResponseResolvers<ContextType>;
   ExternalLink?: ExternalLinkResolvers<ContextType>;
-  Image?: ImageResolvers<ContextType>;
+  EventImage?: EventImageResolvers<ContextType>;
   InLanguage?: InLanguageResolvers<ContextType>;
   InternalIdObject?: InternalIdObjectResolvers<ContextType>;
   Keyword?: KeywordResolvers<ContextType>;


### PR DESCRIPTION
## Description

### chore: rename events-graphql-proxy Image to EventImage, update supergraph

NOTE:
 - THIS **NEEDS HCRC** (i.e. react-helsinki-headless-cms) related changes (See **[PR #114](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/114)**) in tandem for things **to work**, the Image type needs to be updated there also to EventImage i.e. EventsByIdsQuery -> eventsByIds -> data -> images -> __typename should be changed from 'Image' to 'EventImage'.

what was done:

events-graphql-proxy:
 - renamed Image to EventImage
 - renamed ImageResolvers to EventImageResolvers

```bash
cd ./proxies/events-graphql-proxy
yarn build
yarn start
```
-> events-graphql-proxy running at http://localhost:4100/proxy/graphql

Changed temporarily `docker:graphql-router:sports:serve` command in package.json to make the router use the local events-graphql-proxy by setting FEDERATION_EVENTS_ROUTING_URL to
http://host.docker.internal:4100/proxy/graphql

See https://stackoverflow.com/a/24326540 for information about the use of host.docker.internal instead of localhost.

Ran the events-graphql-federation router and made sure it builds: `yarn docker:graphql-router:sports:serve --build`
-> events-graphql-federation running at http://localhost:4000/

```bash
cd ./proxies/events-graphql-federation
rover subgraph introspect http://localhost:4100/proxy/graphql \
    > ./subgraphs/events/events.graphql
rover graph introspect https://harrastus.hkih.stage.geniem.io/graphql \
    > ./subgraphs/cms/cms.graphql
rover supergraph compose --config ./supergraph-config.yaml \
    > ./supergraph.graphql
```
which resulted in an error:
```bash
error[E029]: Encountered 1 build error while trying to build a
supergraph.

Caused by:
    INVALID_GRAPHQL: [cms] - Syntax Error:
    Invalid character escape sequence: "\s".

    GraphQL request:7347:23
    7346 |   NICENAME
    7347 |   "The URL of the user\s website."
         |                       ^
    7348 |   URL
```

Manually renamed in generated cms.graphql:
 - `"The URL of the user\s website."` to
 - `"The URL of the user's website."`

and ran the rover supergraph compose command again which succeeded in generating the supergraph.

Stopped the locally running router and rebuilt it to make sure the supergraph changes got reflected in it:
`yarn docker:graphql-router:sports:serve --build`

Set `FEDERATION_ROUTER_ENDPOINT="http://localhost:4000/"` in apps/sports-helsinki/.env.local so "yarn generate:graphql" will use the locally running router.

Generated the graphql:
```bash
cd ../../apps/sports-helsinki/
yarn generate:graphql
cp ./src/components/domain/graphql/generated/graphql.tsx \
    ../../packages/components/src/types/generated/
cd ../../
npx prettier ./packages/components/src/types/generated/graphql.tsx -w
```

Renamed Image to EventImage in mocking and fakeImage to fakeEventImage.

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
