### PR TITLE
LIIKUNTA-467 | feat(askem): enable Askem in staging & production, fix typos in READMEs

### DIFF
--- a/apps/events-helsinki/README.md
+++ b/apps/events-helsinki/README.md
@@ -25,7 +25,7 @@ This is a [Next.js](https://nextjs.org/) project originally bootstrapped with [`
 
 ### Route (pages)
 
-The pages are served with some server side rendering (SSR) mechanism to offer better search engine optimization (SEO) and fast user friendly UI.
+The pages are served with some server side rendering (SSR) mechanism to offer better search engine optimization (SEO) and fast user-friendly UI.
 The pre-rendering process that we mostly use here is SSG - "automatically generated as static HTML + JSON (uses getStaticProps)".
 The server side rendered pages are under the [pages](./src/pages/) -directory. More about NextJS's data fetching in https://nextjs.org/docs/basic-features/data-fetching/overview.
 

--- a/apps/hobbies-helsinki/README.md
+++ b/apps/hobbies-helsinki/README.md
@@ -25,7 +25,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ### Route (pages)
 
-The pages are served with some server side rendering (SSR) mechanism to offer better search engine optimization (SEO) and fast user friendly UI.
+The pages are served with some server side rendering (SSR) mechanism to offer better search engine optimization (SEO) and fast user-friendly UI.
 The pre-rendering process that we mostly use here is SSG - "automatically generated as static HTML + JSON (uses getStaticProps)".
 The server side rendered pages are under the [pages](./src/pages/) -directory. More about NextJS's data fetching in https://nextjs.org/docs/basic-features/data-fetching/overview.
 

--- a/apps/sports-helsinki/README.md
+++ b/apps/sports-helsinki/README.md
@@ -29,7 +29,7 @@ Note that the 1st production deployment from the monorepo will be done while con
 
 ### Route (pages)
 
-The pages are served with some server side rendering (SSR) mechanism to offer better search engine optimization (SEO) and fast user friendly UI.
+The pages are served with some server side rendering (SSR) mechanism to offer better search engine optimization (SEO) and fast user-friendly UI.
 The pre-rendering process that we mostly use here is SSG - "automatically generated as static HTML + JSON (uses getStaticProps)".
 The server side rendered pages are under the [pages](./src/pages/) -directory. More about NextJS's data fetching in https://nextjs.org/docs/basic-features/data-fetching/overview.
 


### PR DESCRIPTION
## Description

### feat(askem): enable Askem in staging & production, fix typos in READMEs

NOTE: This is a sort of a dummy commit! See the rationale:
 - This corrects a word in each apps' README.md files to trigger the release-please action in order to be able to release the Askem enabling from 323f6f546939b0586f9d52438795e0b4da6d1d89 through the normal release process.

refs LIIKUNTA-467

## Issues

### Closes

**[LIIKUNTA-467](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-467)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-467]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ