### PR TITLE
fix: super event lazy loading when the super event was deleted

### DIFF
--- a/apps/events-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/events-helsinki/src/domain/app/AppConfig.ts
@@ -232,6 +232,16 @@ class AppConfig {
         ROUTES.PAGES.replace('/[...slug]', ''),
     };
   }
+
+  /**
+   * The response status codes that the error handler of
+   * the Apollo federation client should ignore.
+   * */
+  static get apolloErrorHandlerIgnoredStatusCodes() {
+    // Ignore HTTP410 - Not found, which is raised e.g.
+    // when an event has been deleted from the LinkedEvents
+    return [410];
+  }
 }
 
 function parseEnvValue(

--- a/apps/events-helsinki/src/domain/clients/eventsApolloClient.ts
+++ b/apps/events-helsinki/src/domain/clients/eventsApolloClient.ts
@@ -3,6 +3,7 @@ import { EventsFederationApolloClient } from '@events-helsinki/components';
 import React from 'react';
 import routerHelper from '../../domain/app/routerHelper';
 import AppConfig from '../app/AppConfig';
+
 export default function initializeEventsApolloClient(
   config: {
     handleError?: (error: Error) => void;
@@ -13,6 +14,8 @@ export default function initializeEventsApolloClient(
     routerHelper,
     allowUnauthorizedRequests: AppConfig.allowUnauthorizedRequests,
     federationGraphqlEndpoint: AppConfig.federationGraphqlEndpoint,
+    ignoredErrorHandlerStatusCodes:
+      AppConfig.apolloErrorHandlerIgnoredStatusCodes,
   });
 }
 

--- a/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
@@ -232,6 +232,16 @@ class AppConfig {
         ROUTES.PAGES.replace('/[...slug]', ''),
     };
   }
+
+  /**
+   * The response status codes that the error handler of
+   * the Apollo federation client should ignore.
+   * */
+  static get apolloErrorHandlerIgnoredStatusCodes() {
+    // Ignore HTTP410 - Not found, which is raised e.g.
+    // when an event has been deleted from the LinkedEvents
+    return [410];
+  }
 }
 
 function parseEnvValue(

--- a/apps/hobbies-helsinki/src/domain/clients/hobbiesApolloClient.ts
+++ b/apps/hobbies-helsinki/src/domain/clients/hobbiesApolloClient.ts
@@ -3,6 +3,7 @@ import { EventsFederationApolloClient } from '@events-helsinki/components';
 import React from 'react';
 import routerHelper from '../../domain/app/routerHelper';
 import AppConfig from '../app/AppConfig';
+
 export default function initializeHobbiesApolloClient(
   config: {
     handleError?: (error: Error) => void;
@@ -13,6 +14,8 @@ export default function initializeHobbiesApolloClient(
     routerHelper,
     allowUnauthorizedRequests: AppConfig.allowUnauthorizedRequests,
     federationGraphqlEndpoint: AppConfig.federationGraphqlEndpoint,
+    ignoredErrorHandlerStatusCodes:
+      AppConfig.apolloErrorHandlerIgnoredStatusCodes,
   });
 }
 

--- a/apps/sports-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/sports-helsinki/src/domain/app/AppConfig.ts
@@ -251,6 +251,16 @@ class AppConfig {
   static get isHaukiEnabled() {
     return false;
   }
+
+  /**
+   * The response status codes that the error handler of
+   * the Apollo federation client should ignore.
+   * */
+  static get apolloErrorHandlerIgnoredStatusCodes() {
+    // Ignore HTTP410 - Not found, which is raised e.g.
+    // when an event has been deleted from the LinkedEvents
+    return [410];
+  }
 }
 
 function parseEnvValue(

--- a/apps/sports-helsinki/src/domain/clients/sportsApolloClient.ts
+++ b/apps/sports-helsinki/src/domain/clients/sportsApolloClient.ts
@@ -3,6 +3,7 @@ import { EventsFederationApolloClient } from '@events-helsinki/components';
 import React from 'react';
 import routerHelper from '../../domain/app/routerHelper';
 import AppConfig from '../app/AppConfig';
+
 export default function initializeSportsApolloClient(
   config: {
     handleError?: (error: Error) => void;
@@ -13,6 +14,8 @@ export default function initializeSportsApolloClient(
     routerHelper,
     allowUnauthorizedRequests: AppConfig.allowUnauthorizedRequests,
     federationGraphqlEndpoint: AppConfig.federationGraphqlEndpoint,
+    ignoredErrorHandlerStatusCodes:
+      AppConfig.apolloErrorHandlerIgnoredStatusCodes,
   });
 }
 

--- a/packages/components/src/hooks/useSuperEventLazyLoad.ts
+++ b/packages/components/src/hooks/useSuperEventLazyLoad.ts
@@ -53,7 +53,7 @@ function useSuperEventLazyLoad(event?: EventFieldsFragment) {
     superEventId,
     superEventData,
     superEventSearch,
-    superEventLoading,
+    // superEventLoading, // ...should be 1 of the deps here, but e.g. when http410 errors occurs, with it, this fetcher goes in a forever loop.
   ]);
 
   return {


### PR DESCRIPTION
HH-321.

The super event lazy loading took the whole event page
to a never ending reload loop. The loop is fixed by adjusting the
useEffect-hooks dependencies.

Also, it was silly that the "HTTP410 Gone" response for a super event,
which is just some nice to know info, was raising a connection issue message.
The Apollo federation client now supports ignoring some response status codes
with the configuration.

----

### How to test
With event helsinki:agegxbh6iu (http://localhost:3000/fi/tapahtumat/helsinki:agegxbh6iu) that has a removed super event, the page should not go to forever loop with the super event fetching.
With event kulke:56382 (http://localhost:3000/fi/tapahtumat/kulke:56382) that is an ongoing sub event, there should be a super event link rendered properly. (However, the super event has already ended, but there is not enough testable data in the current LinkedEvents: https://linkedevents.api.hel.fi/v1/event/)