### PR TITLE
feat(proxy): fetch venue details with fallback languages

### DIFF
--- a/apps/events-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/events-helsinki/src/domain/app/AppConfig.ts
@@ -1,4 +1,4 @@
-import { EventTypeId } from '@events-helsinki/components';
+import { getEnvOrError, EventTypeId } from '@events-helsinki/components';
 import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { ROUTES } from '../../constants';
@@ -247,19 +247,6 @@ function parseEnvValue(
   } catch (e) {
     return null;
   }
-}
-
-// Accept both variable and name so that variable can be correctly replaced
-// by build.
-// process.env.VAR => value
-// process.env["VAR"] => no value
-// Name is used to make debugging easier.
-function getEnvOrError(variable?: string, name?: string) {
-  if (!variable) {
-    throw Error(`Environment variable with name ${name} was not found`);
-  }
-
-  return variable;
 }
 
 export default AppConfig;

--- a/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
@@ -1,4 +1,4 @@
-import { EventTypeId } from '@events-helsinki/components';
+import { getEnvOrError, EventTypeId } from '@events-helsinki/components';
 import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { ROUTES } from '../../constants';
@@ -247,19 +247,6 @@ function parseEnvValue(
   } catch (e) {
     return null;
   }
-}
-
-// Accept both variable and name so that variable can be correctly replaced
-// by build.
-// process.env.VAR => value
-// process.env["VAR"] => no value
-// Name is used to make debugging easier.
-function getEnvOrError(variable?: string, name?: string) {
-  if (!variable) {
-    throw Error(`Environment variable with name ${name} was not found`);
-  }
-
-  return variable;
 }
 
 export default AppConfig;

--- a/apps/sports-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/sports-helsinki/src/domain/app/AppConfig.ts
@@ -1,3 +1,4 @@
+import { getEnvOrError } from '@events-helsinki/components';
 import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { i18n } from '../../../next-i18next.config';
@@ -265,19 +266,6 @@ function parseEnvValue(
   } catch (e) {
     return null;
   }
-}
-
-// Accept both variable and name so that variable can be correctly replaced
-// by build.
-// process.env.VAR => value
-// process.env["VAR"] => no value
-// Name is used to make debugging easier.
-function getEnvOrError(variable?: string, name?: string) {
-  if (!variable) {
-    throw Error(`Environment variable with name ${name} was not found`);
-  }
-
-  return variable;
 }
 
 export default AppConfig;

--- a/packages/components/src/utils/getEnvOrError.ts
+++ b/packages/components/src/utils/getEnvOrError.ts
@@ -1,0 +1,14 @@
+/**
+ * Accept both variable and name so that variable can be correctly replaced
+ * by build.
+ * process.env.VAR => value
+ * process.env["VAR"] => no value
+ * Name is used to make debugging easier.
+ */
+export default function getEnvOrError(variable?: string, name?: string) {
+  if (!variable) {
+    throw Error(`Environment variable with name ${name} was not found`);
+  }
+
+  return variable;
+}

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './eventUtils';
 export { default as getDateArray } from './getDateArray';
 export { default as getDateRangeStr } from './getDateRangeStr';
 export { default as getDomain } from './getDomain';
+export { default as getEnvOrError } from './getEnvOrError';
 export { default as getLanguageOrDefault } from './get-language-or-default';
 export { default as getLocalizedString } from './getLocalizedString';
 export { default as getSecureImage } from './getSecureImage';

--- a/proxies/venue-graphql-proxy/src/config/AppConfig.ts
+++ b/proxies/venue-graphql-proxy/src/config/AppConfig.ts
@@ -1,3 +1,5 @@
+import type { Locale } from '../types';
+
 class AppConfig {
   static get debug() {
     return Boolean(parseEnvValue(process.env.GRAPHQL_PROXY_DEBUG));
@@ -5,6 +7,24 @@ class AppConfig {
 
   static get isHaukiEnabled() {
     return false;
+  }
+
+  static get supportedLocales() {
+    return ['fi', 'en', 'sv'] as Locale[];
+  }
+
+  /** A prioritized list of fallback languages. */
+  static get fallbackLocales() {
+    return ['en', 'fi', 'sv'] as Locale[];
+  }
+
+  /**
+   * When Venue details are fetched and there are no details populated for the language in the context,
+   * should the server serve the details in the most prioritized fallback langauge.
+   * @return boolean  Returns tru if the fallback langauges should be used.
+   */
+  static get isUseFallbackLocalesEnabled() {
+    return true;
   }
 }
 
@@ -28,12 +48,12 @@ function parseEnvValue(
 // process.env.VAR => value
 // process.env["VAR"] => no value
 // Name is used to make debugging easier.
-function getEnvOrError(variable?: string, name?: string) {
-  if (!variable) {
-    throw Error(`Environment variable with name ${name} was not found`);
-  }
+// function getEnvOrError(variable?: string, name?: string) {
+//   if (!variable) {
+//     throw Error(`Environment variable with name ${name} was not found`);
+//   }
 
-  return variable;
-}
+//   return variable;
+// }
 
 export default AppConfig;

--- a/proxies/venue-graphql-proxy/src/config/AppConfig.ts
+++ b/proxies/venue-graphql-proxy/src/config/AppConfig.ts
@@ -42,18 +42,4 @@ function parseEnvValue(
     return null;
   }
 }
-
-// Accept both variable and name so that variable can be correctly replaced
-// by build.
-// process.env.VAR => value
-// process.env["VAR"] => no value
-// Name is used to make debugging easier.
-// function getEnvOrError(variable?: string, name?: string) {
-//   if (!variable) {
-//     throw Error(`Environment variable with name ${name} was not found`);
-//   }
-
-//   return variable;
-// }
-
 export default AppConfig;

--- a/proxies/venue-graphql-proxy/src/resolvers/integrations/VenueServiceMapIntegration.ts
+++ b/proxies/venue-graphql-proxy/src/resolvers/integrations/VenueServiceMapIntegration.ts
@@ -1,3 +1,4 @@
+import AppConfig from '../../config/AppConfig';
 import { Sources } from '../../contants/constants';
 import type { TprekUnit, VenueDetails } from '../../types';
 import {
@@ -22,7 +23,12 @@ export default class VenueServiceMapIntegration extends VenueResolverIntegration
         dataSources.serviceMap.getUnit(id),
       ],
       enrichers: config.enrichers,
-      format: (data, context) => translateVenue(this.formatter(data), context),
+      format: (data, context) =>
+        translateVenue(
+          this.formatter(data),
+          context,
+          AppConfig.isUseFallbackLocalesEnabled
+        ),
     });
   }
 

--- a/proxies/venue-graphql-proxy/src/utils/__tests__/utils.test.ts
+++ b/proxies/venue-graphql-proxy/src/utils/__tests__/utils.test.ts
@@ -1,0 +1,76 @@
+import AppConfig from '../../config/AppConfig';
+import type VenueContext from '../../context/VenueContext';
+import type { TranslationsObject, Locale, VenueDetails } from '../../types';
+import { pickLocaleWithFallback, translateVenue } from '../utils';
+
+const fi = 'tekstiä suomeksi';
+const sv = 'text på svenska';
+const en = 'text in English';
+
+describe('pickLocaleWithFallback', () => {
+  it.each<[Locale, Locale, TranslationsObject]>([
+    ['sv', 'en', { sv }],
+    ['fi', 'en', { fi, sv }],
+    ['en', 'sv', { fi, en }],
+    ['fi', 'sv', { fi }],
+  ])(
+    'uses "%s" as first fallback locale to fetch the details when the default locale "%s" is not available in object %o',
+    (resultLocale, locale, obj) => {
+      const translation = pickLocaleWithFallback(obj, locale);
+      const expectedTranslation = obj[resultLocale];
+      expect(translation).toStrictEqual(expectedTranslation);
+    }
+  );
+});
+
+describe('translateVenue', () => {
+  it.each(AppConfig.supportedLocales)(
+    'returns the details in given language %s',
+    (locale) => {
+      const venueData = {
+        name: {
+          fi,
+          en,
+          sv,
+        },
+        description: {
+          fi,
+          en,
+          sv,
+        },
+      } as Partial<VenueDetails>;
+      const context = { language: locale } as VenueContext;
+      const translatedVenue = translateVenue(venueData, context);
+      expect(translatedVenue.description).toStrictEqual(
+        venueData.description![locale]
+      );
+      expect(translatedVenue.name).toStrictEqual(venueData.name![locale]);
+    }
+  );
+  it.each(AppConfig.supportedLocales)(
+    'uses a fallback language when the requested details are not available in given language %s',
+    (locale) => {
+      const venueData = {
+        name: {
+          fi,
+          en,
+          sv,
+        },
+        description: {
+          fi,
+          en,
+          sv,
+        },
+      } as Partial<VenueDetails>;
+      const fallbackLng = locale === 'en' ? 'fi' : 'en';
+      const context = { language: locale } as VenueContext;
+      delete venueData.description![locale];
+      delete venueData.name![locale];
+      const translatedVenue = translateVenue(venueData, context, true);
+      expect(translatedVenue.description).toStrictEqual(
+        venueData.description![fallbackLng]
+      );
+      expect(translatedVenue.name).toStrictEqual(venueData.name![fallbackLng]);
+    }
+  );
+});


### PR DESCRIPTION
LIIKUNTA-547.
If the locale that is set in header does not return any results,
use the configured fallback languages.

NOTE: The work is done to the venue proxy -- not in the client.

> Instead of trying to fix this on the client side, the resolver in the Venue-graphql-proxy could be modified so that it uses a fallback language instead of undefined

> The problem is that the Sport app venue search uses the Unified-Search, but the Venue details page uses the Venue proxy, which fetches directly from the TPREK / Servicemap. The Venue-proxy returns the details in only 1 language (unlike e.g the LinkedEvents) which is defined in the request header.