### PR TITLE
chore: use react-helsinki-headless-cms v1.0.0-alpha189

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha187",
+    "react-helsinki-headless-cms": "1.0.0-alpha189",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha187",
+    "react-helsinki-headless-cms": "1.0.0-alpha189",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -80,7 +80,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha187",
+    "react-helsinki-headless-cms": "1.0.0-alpha189",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha187",
+    "react-helsinki-headless-cms": "1.0.0-alpha189",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,7 +3325,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha187"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha189"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -13680,7 +13680,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha187"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha189"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -15499,7 +15499,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha187"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha189"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -22590,13 +22590,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha187":
-  version: 1.0.0-alpha187
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha187"
+"react-helsinki-headless-cms@npm:1.0.0-alpha189":
+  version: 1.0.0-alpha189
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha189"
   dependencies:
     hds-design-tokens: "npm:^2.3.0"
     html-react-parser: "npm:^1.4.8"
     isomorphic-dompurify: "npm:^0.18.0"
+    lodash: "npm:^4.17.21"
   peerDependencies:
     "@apollo/client": ^3.5.10
     date-fns: ^2.28.0
@@ -22606,7 +22607,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: d929296b8ac1ac6655d932317f89c375b4ed591b54edc0de4a3cc10998e0df4cf4b5d11bff6f747351112c170e589c3d5bb01e738c2e198c2de35c30b6df65c9
+  checksum: 8398519f1b3d43ee7adfd63241dbceeaf1a9b5e783bbb49ad1b6deea0ac776a6f272a79820b5b3749a5fcd6a65979f3fc1f4fce936083b408e9570eec5abab10
   languageName: node
   linkType: hard
 
@@ -24655,7 +24656,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha187"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha189"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"


### PR DESCRIPTION
## Description

### chore: use react-helsinki-headless-cms v1.0.0-alpha189

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
