### PR TITLE
fix: go back url from details page when a language has been changed

### DIFF
--- a/apps/events-helsinki/tsconfig.json
+++ b/apps/events-helsinki/tsconfig.json
@@ -28,9 +28,6 @@
       "@events-helsinki/components": ["../../../packages/components/src/index"],
       "@events-helsinki/common-tests/*": [
         "../../../packages/common-tests/src/*"
-      ],
-      "@events-helsinki/common-tests": [
-        "../../../packages/common-tests/src/index"
       ]
     }
   },

--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -5,6 +5,7 @@ import {
   EllipsedTextWithToggle,
   getSecureImage,
   useVenueTranslation,
+  getLocaleFromPathname,
 } from '@events-helsinki/components';
 import type { ReturnParams } from '@events-helsinki/components/utils/eventQueryString.util';
 import { extractLatestReturnPath } from '@events-helsinki/components/utils/eventQueryString.util';
@@ -38,7 +39,11 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
   const returnParam = extractLatestReturnPath(search, `/${locale}`);
 
   const goBack = ({ returnPath, remainingQueryString = '' }: ReturnParams) => {
-    router.push(`${returnPath}${remainingQueryString}`);
+    const goBackUrl = `${
+      returnPath.startsWith('/') ? '' : '/'
+    }${returnPath}${remainingQueryString}`;
+    const goBackUrlLocale = getLocaleFromPathname(goBackUrl);
+    router.push(goBackUrl, undefined, { locale: goBackUrlLocale });
   };
 
   const imageUrl = venue.image ? getSecureImage(venue.image) : '';

--- a/apps/sports-helsinki/src/middleware.ts
+++ b/apps/sports-helsinki/src/middleware.ts
@@ -1,11 +1,12 @@
 // import { DEFAULT_LANGUAGE } from '@events-helsinki/components';
-import stringifyUrlObject from '@events-helsinki/components/utils/stringifyUrlObject';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+// import { i18n } from '../next-i18next.config'; The import does not work to fetch locales
 import redirectRoutes from '../redirectRoutes.config';
 
 // TODO: For some reason middleware cannot read `'@events-helsinki/components` package without breaking the build
 const DEFAULT_LANGUAGE = 'fi';
+const locales = ['fi', 'en', 'sv']; // i18n.locales.join('|');
 
 const requestType = {
   isStaticFile: (req: NextRequest) => req.nextUrl.pathname.startsWith('/_next'),
@@ -15,24 +16,67 @@ const requestType = {
   isPublicFile: (req: NextRequest) => /\.(.*)$/.test(req.nextUrl.pathname),
 };
 
+/** Get the preferred locale, similar to above or using a library */
+function getLocaleFromPathname(pathname: string) {
+  const pattern = `^/?(?<locale>${locales.join('|')})/?`;
+  const match = pathname.match(new RegExp(pattern, 'i'));
+  return match?.groups?.locale;
+}
+
+function getLocale(req: NextRequest) {
+  const { pathname } = new URL(req.url);
+  return getLocaleFromPathname(pathname) ?? DEFAULT_LANGUAGE;
+}
+
+function isPathnameMissingLocale(pathname: string) {
+  return locales.every(
+    (locale) =>
+      !pathname.startsWith(`/${locale}/`) &&
+      pathname !== `/${locale}` &&
+      // The root in default locale does not have a locale set
+      pathname !== '/'
+  );
+}
 /**
  * Enforce prefix for default locale 'fi'
  * https://github.com/vercel/next.js/discussions/18419
  * @param req
  */
 const prefixDefaultLocale = async (req: NextRequest) => {
-  // stringify and map dynamic paths to segmented, ie: /venues/:id => /venues/[id]
-  const path = stringifyUrlObject(req.nextUrl);
-  if (Object.keys(redirectRoutes).includes(path)) {
-    // Let redirect routes through without prefixing them with locale
-    return NextResponse.redirect(new URL(path, req.url));
-  } else if (req.nextUrl.locale === 'default') {
+  const url = new URL(req.url);
+  const { pathname, search } = req.nextUrl;
+  const locale = getLocale(req);
+  // Check if there is any supported locale in the pathname
+  const nextUrlPathnameIsMissingLocale = isPathnameMissingLocale(pathname);
+  const requestUrlPathnameIsMissingLocale = isPathnameMissingLocale(
+    url.pathname
+  );
+
+  // Let redirect routes through without prefixing them with locale
+  if (Object.keys(redirectRoutes).includes(pathname)) {
+    return NextResponse.redirect(new URL(pathname, req.url));
+  }
+
+  // The default locale needs to be redirected so that it uses the default language in URL.
+  if (req.nextUrl.locale === 'default') {
     return NextResponse.redirect(
-      new URL(`/${DEFAULT_LANGUAGE}${path}`, req.url)
+      new URL(`/${DEFAULT_LANGUAGE}${pathname}${search}`, req.url)
     );
-  } else if (!path.includes(req.nextUrl.pathname)) {
+  }
+
+  // Redirect if there is no locale.
+  // Redirect is not needed for the default language
+  // If the current full request URL pathname is also missing the locale,
+  // set the default language as a locale.
+  if (
+    nextUrlPathnameIsMissingLocale &&
+    requestUrlPathnameIsMissingLocale &&
+    locale !== DEFAULT_LANGUAGE
+  ) {
+    // e.g. incoming request is /haku
+    // The new URL is now /fi/haku
     return NextResponse.redirect(
-      new URL(`/${req.nextUrl.locale}${path}`, req.url)
+      new URL(`/${DEFAULT_LANGUAGE}${pathname}${search}`, req.url)
     );
   }
 };

--- a/packages/components/src/components/eventHero/EventHero.tsx
+++ b/packages/components/src/components/eventHero/EventHero.tsx
@@ -34,7 +34,7 @@ import {
   getEventPrice,
 } from '../../utils/eventUtils';
 import getDateRangeStr from '../../utils/getDateRangeStr';
-
+import getLocaleFromPathname from '../../utils/getLocaleFromPathname';
 import styles from './eventHero.module.scss';
 
 export type EventHeroProps = {
@@ -77,7 +77,11 @@ const EventHero: React.FC<EventHeroProps> = ({
   const returnParam = extractLatestReturnPath(search, `/${locale}`);
 
   const goBack = ({ returnPath, remainingQueryString = '' }: ReturnParams) => {
-    router.push(`${returnPath}${remainingQueryString}`);
+    const goBackUrl = `${
+      returnPath.startsWith('/') ? '' : '/'
+    }${returnPath}${remainingQueryString}`;
+    const goBackUrlLocale = getLocaleFromPathname(goBackUrl);
+    router.push(goBackUrl, undefined, { locale: goBackUrlLocale });
   };
 
   const startTime =

--- a/packages/components/src/utils/getLocaleFromPathname.ts
+++ b/packages/components/src/utils/getLocaleFromPathname.ts
@@ -1,0 +1,8 @@
+import { APP_LANGUAGES, DEFAULT_LANGUAGE } from '../constants';
+
+/** Get the preferred locale, similar to above or using a library */
+export default function getLocaleFromPathname(pathname: string) {
+  const pattern = `^/?(?<locale>${APP_LANGUAGES.join('|')})/?`;
+  const match = pathname.match(new RegExp(pattern, 'i'));
+  return match?.groups?.locale ?? DEFAULT_LANGUAGE;
+}

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -24,3 +24,4 @@ export * from './headless-cms';
 export { default as stringifyUrlObject } from './stringifyUrlObject';
 export { default as getTranslation } from './getTranslation';
 export { default as getLinkArrowLabel } from './getLinkArrowLabel';
+export { default as getLocaleFromPathname } from './getLocaleFromPathname';


### PR DESCRIPTION
HH-323.

Fixed / refactored the venue and event details
go back- functions so that they handle the locale
better. There was an issue when the UI language
was changed when the user had navigated
from the search page and changed the language in
the details page.
