### PR TITLE
refactor(search): superEventType and superEvent params usage

### DIFF
--- a/apps/events-helsinki/config/jest/mocks/eventListMocks.ts
+++ b/apps/events-helsinki/config/jest/mocks/eventListMocks.ts
@@ -26,7 +26,7 @@ export const baseVariables = {
   sort: DEFAULT_EVENT_SORT_OPTION,
   start: 'now',
   startsAfter: undefined,
-  superEventType: ['umbrella', 'none'],
+  // superEventType: ['umbrella', 'none'], // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
 };
 
 export const eventListBaseVariables: QueryEventListArgs = {

--- a/apps/events-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
+++ b/apps/events-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
@@ -24,7 +24,8 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
       pageSize: 100, // TODO: use SIMILAR_EVENTS_AMOUNT when LinkedEvents-query with keyword_OR_set* -param is fixed and it returns distinct results
       params: new URLSearchParams(searchParams),
       sortOrder: EVENT_SORT_OPTIONS.END_TIME,
-      superEventType: ['umbrella', 'none'],
+      // superEventType: ['umbrella', 'none'] // Don't use superEventType when experimenting LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
+      // superEvent: 'none', // Only the course type search should use this param; LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
     });
   }, [event]);
 };

--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -56,7 +56,8 @@ const SearchPage: React.FC<{
       sortOrder: isEventSortOption(sortParam)
         ? sortParam
         : DEFAULT_EVENT_SORT_OPTION,
-      superEventType: ['umbrella', 'none'],
+      // superEventType: ['umbrella', 'none'] // Don't use superEventType when experimenting LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
+      // superEvent: 'none', // Only the course type search should use this param; LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
     });
     return variables;
   }, [router.query, params.place]);

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -138,6 +138,7 @@ export const getEventSearchVariables = ({
   params,
   sortOrder,
   superEventType,
+  superEvent,
   place,
 }: {
   include: string[];
@@ -145,7 +146,8 @@ export const getEventSearchVariables = ({
   pageSize: number;
   params: URLSearchParams;
   sortOrder: EVENT_SORT_OPTIONS;
-  superEventType: string[];
+  superEventType?: string[];
+  superEvent?: string;
   place?: string;
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }): QueryEventListArgs => {
@@ -238,6 +240,7 @@ export const getEventSearchVariables = ({
     start,
     startsAfter,
     superEventType,
+    superEvent,
     eventType: AppConfig.supportedEventTypes,
   };
 };

--- a/apps/hobbies-helsinki/config/jest/mocks/eventListMocks.ts
+++ b/apps/hobbies-helsinki/config/jest/mocks/eventListMocks.ts
@@ -25,7 +25,8 @@ export const baseVariables = {
   sort: 'end_time',
   start: 'now',
   startsAfter: undefined,
-  superEventType: ['umbrella', 'none'],
+  // superEventType: ['umbrella', 'none'], // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
+  superEvent: 'none', // Added for courses in LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
 };
 
 export const eventListBaseVariables: QueryEventListArgs = {

--- a/apps/hobbies-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
@@ -29,7 +29,8 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
         pageSize: 100, // TODO: use SIMILAR_EVENTS_AMOUNT when LinkedEvents-query with keyword_OR_set* -param is fixed and it returns distinct results
         params: new URLSearchParams(searchParams),
         sortOrder: EVENT_SORT_OPTIONS.END_TIME,
-        superEventType: ['umbrella', 'none'],
+        // superEventType: ['umbrella', 'none'] // Don't use superEventType when experimenting LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
+        superEvent: 'none', // Set the superEvent param to "none" for courses; LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
       }),
       [EVENT_SEARCH_FILTERS.SUITABLE]: [],
     };

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -52,7 +52,8 @@ const SearchPage: React.FC<{
       params: searchParams,
       place: params.place,
       sortOrder: EVENT_SORT_OPTIONS.END_TIME,
-      superEventType: ['umbrella', 'none'],
+      // superEventType: ['umbrella', 'none'] // Don't use superEventType when experimenting LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
+      superEvent: 'none', // Set the superEvent param to "none" for courses; LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
     });
     return variables;
   }, [router.query, params.place]);

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -177,6 +177,7 @@ export const getEventSearchVariables = ({
   params,
   sortOrder,
   superEventType,
+  superEvent,
   place,
 }: {
   include: string[];
@@ -184,7 +185,8 @@ export const getEventSearchVariables = ({
   pageSize: number;
   params: URLSearchParams;
   sortOrder: EVENT_SORT_OPTIONS;
-  superEventType: string[];
+  superEventType?: string[];
+  superEvent?: string;
   place?: string;
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }): QueryEventListArgs => {
@@ -285,6 +287,7 @@ export const getEventSearchVariables = ({
     start,
     startsAfter,
     superEventType,
+    superEvent,
     suitableFor: [Number(audienceMinAgeLt), Number(audienceMaxAgeGt)].filter(
       (v) => v
     ),

--- a/apps/sports-helsinki/config/jest/mocks/eventListMocks.ts
+++ b/apps/sports-helsinki/config/jest/mocks/eventListMocks.ts
@@ -20,7 +20,7 @@ export const baseVariables = {
   publisher: null,
   sort: 'end_time',
   start: 'now',
-  superEventType: ['umbrella', 'none'],
+  // superEventType: ['umbrella', 'none'], // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
 };
 
 export const eventListBaseVariables: QueryEventListArgs = {

--- a/apps/sports-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -120,6 +120,7 @@ const mocks = [
       allOngoing: true,
       keywordOrSet2: eventKeywordIds,
       eventType: [EventTypeId.Course],
+      superEvent: 'none',
       pageSize: 100,
     },
     response: similarEvents,

--- a/apps/sports-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
+++ b/apps/sports-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
@@ -1,4 +1,5 @@
 import { EVENT_SORT_OPTIONS } from '@events-helsinki/components/constants/event-constants';
+import { EventTypeId } from '@events-helsinki/components/types';
 import type { EventFields } from '@events-helsinki/components/types/event-types';
 import React from 'react';
 import { EVENT_SEARCH_FILTERS } from '../search/eventSearch/constants';
@@ -25,7 +26,8 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
         pageSize: 100, // TODO: use SIMILAR_EVENTS_AMOUNT when LinkedEvents-query with keyword_OR_set* -param is fixed and it returns distinct results
         params: new URLSearchParams(searchParams),
         sortOrder: EVENT_SORT_OPTIONS.END_TIME,
-        superEventType: ['umbrella', 'none'],
+        // superEventType: ['umbrella', 'none'] // Don't use superEventType when experimenting LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
+        superEvent: event.typeId === EventTypeId.Course ? 'none' : undefined, // Only the course type search should use this param; LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
         eventType: event.typeId ? [event.typeId] : undefined,
       }),
       // Set to undefined, because keywordOrSet1 contains SPORT_COURSES_KEYWORDS, which shouldn't

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
@@ -33,6 +33,7 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
   sort: EventSearchParams['sort'];
   eventType: EventSearchParams['eventType'];
   superEventType: EventSearchParams['superEventType'];
+  superEvent: EventSearchParams['superEvent'];
   publisher: EventSearchParams['publisher'];
   publisherAncestor: EventSearchParams['publisherAncestor'];
   page: EventSearchParams['page'];
@@ -69,6 +70,18 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
     this.publisherAncestor = input.helsinkiOnly
       ? CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID
       : initialEventSearchAdapterValues.publisherAncestor;
+    this.superEvent = this.getSuperEvent(eventType);
+  }
+
+  /**
+   * If the search is for Courses,
+   * the superEvent should be set to 'none' -
+   * LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
+   * */
+  public getSuperEvent(eventType: EventTypeId) {
+    if (eventType === EventTypeId.Course) {
+      return 'none';
+    }
   }
 
   public getSportsKeywords({ sportsCategories }: CombinedSearchAdapterInput) {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -159,7 +159,7 @@ describe('CombinedSearchFormAdapter', () => {
           publisher: null,
           publisherAncestor: null,
           include: ['keywords', 'location'],
-          superEventType: ['umbrella', 'none'],
+          // superEventType: ['umbrella', 'none'], // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
         },
       ],
     ])(

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
@@ -19,7 +19,7 @@ describe('EventSearchAdapter', () => {
           keywords: [],
         };
         const adapter = new EventSearchAdapter(input, eventType);
-        expect(adapter.getQueryVariables()).toStrictEqual({
+        const result = {
           eventType,
           allOngoingAnd: [input.text],
           start: 'now',
@@ -69,10 +69,18 @@ describe('EventSearchAdapter', () => {
           publisher: null,
           publisherAncestor: 'ahjo:00001',
           include: ['keywords', 'location'],
-          superEventType: ['umbrella', 'none'],
+          // superEventType: ['umbrella', 'none'], // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
+          superEvent: eventType === EventTypeId.Course ? 'none' : undefined, // Added for courses in LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
           sort:
             eventType === EventTypeId.General ? input.eventOrderBy : 'end_time',
-        });
+        };
+        // Remove undefined keys
+        Object.keys(result).forEach(
+          (key) =>
+            result[key as keyof typeof result] === undefined &&
+            delete result[key as keyof typeof result]
+        );
+        expect(adapter.getQueryVariables()).toStrictEqual(result);
       }
     );
   });

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`CombinedSearchProvider reads the context properly 1`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;
@@ -35,17 +35,17 @@ exports[`CombinedSearchProvider reads the context properly 2`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":["test text"],"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;
@@ -60,17 +60,17 @@ exports[`CombinedSearchProvider reads the context properly 3`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEventType":["umbrella","none"],"publisher":"testorg","publisherAncestor":null,"pageSize":10}
+    {"allOngoingAnd":[],"allOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10}
   </p>
 </div>
 `;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
@@ -54,7 +54,8 @@ export const initialEventSearchAdapterValues: EventSearchParams = {
   location: [],
   sort: EVENT_SORT_OPTIONS.END_TIME,
   eventType: EventTypeId.General,
-  superEventType: ['umbrella', 'none'],
+  superEventType: undefined, // Don't use superEventType when experimenting LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
+  superEvent: undefined, // Only the course type search should use this param; LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
   publisher: null,
   publisherAncestor: null,
   pageSize: 10,

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -84,6 +84,7 @@ export type EventSearchParams = Pick<
   | 'sort'
   | 'eventType'
   | 'superEventType'
+  | 'superEvent'
   | 'publisher'
   | 'publisherAncestor'
   | 'page'

--- a/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -154,6 +154,7 @@ export const getEventSearchVariables = ({
   params,
   sortOrder,
   superEventType,
+  superEvent,
   place,
   eventType,
 }: {
@@ -162,7 +163,8 @@ export const getEventSearchVariables = ({
   pageSize: number;
   params: URLSearchParams;
   sortOrder: EVENT_SORT_OPTIONS;
-  superEventType: string[];
+  superEventType?: string[];
+  superEvent?: string;
   place?: string;
   eventType?: (EventTypeId.Course | EventTypeId.General)[];
   // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -239,6 +241,7 @@ export const getEventSearchVariables = ({
     sort: sortOrder,
     start,
     superEventType,
+    superEvent,
     eventType,
   };
 };

--- a/apps/sports-helsinki/src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx
+++ b/apps/sports-helsinki/src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx
@@ -21,7 +21,7 @@ const similarEventQueryVariables = {
   include: ['keywords', 'location'],
   start: 'now',
   sort: EVENT_SORT_OPTIONS.END_TIME,
-  superEventType: 'none',
+  // superEventType: 'none', // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   pageSize: 6,
   end: undefined,
   isFree: undefined,

--- a/packages/components/config/tests/mocks/eventListMocks.ts
+++ b/packages/components/config/tests/mocks/eventListMocks.ts
@@ -24,7 +24,7 @@ export const baseVariables = {
   sort: DEFAULT_EVENT_SORT_OPTION,
   start: 'now',
   startsAfter: undefined,
-  superEventType: ['umbrella', 'none'],
+  // superEventType: ['umbrella', 'none'], // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
 };
 
 export const eventListBaseVariables: QueryEventListArgs = {

--- a/packages/components/src/components/domain/event/queryUtils.ts
+++ b/packages/components/src/components/domain/event/queryUtils.ts
@@ -219,7 +219,7 @@ export const useLocationUpcomingEventsQuery = ({
     include: ['keywords', 'location'],
     start: 'now',
     sort: EVENT_SORT_OPTIONS.END_TIME,
-    superEventType: 'none',
+    // superEventType: 'none', // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
     pageSize,
   };
   return useEventListQuery({ variables, ssr: false });

--- a/packages/components/src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
+++ b/packages/components/src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
@@ -73,7 +73,7 @@ const similarEventFilters = {
   publisher: null,
   sort: 'end_time',
   start: 'now',
-  superEventType: ['umbrella', 'none'],
+  // superEventType: ['umbrella', 'none'], // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   keywordOrSet2: [''],
   allOngoing: true,
   keywordOrSet3: [''],


### PR DESCRIPTION
LIIKUNTA-512.

Remove a superEventType-param from all
event searches no matter the type.
Add a superEvent-param for courses.

The changes are affecting the main event search
and the similar events search.