### PR TITLE
refactor: test clean function uniqueness, simplify venue proxy types

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -47,6 +47,10 @@ describe('CombinedSearchFormAdapter', () => {
       }
     });
 
+    it('field specific clean functions should have unique names', () => {
+      expect(cleanFunctionNames).toHaveLength(new Set(cleanFunctionNames).size);
+    });
+
     it('field specific clean functions take no parameters', () => {
       const adapter = new CombinedSearchFormAdapter(locale, input);
       for (const cleanFunctionName of cleanFunctionNames) {

--- a/packages/components/src/utils/typescript.utils.ts
+++ b/packages/components/src/utils/typescript.utils.ts
@@ -11,6 +11,15 @@ export const skipFalsyType = <ValueType>(
 };
 
 /**
+ * Extract prefixes from strings that are suffixed with underscore and any given locale.
+ * @example ExtractPrefixesFromLocaleSuffixedNames<'a_fi' | 'b_sv' | 'c'> == 'a' | 'b'
+ */
+export type ExtractPrefixesFromLocaleSuffixedNames<
+  T extends string,
+  Locale extends string = 'fi' | 'en' | 'sv'
+> = T extends `${infer Prefix}_${Locale}` ? Prefix : never;
+
+/**
  * Check at compile time that Subtype is a subset of Supertype or not.
  * @warning This works with string literal types, but not necessarily with all types
  * @return Subtype if Subtype is a subset of Supertype, otherwise raise an error.
@@ -25,8 +34,46 @@ type BC = { b: string; c: string };
 type ABC = AB & BC;
 type EnFr = 'en' | 'fr';
 
+type Translatable = {
+  a_en: string;
+  b_en: string;
+  b_fr: string;
+  c: string;
+};
+
+type TestCombos =
+  | 'EnFi_en'
+  | 'EnFi_fi'
+  | 'EnFiSv_en'
+  | 'EnFiSv_fi'
+  | 'EnFiSv_sv'
+  | 'EnSv_en'
+  | 'EnSv_sv'
+  | 'FiSv_fi'
+  | 'FiSv_sv'
+  | 'OnlyEn_en'
+  | 'OnlyFi_fi'
+  | 'OnlySv_sv'
+  | 'ShouldNotShow sv'
+  | 'ShouldNotShow'
+  | 'ShouldNotShow-en'
+  | 'ShouldNotShow_'
+  | 'ShouldNotShow_ending'
+  | 'ShouldNotShow_finishing'
+  | 'ShouldNotShow_svenska'
+  | 'ShouldNotShowfi';
+
+type ExpectedPrefixes =
+  | 'EnFi'
+  | 'EnFiSv'
+  | 'EnSv'
+  | 'FiSv'
+  | 'OnlyEn'
+  | 'OnlyFi'
+  | 'OnlySv';
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type SubsetTests = [
+type Tests = [
   // Equal sets:
   Subset<'a', 'a'>,
   Subset<'a' | 'b' | 'c', 'a' | 'b' | 'c'>,
@@ -47,5 +94,25 @@ type SubsetTests = [
   // @ts-expect-error keyof AB is not a subset of keyof BC
   Subset<keyof BC, keyof AB>,
   // @ts-expect-error `${keyof AB}_${EnFr}` is not a subset of 'a_fr' | 'b_en' | 'b_fr'
-  Subset<'a_fr' | 'b_en' | 'b_fr', `${keyof AB}_${EnFr}`>
+  Subset<'a_fr' | 'b_en' | 'b_fr', `${keyof AB}_${EnFr}`>,
+  // Prefixes from Translatable should be 'a' and 'b' using default locale selection:
+  Subset<ExtractPrefixesFromLocaleSuffixedNames<keyof Translatable>, 'a' | 'b'>,
+  Subset<'a' | 'b', ExtractPrefixesFromLocaleSuffixedNames<keyof Translatable>>,
+  // Prefixes from Translatable should be 'a' and 'b' using 'en' and 'fr' locales
+  Subset<
+    ExtractPrefixesFromLocaleSuffixedNames<keyof Translatable, EnFr>,
+    'a' | 'b'
+  >,
+  Subset<
+    'a' | 'b',
+    ExtractPrefixesFromLocaleSuffixedNames<keyof Translatable, EnFr>
+  >,
+  // Prefixes from Translatable should be 'b' using 'fr' locale
+  Subset<ExtractPrefixesFromLocaleSuffixedNames<keyof Translatable, 'fr'>, 'b'>,
+  Subset<'b', ExtractPrefixesFromLocaleSuffixedNames<keyof Translatable, 'fr'>>,
+  // Prefixes from TestCombos should be ExpectedPrefixes
+  Subset<ExtractPrefixesFromLocaleSuffixedNames<TestCombos>, ExpectedPrefixes>,
+  Subset<ExpectedPrefixes, ExtractPrefixesFromLocaleSuffixedNames<TestCombos>>,
+  // @ts-expect-error 'ShouldNotShow' should not be found as a prefix from TestCombos
+  Subset<ExtractPrefixesFromLocaleSuffixedNames<TestCombos>, 'ShouldNotShow'>
 ];

--- a/proxies/venue-graphql-proxy/src/types.ts
+++ b/proxies/venue-graphql-proxy/src/types.ts
@@ -1,4 +1,3 @@
-import type { Subset } from '@events-helsinki/components/src/utils/typescript.utils';
 import type { Sources } from './contants/constants';
 import type { Ontology, Point } from './types/types';
 
@@ -141,30 +140,6 @@ export type TprekUnitWithoutNull = {
   phone?: string;
   picture_url?: string;
 };
-
-export type TprekUnitTranslatableFields =
-  | 'address_city'
-  | 'address_postal_full'
-  | 'desc'
-  | 'displayed_service_owner'
-  | 'name'
-  | 'short_desc'
-  | 'street_address'
-  | 'www';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type UnitHasTranslatableFieldsWithLocaleSuffix = Subset<
-  keyof TprekUnitWithoutNull,
-  `${TprekUnitTranslatableFields}_${Locale}`
->;
-
-export type TprekUnitConnectionTranslatableFields = 'name' | 'www';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ConnectionHasTranslatableFieldsWithLocaleSuffix = Subset<
-  keyof TprekUnitConnection,
-  `${TprekUnitConnectionTranslatableFields}_${Locale}`
->;
 
 export type TprekUnit = TprekUnitWithoutNull | null;
 

--- a/proxies/venue-graphql-proxy/src/utils/utils.ts
+++ b/proxies/venue-graphql-proxy/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import type { ExtractPrefixesFromLocaleSuffixedNames } from '@events-helsinki/components/src/utils/typescript.utils';
 import get from 'lodash/get';
 import AppConfig from '../config/AppConfig';
 import { Sources } from '../contants/constants';
@@ -11,9 +12,7 @@ import type {
   TranslatableVenueDetails,
   TranslationsObject,
   TranslatedVenueDetails,
-  TprekUnitTranslatableFields,
   TprekUnitConnection,
-  TprekUnitConnectionTranslatableFields,
 } from '../types';
 import type { Point } from '../types/types';
 
@@ -40,9 +39,9 @@ const LOCALIZED_SENTENCE_NAME: Record<
 type TranslatableObjectType = TprekUnitWithoutNull | TprekUnitConnection;
 type TranslatableFieldsFor<T extends TranslatableObjectType> =
   T extends TprekUnitWithoutNull
-    ? TprekUnitTranslatableFields
+    ? ExtractPrefixesFromLocaleSuffixedNames<keyof TprekUnitWithoutNull, Locale>
     : T extends TprekUnitConnection
-    ? TprekUnitConnectionTranslatableFields
+    ? ExtractPrefixesFromLocaleSuffixedNames<keyof TprekUnitConnection, Locale>
     : never;
 
 export function formTranslationObject<


### PR DESCRIPTION
## Description

### refactor: test clean function uniqueness, simplify venue proxy types

refs LIIKUNTA-488, LIIKUNTA-548

## Issues

### Closes

### Related

**[LIIKUNTA-488](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-488)**
**[LIIKUNTA-548](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-548)**

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-488]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIIKUNTA-548]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ