### PR TITLE
fix(venues-proxy): venuesByIds should not return empty venues

### DIFF
--- a/proxies/venue-graphql-proxy/src/resolvers/venuesByIdsResolver.ts
+++ b/proxies/venue-graphql-proxy/src/resolvers/venuesByIdsResolver.ts
@@ -21,11 +21,14 @@ const venusByIdsResolver = async (
   resolveInfo: GraphQLResolveInfo
 ) => {
   const venueIds = (params as { ids: string[] }).ids;
-  return await Promise.all(
+  const venues = await Promise.all(
     venueIds.map((idWithSource: string) =>
       venueQueryResolver(source, { id: idWithSource }, context, resolveInfo)
     )
   );
+  // Filter the "empty venues" (look for EMPTY_VENUE_DETAILS),
+  // because any client should never have any need for those.
+  return venues.filter((venue) => venue?.id);
 };
 
 export default venusByIdsResolver;


### PR DESCRIPTION
LIIKUNTA-551

The venue resolver can return an "empty venue"
in some cases when the datasource has not listed
the requested venue or it is not with the same id
as it is in another source. In those cases, also
the venuesByIds query gets empty venues in the
list that it returns, but no client should never ever
have any need for the empty venue details, so it
can be removed.

----

To set a local venue proxy and a local federation router, start the venue-proxy locally and the router with `"docker:graphql-router:sports:serve": "cross-env FEDERATION_CMS_ROUTING_URL=https://liikunta.hkih.stage.geniem.io/graphql FEDERATION_EVENTS_ROUTING_URL=https://events-graphql-proxy.test.hel.ninja/proxy/graphql FEDERATION_UNIFIED_SEARCH_ROUTING_URL=https://kuva-unified-search.api.test.hel.ninja/search FEDERATION_VENUES_ROUTING_URL=http://docker.for.mac.localhost:4200/proxy/graphql docker-compose -f docker-compose.router.yml up",`