### PR TITLE
fix(locale): i18n routes rewrites

### DIFF
--- a/apps/sports-helsinki/next.config.js
+++ b/apps/sports-helsinki/next.config.js
@@ -14,8 +14,8 @@ module.exports = nextBaseConfig({
         // Not setting `locale: false` here because that didn't work for some reason.
         // When locale is left undefined middleware.ts's prefixDefaultLocale function
         // lets these redirect routes through without prefixing them with locale.
-        source: source,
-        destination: destination,
+        source,
+        destination,
         permanent: true,
       },
     ]);

--- a/next.base.config.js
+++ b/next.base.config.js
@@ -146,7 +146,7 @@ const nextBaseConfig = ({
     async rewrites() {
       return Object.entries(i18nRoutes).flatMap(([destination, sources]) =>
         sources.map(({ source, locale }) => ({
-          destination,
+          destination: `/${locale}${destination}`,
           source: `/${locale}${source}`,
           locale: false,
         }))


### PR DESCRIPTION
HH-320.

Fix the Swedish UI, which was broke by the last dependency upgrade process.
The i18n routes rewrite table was needed to be built differently.
NOTE: The change affects to all 3 apps.