### PR TITLE
chore: use react-helsinki-headless-cms v1.0.0-alpha191

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha188",
+    "react-helsinki-headless-cms": "v1.0.0-alpha191",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha188",
+    "react-helsinki-headless-cms": "v1.0.0-alpha191",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -80,7 +80,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha188",
+    "react-helsinki-headless-cms": "v1.0.0-alpha191",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha188",
+    "react-helsinki-headless-cms": "v1.0.0-alpha191",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,7 +3325,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha188"
+    react-helsinki-headless-cms: "npm:v1.0.0-alpha191"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -13680,7 +13680,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha188"
+    react-helsinki-headless-cms: "npm:v1.0.0-alpha191"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -15499,7 +15499,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha188"
+    react-helsinki-headless-cms: "npm:v1.0.0-alpha191"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -22590,13 +22590,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:v1.0.0-alpha188":
-  version: 1.0.0-alpha188
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha188"
+"react-helsinki-headless-cms@npm:v1.0.0-alpha191":
+  version: 1.0.0-alpha191
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha191"
   dependencies:
     hds-design-tokens: "npm:^2.3.0"
     html-react-parser: "npm:^1.4.8"
     isomorphic-dompurify: "npm:^0.18.0"
+    lodash: "npm:^4.17.21"
   peerDependencies:
     "@apollo/client": ^3.5.10
     date-fns: ^2.28.0
@@ -22606,7 +22607,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: 6dd9c70884d43466c779c7720476e9adc7b0f24706395fc29fa68ca8a395048c4e9f179ec5f5f5c68a2e4caa74210c221967a58e7493b255383bff9dd39a551b
+  checksum: e0b60995c704e6bbaf7e20a67962517fa59208e73ae8ee6cb97416cd7993c2829257ee7621b1dd30cc874e577023505503c28aedd3a8c99afef744bbf9802cf2
   languageName: node
   linkType: hard
 
@@ -24655,7 +24656,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha188"
+    react-helsinki-headless-cms: "npm:v1.0.0-alpha191"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"


### PR DESCRIPTION
## Description

### chore: use react-helsinki-headless-cms v1.0.0-alpha191

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
