### PR TITLE
LIIKUNTA-548 | fix(sports): fix removing publisher filter from FilterSummary

### DIFF
--- a/apps/sports-helsinki/config/jest/mockDataUtils.ts
+++ b/apps/sports-helsinki/config/jest/mockDataUtils.ts
@@ -493,7 +493,7 @@ export const appRoutingUrlMocks: AppRoutingContextProps = {
     .fn()
     .mockImplementation(
       (event: EventFields, _router: NextRouter, _locale: AppLanguage) =>
-        `/haku?publisher=${event.publisher}&searchType=${event.typeId}`
+        `/haku?organization=${event.publisher}&searchType=${event.typeId}`
     ),
   getPlainEventUrl: jest
     .fn()

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchProvider.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchProvider.test.tsx
@@ -35,7 +35,7 @@ describe('CombinedSearchProvider', () => {
     // text and sportsCategories included
     'text=test%20text&sportsCategories=gym&sportsCategories=playgrounds',
     // organization included
-    'publisher=testorg',
+    'organization=testorg',
   ])('reads the context properly', (searchParams) => {
     mockRouter.setCurrentUrl(`/?${searchParams}`);
     // TODO: Remove the useSearchParamsSpy when mockRouter supports next/navigation.

--- a/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
@@ -1,7 +1,7 @@
 import {
   useLocale,
   HelsinkiOnlyFilter,
-  PublisherFilter,
+  OrganizationFilter,
   FilterButton,
   translateValue,
   PlaceFilter,
@@ -30,7 +30,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
   const {
     sportsCategories,
     targetGroups,
-    organization: publisher,
+    organization,
     helsinkiOnly,
     text: q,
     place,
@@ -67,7 +67,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
     !!sportsCategories.length ||
     !!targetGroups.length ||
     !!helsinkiOnly ||
-    !!publisher ||
+    !!organization ||
     !!place ||
     !!q?.length;
 
@@ -89,7 +89,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
             sportsCategory,
             t
           )}
-          type="sportsCategory"
+          type="sportsCategories"
           value={sportsCategory}
         />
       ))}
@@ -98,14 +98,14 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
           key={targetGroup}
           onRemove={() => handleFilterRemove('targetGroups', targetGroup)}
           text={translateValue('appSports:home.targetGroup.', targetGroup, t)}
-          type="targetGroup"
+          type="targetGroups"
           value={targetGroup}
         />
       ))}
-      {publisher && (
-        <PublisherFilter
-          id={publisher}
-          onRemove={() => handleFilterRemove('organization', publisher)}
+      {organization && (
+        <OrganizationFilter
+          id={organization}
+          onRemove={() => handleFilterRemove('organization', organization)}
         />
       )}
       {helsinkiOnly && (

--- a/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx
@@ -82,7 +82,7 @@ interface UrlParams {
   // divisions: string;
   end: string;
   place: string;
-  publisher: string;
+  organization: string;
   start: string;
   text: string;
 }
@@ -93,7 +93,7 @@ const urlParams: UrlParams = {
   // divisions: neighborhoodId,
   end: '2020-08-23',
   place: placeId,
-  publisher: organizationId,
+  organization: organizationId,
   start: '2020-08-20',
   text: 'jazz',
 };
@@ -102,7 +102,7 @@ const urlParams: UrlParams = {
 
 const routes = [
   // eslint-disable-next-line max-len
-  `/haku?categories=${urlParams.categories}&dateTypes=today&end=${urlParams.end}&place=${urlParams.place}&publisher=${urlParams.publisher}&start=${urlParams.start}&text=${urlParams.text}`,
+  `/haku?categories=${urlParams.categories}&dateTypes=today&end=${urlParams.end}&place=${urlParams.place}&organization=${urlParams.organization}&start=${urlParams.start}&text=${urlParams.text}`,
 ];
 
 // TODO: when HDS fixes the tag id -> uncomment
@@ -166,7 +166,7 @@ it.todo('routes to correct url after deleting filters');
 //     { button: `Poista suodatin: ${placeName}`, params: ["place"] },
 //     {
 //       button: `Poista suodatin: ${organizationName}`,
-//       params: ["publisher"],
+//       params: ["organization"],
 //     },
 //     { button: "Poista suodatin: jazz", params: ["text"] },
 //   ];

--- a/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -421,7 +421,7 @@ export const getOrganizationSearchUrl = (
     ROUTES.SEARCH,
     {
       searchType: event.typeId ?? EventTypeId.General,
-      publisher: event.publisher ?? '',
+      organization: event.publisher ?? '',
     },
     locale
   );

--- a/packages/components/src/components/filterButton/types.ts
+++ b/packages/components/src/components/filterButton/types.ts
@@ -1,19 +1,24 @@
+export type AgeFilterType = 'maxAge' | 'minAge';
+export type DateFilterType = 'date' | 'dateType';
+
 /**
- * @deprecated since the CombinedSearch refactoring it's new types and adapters should be used instead (e.g CombinedSearchAdapterInput).
+ * @deprecated since the CombinedSearch refactoring its new types and adapters should
+ * be used instead (e.g CombinedSearchAdapterInput) i.e. this should be a subset of
+ * keyof CombinedSearchAdapterInput
  */
-export type FilterType =
-  | 'category'
-  | 'hobbyType'
-  | 'sportsCategory'
-  | 'targetGroup'
+type CombinedSearchInputSubset =
   | 'helsinkiOnly'
-  | 'date'
-  | 'dateType'
-  | 'division'
+  | 'organization'
   | 'place'
-  | 'publisher'
-  | 'target'
-  | 'text'
-  | 'minAge'
-  | 'maxAge'
-  | 'exactAge';
+  | 'sportsCategories'
+  | 'targetGroups'
+  | 'text';
+
+export type FilterType =
+  | AgeFilterType
+  | DateFilterType
+  | CombinedSearchInputSubset
+  | 'category' // Used in events-helsinki and hobbies-helsinki
+  | 'division' // Used in events-helsinki and hobbies-helsinki
+  | 'hobbyType' // Used in hobbies-helsinki
+  | 'publisher'; // Used in events-helsinki and hobbies-helsinki

--- a/packages/components/src/components/filters/AgeFilter.tsx
+++ b/packages/components/src/components/filters/AgeFilter.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useCommonTranslation, useSearchTranslation } from '../../hooks';
-import type { FilterType } from '../filterButton';
+import type { FilterType, AgeFilterType } from '../filterButton';
 import { FilterButton } from '../filterButton';
 
 export interface AgeFilterProps {
   value: string;
-  type: 'minAge' | 'maxAge';
+  type: AgeFilterType;
   onRemove: (value: string, type: FilterType) => void;
 }
 

--- a/packages/components/src/components/filters/DateFilter.tsx
+++ b/packages/components/src/components/filters/DateFilter.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { useCommonTranslation } from '../../hooks';
 import { translateValue } from '../../utils';
 import { FilterButton } from '../filterButton';
-import type { FilterType } from '../filterButton';
+import type { DateFilterType, FilterType } from '../filterButton';
 
 export interface DateFilterProps {
   onRemove: (value: string, type: FilterType) => void;
   text?: string;
-  type: 'date' | 'dateType';
+  type: DateFilterType;
   value: string;
 }
 

--- a/packages/components/src/components/filters/OrganizationFilter.tsx
+++ b/packages/components/src/components/filters/OrganizationFilter.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useCommonTranslation } from '../../hooks';
+import { useOrganizationDetailsQuery } from '../../types';
+import { FilterButton } from '../filterButton';
+import type { FilterType } from '../filterButton';
+
+interface Props {
+  id: string;
+  onRemove: (value: string, type: FilterType) => void;
+}
+
+const OrganizationFilter: React.FC<Props> = ({ id, onRemove }) => {
+  const { t } = useCommonTranslation();
+  const { data, loading } = useOrganizationDetailsQuery({
+    variables: { id },
+  });
+
+  return loading ? (
+    <FilterButton
+      onRemove={onRemove}
+      text={t('common:loading')}
+      type="organization"
+      value={id}
+    />
+  ) : data && data.organizationDetails.name ? (
+    <FilterButton
+      onRemove={onRemove}
+      text={data.organizationDetails.name}
+      type="organization"
+      value={id}
+    />
+  ) : null;
+};
+
+export default OrganizationFilter;

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -46,6 +46,7 @@ export { default as Document } from './document/Document';
 export { default as AgeFilter } from './filters/AgeFilter';
 export { default as DateFilter } from './filters/DateFilter';
 export { default as HelsinkiOnlyFilter } from './filters/HelsinkiOnlyFilter';
+export { default as OrganizationFilter } from './filters/OrganizationFilter';
 export { default as PlaceFilter } from './filters/PlaceFilter';
 export { default as PublisherFilter } from './filters/PublisherFilter';
 export { default as TextFilter } from './filters/TextFilter';


### PR DESCRIPTION
## Description

Summary:
 - Changed the publisher filter to an organization filter in sports-helsinki

### fix(sports): fix removing publisher filter from FilterSummary

NOTE:
 - `FilterType` could use more refactoring but tried to make the type
   overlap with `keyof CombinedSearchAdapterInput` more explicit

refs LIIKUNTA-548

## Issues

### Closes

**[LIIKUNTA-548](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-548)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-548]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ