### PR TITLE
LIIKUNTA-548 | fix(sports): fix CombinedSearchFormAdapter's clean function

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -8,7 +8,9 @@ import type {
   CombinedSearchAdapterInput,
   CombinedSearchAdapterOutput,
 } from '../../types';
-import CombinedSearchFormAdapter from '../CombinedSearchFormAdapter';
+import CombinedSearchFormAdapter, {
+  cleanFunctionNames,
+} from '../CombinedSearchFormAdapter';
 
 const locale = 'fi';
 
@@ -36,6 +38,52 @@ beforeEach(() => {
 });
 
 describe('CombinedSearchFormAdapter', () => {
+  describe('clean', () => {
+    it('field specific clean functions are found in CombinedSearchFormAdapter', () => {
+      const adapter = new CombinedSearchFormAdapter(locale, input);
+      for (const cleanFunctionName of cleanFunctionNames) {
+        expect(adapter).toHaveProperty(cleanFunctionName);
+        expect(typeof adapter[cleanFunctionName]).toBe('function');
+      }
+    });
+
+    it('field specific clean functions take no parameters', () => {
+      const adapter = new CombinedSearchFormAdapter(locale, input);
+      for (const cleanFunctionName of cleanFunctionNames) {
+        expect(adapter[cleanFunctionName]).toHaveLength(0);
+      }
+    });
+
+    it('field specific clean functions return nothing', () => {
+      const adapter = new CombinedSearchFormAdapter(locale, input);
+      for (const cleanFunctionName of cleanFunctionNames) {
+        expect(adapter[cleanFunctionName]()).toBeUndefined();
+      }
+    });
+
+    it('clean function calls all field specific clean functions', () => {
+      const adapter = new CombinedSearchFormAdapter(locale, input);
+      const cleanFunctionSpies = cleanFunctionNames.map((cleanFunctionName) =>
+        jest.spyOn(adapter, cleanFunctionName)
+      );
+      cleanFunctionSpies.forEach((cleanFunctionSpy) =>
+        expect(cleanFunctionSpy).not.toHaveBeenCalled()
+      );
+      adapter.clean();
+      cleanFunctionSpies.forEach((cleanFunctionSpy) =>
+        expect(cleanFunctionSpy).toHaveBeenCalled()
+      );
+    });
+
+    it('CombinedSearchFormAdapter constructor calls clean function', () => {
+      const adapterPrototype = CombinedSearchFormAdapter.prototype;
+      const cleanFunctionSpy = jest.spyOn(adapterPrototype, 'clean');
+      expect(cleanFunctionSpy).not.toHaveBeenCalled();
+      new CombinedSearchFormAdapter(locale, input);
+      expect(cleanFunctionSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('getURLQuery', () => {
     it('collects the form values from the URL but does not exclude the extra params', () => {
       const adapter = new CombinedSearchFormAdapter(locale, input);


### PR DESCRIPTION
## Description

NOTE:
 - I have no idea why the typoed cleanHelsinkOnly function didn't raise a type error before, I fixed that

### fix(sports): fix CombinedSearchFormAdapter's clean function

make sure CombinedSearchFormAdapter's clean function calls all available
field specific cleaning functions

refs LIIKUNTA-548 (noticed while working on this ticket)

## Issues

### Closes

### Related

**[LIIKUNTA-548](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-548)**

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-548]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ