### PR TITLE
fix: remove publicRuntimeConfig and use environment variables instead

### DIFF
--- a/apps/events-helsinki/.jest/setupTests.ts
+++ b/apps/events-helsinki/.jest/setupTests.ts
@@ -61,15 +61,6 @@ jest.mock('next/head', () => {
   };
 });
 
-// Mock the public runtime config
-jest.mock('next/config', () => () => ({
-  publicRuntimeConfig: {
-    federationRouter: 'https://localhost/federationrouter/',
-    cmsOrigin: 'https://localhost/cms/graphql',
-    linkedEvents: 'https://linkedevents-url.fi',
-  },
-}));
-
 // Extend except with jest-axe
 expect.extend(toHaveNoViolations);
 

--- a/apps/events-helsinki/README.md
+++ b/apps/events-helsinki/README.md
@@ -98,7 +98,7 @@ class AppConfig {
   // ...
   static get linkedEventsEventEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.linkedEvents,
+      process.env.LINKEDEVENTS_EVENT_ENDPOINT,
       "LINKEDEVENTS_EVENT_ENDPOINT"
     );
   }

--- a/apps/events-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/events-helsinki/src/domain/app/AppConfig.ts
@@ -3,9 +3,6 @@ import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { ROUTES } from '../../constants';
 
-// Only holds publicRuntimeConfig
-const { publicRuntimeConfig } = getConfig();
-
 class AppConfig {
   /**
    * The base URL of the CMS.
@@ -17,7 +14,7 @@ class AppConfig {
    * inside the app.
    * */
   static get cmsOrigin() {
-    return getEnvOrError(publicRuntimeConfig.cmsOrigin, 'CMS_ORIGIN');
+    return getEnvOrError(process.env.CMS_ORIGIN, 'CMS_ORIGIN');
   }
 
   /**
@@ -26,7 +23,7 @@ class AppConfig {
    * */
   static get federationGraphqlEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.federationRouter,
+      process.env.FEDERATION_ROUTER_ENDPOINT,
       'FEDERATION_ROUTER_ENDPOINT'
     );
   }
@@ -42,7 +39,7 @@ class AppConfig {
    * */
   static get linkedEventsEventEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.linkedEvents,
+      process.env.LINKEDEVENTS_EVENT_ENDPOINT,
       'LINKEDEVENTS_EVENT_ENDPOINT'
     );
   }

--- a/apps/hobbies-helsinki/.jest/setupTests.ts
+++ b/apps/hobbies-helsinki/.jest/setupTests.ts
@@ -61,15 +61,6 @@ jest.mock('next/head', () => {
   };
 });
 
-// Mock the public runtime config
-jest.mock('next/config', () => () => ({
-  publicRuntimeConfig: {
-    federationRouter: 'https://localhost/federationrouter/',
-    cmsOrigin: 'https://localhost/cms/graphql',
-    linkedEvents: 'https://linkedevents-url.fi',
-  },
-}));
-
 // https://stackoverflow.com/questions/67872622/jest-spyon-not-working-on-index-file-cannot-redefine-property/69951703#69951703
 jest.mock('@events-helsinki/components/hooks/useLocale', () => ({
   __esModule: true,

--- a/apps/hobbies-helsinki/README.md
+++ b/apps/hobbies-helsinki/README.md
@@ -105,7 +105,7 @@ class AppConfig {
   // ...
   static get linkedEventsEventEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.linkedEvents,
+      process.env.LINKEDEVENTS_EVENT_ENDPOINT,
       "LINKEDEVENTS_EVENT_ENDPOINT"
     );
   }

--- a/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
@@ -3,9 +3,6 @@ import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { ROUTES } from '../../constants';
 
-// Only holds publicRuntimeConfig
-const { publicRuntimeConfig } = getConfig();
-
 class AppConfig {
   /**
    * The base URL of the CMS.
@@ -17,7 +14,7 @@ class AppConfig {
    * inside the app.
    * */
   static get cmsOrigin() {
-    return getEnvOrError(publicRuntimeConfig.cmsOrigin, 'CMS_ORIGIN');
+    return getEnvOrError(process.env.CMS_ORIGIN, 'CMS_ORIGIN');
   }
 
   /**
@@ -26,7 +23,7 @@ class AppConfig {
    * */
   static get federationGraphqlEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.federationRouter,
+      process.env.FEDERATION_ROUTER_ENDPOINT,
       'FEDERATION_ROUTER_ENDPOINT'
     );
   }
@@ -42,7 +39,7 @@ class AppConfig {
    * */
   static get linkedEventsEventEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.linkedEvents,
+      process.env.LINKEDEVENTS_EVENT_ENDPOINT,
       'LINKEDEVENTS_EVENT_ENDPOINT'
     );
   }

--- a/apps/sports-helsinki/.jest/setupTests.ts
+++ b/apps/sports-helsinki/.jest/setupTests.ts
@@ -61,15 +61,6 @@ jest.mock('next/head', () => {
   };
 });
 
-// Mock the public runtime config
-jest.mock('next/config', () => () => ({
-  publicRuntimeConfig: {
-    federationRouter: 'https://localhost/federationrouter/',
-    cmsOrigin: 'https://localhost/cms/graphql',
-    linkedEvents: 'https://linkedevents-url.fi',
-  },
-}));
-
 // https://stackoverflow.com/questions/67872622/jest-spyon-not-working-on-index-file-cannot-redefine-property/69951703#69951703
 jest.mock('@events-helsinki/components/hooks/useLocale', () => ({
   __esModule: true,

--- a/apps/sports-helsinki/README.md
+++ b/apps/sports-helsinki/README.md
@@ -264,7 +264,7 @@ class AppConfig {
   // ...
   static get linkedEventsEventEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.linkedEvents,
+      process.env.LINKEDEVENTS_EVENT_ENDPOINT,
       "LINKEDEVENTS_EVENT_ENDPOINT"
     );
   }

--- a/apps/sports-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/sports-helsinki/src/domain/app/AppConfig.ts
@@ -4,9 +4,6 @@ import getConfig from 'next/config';
 import { i18n } from '../../../next-i18next.config';
 import { ROUTES } from '../../constants';
 
-// Only holds publicRuntimeConfig
-const { publicRuntimeConfig } = getConfig();
-
 class AppConfig {
   /**
    * The base URL of the CMS.
@@ -18,7 +15,7 @@ class AppConfig {
    * inside the app.
    * */
   static get cmsOrigin() {
-    return getEnvOrError(publicRuntimeConfig.cmsOrigin, 'CMS_ORIGIN');
+    return getEnvOrError(process.env.CMS_ORIGIN, 'CMS_ORIGIN');
   }
 
   /**
@@ -27,7 +24,7 @@ class AppConfig {
    * */
   static get federationGraphqlEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.federationRouter,
+      process.env.FEDERATION_ROUTER_ENDPOINT,
       'FEDERATION_ROUTER_ENDPOINT'
     );
   }
@@ -43,7 +40,7 @@ class AppConfig {
    * */
   static get linkedEventsEventEndpoint() {
     return getEnvOrError(
-      publicRuntimeConfig.linkedEvents,
+      process.env.LINKEDEVENTS_EVENT_ENDPOINT,
       'LINKEDEVENTS_EVENT_ENDPOINT'
     );
   }

--- a/next.base.config.js
+++ b/next.base.config.js
@@ -274,12 +274,6 @@ const nextBaseConfig = ({
       // to bypass https://github.com/zeit/next.js/issues/8251
       PROJECT_ROOT: __dirname,
     },
-    publicRuntimeConfig: {
-      // Will be available on both server and client
-      federationRouter: process.env.FEDERATION_ROUTER_ENDPOINT,
-      cmsOrigin: process.env.CMS_ORIGIN,
-      linkedEvents: process.env.LINKEDEVENTS_EVENT_ENDPOINT,
-    },
   };
 
   let config = { ...nextConfig, ...overrideConfig };


### PR DESCRIPTION
## Description

Federation router environment variable is fixed on production container. Most probably because values are solved during build time

https://nextjs.org/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
