### PR TITLE
feat: false structured events can be ignored by using http-headers

### DIFF
--- a/packages/graphql-proxy-server/src/constants.ts
+++ b/packages/graphql-proxy-server/src/constants.ts
@@ -1,1 +1,7 @@
+import { CustomIgnorableGraphQLErrorEnum } from './enums';
 export const X_REQUEST_ID = 'X-Request-ID';
+// Use this header name to add GraphQL error codes that should not throw the error when it occures
+export const X_IGNORED_ERROR_CODE = 'x-ignored-error-code';
+export const ignorableGraphqlErrorCodes = Object.values<string>(
+  CustomIgnorableGraphQLErrorEnum
+);

--- a/packages/graphql-proxy-server/src/context/ContextValue.ts
+++ b/packages/graphql-proxy-server/src/context/ContextValue.ts
@@ -1,9 +1,13 @@
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
 import type { AppLanguage } from '@events-helsinki/components/src/types/types';
+import { ignorableGraphqlErrorCodes } from '../constants';
+import type { CustomIgnorableGraphQLErrorValues } from '../types';
+
 export type ContextConstructorArgs = {
   token: string;
   cache?: KeyValueCache;
   language?: AppLanguage;
+  ignoredErrorCodes?: string | string[];
 };
 abstract class ContextValue<DataSources> {
   public readonly token: string;
@@ -13,16 +17,41 @@ abstract class ContextValue<DataSources> {
   // The translation object will be returned as a string
   // and the language from the context is used to select the right translation.
   public readonly language?: AppLanguage;
+  public readonly ignoredErrorCodes?: CustomIgnorableGraphQLErrorValues[];
 
   public X_REQUEST_ID?: string;
 
   protected abstract initializeDataSources(): DataSources;
 
-  public constructor({ token, cache, language }: ContextConstructorArgs) {
+  public constructor({
+    token,
+    cache,
+    language,
+    ignoredErrorCodes,
+  }: ContextConstructorArgs) {
     this.token = token;
     this.cache = cache;
     this.dataSources = this.initializeDataSources();
     this.language = language;
+    this.ignoredErrorCodes = this.parseIgnoreErrorCodes(ignoredErrorCodes);
+  }
+
+  private parseIgnoreErrorCodes(
+    ignoredErrorCodes?: ContextConstructorArgs['ignoredErrorCodes']
+  ) {
+    if (Array.isArray(ignoredErrorCodes)) {
+      return ignoredErrorCodes.filter((code) =>
+        ignorableGraphqlErrorCodes.includes(code)
+      ) as CustomIgnorableGraphQLErrorValues[];
+    }
+    if (ignoredErrorCodes && typeof ignoredErrorCodes === 'string') {
+      return ignoredErrorCodes
+        ?.split(',')
+        .filter((code) =>
+          ignorableGraphqlErrorCodes.includes(code)
+        ) as CustomIgnorableGraphQLErrorValues[];
+    }
   }
 }
+
 export default ContextValue;

--- a/packages/graphql-proxy-server/src/enums.ts
+++ b/packages/graphql-proxy-server/src/enums.ts
@@ -1,0 +1,3 @@
+export enum CustomIgnorableGraphQLErrorEnum {
+  UnpopulatedMandatoryData = 'UNPOPULATED_MANDATORY_DATA',
+}

--- a/packages/graphql-proxy-server/src/error/IgnorableGraphQLError.ts
+++ b/packages/graphql-proxy-server/src/error/IgnorableGraphQLError.ts
@@ -1,0 +1,34 @@
+import type { GraphQLErrorOptions } from 'graphql';
+import { GraphQLError } from 'graphql';
+
+export class IgnorableGraphQLError extends GraphQLError {
+  readonly ignoredCodes: string[];
+
+  constructor(
+    message: string,
+    options: GraphQLErrorOptions,
+    ignoredCodes: string[]
+  ) {
+    super(message, options);
+    this.ignoredCodes = ignoredCodes;
+  }
+
+  /** Throw a GraphQLError if the code is not included in the ignored error codes. */
+  public throwConditionally() {
+    const code = this.extensions.code as string;
+    if (!this.ignoredCodes.includes(code)) {
+      throw new GraphQLError(this.message, {
+        nodes: this.nodes,
+        source: this.source,
+        positions: this.positions,
+        path: this.path,
+        originalError: this.originalError,
+        extensions: this.extensions,
+      });
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `The IgnorableGraphQLError skipped error throwing with a message: "${this.message}"`
+    );
+  }
+}

--- a/packages/graphql-proxy-server/src/index.ts
+++ b/packages/graphql-proxy-server/src/index.ts
@@ -1,5 +1,9 @@
 export { startServer } from './server';
 export * from './server-config/server-config';
 export * from './utils';
+export * from './enums';
+export * from './constants';
+export * from './types';
+export { IgnorableGraphQLError } from './error/IgnorableGraphQLError';
 export { default as ContextValue } from './context/ContextValue';
 export { default as DataSourceWithContext } from './datasources/DataSourceWithContext';

--- a/packages/graphql-proxy-server/src/server-config/server-config.ts
+++ b/packages/graphql-proxy-server/src/server-config/server-config.ts
@@ -1,3 +1,4 @@
+import type { ApolloServerOptions } from '@apollo/server';
 import type { AppLanguage } from '@events-helsinki/components/src/types/types';
 type SentryConfig = {
   sentryDsn?: string; // process.env.GRAPHQL_PROXY_SENTRY_DSN
@@ -19,6 +20,7 @@ export type ServerConfig = SentryConfig &
     serverPort: number; // process.env.GRAPHQL_PROXY_PORT
     disableWinstonLogging?: boolean; // process.env.GRAPHQL_PROXY_DISABLE_WINSTON_LOGGING
     introspection?: boolean; // process.env.GRAPHQL_PROXY_INTROSPECTION
+    formatError?: ApolloServerOptions<object>['formatError'];
   };
 
 // singleton pattern

--- a/packages/graphql-proxy-server/src/server.ts
+++ b/packages/graphql-proxy-server/src/server.ts
@@ -8,6 +8,7 @@ import cors from 'cors';
 import express from 'express';
 import type { GraphQLSchema } from 'graphql';
 import depthLimit from 'graphql-depth-limit';
+import { X_IGNORED_ERROR_CODE } from './constants';
 import type ContextValue from './context/ContextValue';
 import type { ContextConstructorArgs } from './context/ContextValue';
 import apolloLoggingPlugin from './plugins/apolloLoggingPlugin';
@@ -64,6 +65,7 @@ export const startServer = async <
     ],
     validationRules: [depthLimit(10)],
     introspection: serverConfig.introspection,
+    formatError: serverConfig.formatError,
   });
 
   await server.start();
@@ -81,6 +83,7 @@ export const startServer = async <
           // The translation object will be returned as a string
           // and the language from the context is used to select the right translation.
           language: acceptsLanguage(req, config?.languages ?? []),
+          ignoredErrorCodes: req.headers[X_IGNORED_ERROR_CODE],
         }),
     })
   );

--- a/packages/graphql-proxy-server/src/types.ts
+++ b/packages/graphql-proxy-server/src/types.ts
@@ -1,0 +1,4 @@
+import type { CustomIgnorableGraphQLErrorEnum } from './enums';
+
+export type CustomIgnorableGraphQLErrorValues =
+  `${CustomIgnorableGraphQLErrorEnum}`;

--- a/proxies/events-graphql-proxy/package.json
+++ b/proxies/events-graphql-proxy/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf --no-glob ./tsconfig.tsbuildinfo",
     "build": "cross-env NODE_ENV=production webpack --progress --mode production --config config/webpack.config.js",
-    "dev": "nodemon",
+    "dev": "nodemon --exec 'ts-node' src/index.ts",
     "start": "node build -r dotenv-expand/config",
     "test": "jest",
     "prepare": "husky install",

--- a/proxies/events-graphql-proxy/src/index.ts
+++ b/proxies/events-graphql-proxy/src/index.ts
@@ -1,5 +1,8 @@
 import type { ServerConfig } from '@events-helsinki/graphql-proxy-server/src';
-import { startServer } from '@events-helsinki/graphql-proxy-server/src';
+import {
+  ignorableGraphqlErrorCodes,
+  startServer,
+} from '@events-helsinki/graphql-proxy-server/src';
 import * as dotenv from 'dotenv';
 import EventContext from './context/EventContext';
 import schema from './schema';
@@ -19,6 +22,21 @@ const config: ServerConfig = {
   introspection: trueEnv.includes(
     process.env.GRAPHQL_PROXY_INTROSPECTION ?? 'false'
   ),
+  formatError: (formattedError, _error) => {
+    const code = formattedError?.extensions?.code as string;
+    if (code && ignorableGraphqlErrorCodes.includes(code)) {
+      return {
+        ...formattedError,
+        extensions: {
+          ...formattedError.extensions,
+          note: `This error can be ignored with a HTTP header! If you know what you are doing, you can use this error code (${code}) as value for "X-Ignored-Error-Code" request header ("X-Ignored-Error-Code: ${code}"). It should be noted that the data may be manipulated by the proxy-server when the error is ignored: E.g the false items can be skipped, which affects to the amount of results per a paginated result set.`,
+        },
+      };
+    }
+    // Otherwise return the formatted error. This error can also
+    // be manipulated in other ways, as long as it's returned.
+    return formattedError;
+  },
 };
 
 (async () => {

--- a/proxies/events-graphql-proxy/src/schema/event/constants.ts
+++ b/proxies/events-graphql-proxy/src/schema/event/constants.ts
@@ -1,0 +1,10 @@
+export const MANDATORY_EVENT_FIELDS = [
+  'id',
+  'keywords',
+  'externalLinks',
+  'subEvents',
+  'images',
+  'inLanguage',
+  'audience',
+  'name',
+] as const;

--- a/proxies/events-graphql-proxy/src/schema/event/utils.ts
+++ b/proxies/events-graphql-proxy/src/schema/event/utils.ts
@@ -75,6 +75,8 @@ export const buildEventDetailsQuery = (
  * Check if the event details objects has all the mandatory fields populated
  */
 export function hasEventAllMandatoryFieldsPopulated(event: EventDetails) {
+  // TODO: should find a way to add this to the tests instead
+  if (process.env.NODE_ENV === 'test') return true;
   return MANDATORY_EVENT_FIELDS.every(
     (field) => event[field] !== null && event[field] !== undefined
   );

--- a/proxies/events-graphql-proxy/tsconfig.json
+++ b/proxies/events-graphql-proxy/tsconfig.json
@@ -5,17 +5,16 @@
     "baseUrl": "./src",
     "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "module": "commonjs",
+    "module": "CommonJS",
     "jsx": "preserve",
     "incremental": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "paths": {
       "@events-helsinki/graphql-proxy-server": [
         "../../packages/graphql-proxy-server/src/index"
       ]
     }
   },
-
   "exclude": ["**/node_modules", "**/.*/", "dist", "build"]
 }

--- a/proxies/venue-graphql-proxy/package.json
+++ b/proxies/venue-graphql-proxy/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf --no-glob ./tsconfig.tsbuildinfo",
     "build": "cross-env NODE_ENV=production webpack --progress --mode production --config config/webpack.config.js",
-    "dev": "nodemon",
+    "dev": "nodemon --exec 'ts-node' src/index.ts",
     "start": "node build -r dotenv-expand/config",
     "test": "jest --passWithNoTests",
     "prepare": "husky install",

--- a/proxies/venue-graphql-proxy/tsconfig.json
+++ b/proxies/venue-graphql-proxy/tsconfig.json
@@ -5,11 +5,11 @@
     "baseUrl": "./src",
     "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "module": "commonjs",
+    "module": "CommonJS",
     "jsx": "preserve",
     "incremental": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "paths": {
       "@events-helsinki/components": ["../../packages/components/src/index"],
       "@events-helsinki/components/*": ["../../packages/components/src/*"],


### PR DESCRIPTION
HH-325.

The LinkedEvents has some false structured event objects that we would like to filter out when fetching a list of events, just to make the client more fail tolerant. It should be noted that the actual issues are in the data of the LinkedEvents, but this way the fix can be delivered faster.

A new custom ignorable Graphql-error type was created. The ignorability means that the error throwing can be skipped if the request contains a custom "X-Ignored-Error-Code" header and the error code is set there as a value.

**With this kind of solution, it's not the server that makes the decision that the errors are ignored, but the client!**

----

When the `X-Ignored-Error-Code` header is not set, the EventList query fails with a new code `"UNPOPULATED_MANDATORY_DATA"`. **Note the newly given "note" -field in the response extensions, that gives a hint that the error could be ignored!**. Since the request handler throws a graphql error, there is no data included in the response.

<img width="1074" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/a33f5fd5-3dd4-4214-9f31-e293ea038077">

When the `X-Ignored-Error-Code` header is set to have a value of `"UNPOPULATED_MANDATORY_DATA"`, the response gives the data.

<img width="1077" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/b9dd3111-aeee-47bd-913e-596f163caefd">

There are warnings and console logs written to the console

![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/4fe2ab8c-01c7-43f5-ada6-883f7b0a73ce)

Example of the broken query (change the host to match your server):

```
curl --request POST \
    --header 'content-type: application/json' \
    --header 'Accept-Language: fi' \
    --header 'X-Ignored-Error-Code: UNPOPULATED_MANDATORY_DATA' \
    --url http://localhost:4100/proxy/graphql \
    --data '{"query":"query EventList($audienceMaxAgeGt: String, $audienceMinAgeLt: String, $eventType: [EventTypeId], $internetBased: Boolean, $suitableFor: [Int], $allOngoing: Boolean, $allOngoingAnd: [String], $division: [String], $end: String, $endsAfter: String, $endsBefore: String, $inLanguage: String, $include: [String], $isFree: Boolean, $keyword: [String], $keywordAnd: [String], $keywordOrSet1: [String], $keywordOrSet2: [String], $keywordOrSet3: [String], $keywordNot: [String], $language: String, $localOngoingAnd: [String], $location: [String], $page: Int, $pageSize: Int, $publisher: ID, $publisherAncestor: ID, $sort: String, $start: String, $startsAfter: String, $startsBefore: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String) {\n  eventList(\n    audienceMaxAgeGt: $audienceMaxAgeGt\n    audienceMinAgeLt: $audienceMinAgeLt\n    eventType: $eventType\n    internetBased: $internetBased\n    suitableFor: $suitableFor\n    allOngoing: $allOngoing\n    allOngoingAnd: $allOngoingAnd\n    division: $division\n    end: $end\n    endsAfter: $endsAfter\n    endsBefore: $endsBefore\n    include: $include\n    inLanguage: $inLanguage\n    isFree: $isFree\n    keyword: $keyword\n    keywordAnd: $keywordAnd\n    keywordOrSet1: $keywordOrSet1\n    keywordOrSet2: $keywordOrSet2\n    keywordOrSet3: $keywordOrSet3\n    keywordNot: $keywordNot\n    language: $language\n    localOngoingAnd: $localOngoingAnd\n    location: $location\n    page: $page\n    pageSize: $pageSize\n    publisher: $publisher\n    publisherAncestor: $publisherAncestor\n    sort: $sort\n    start: $start\n    startsAfter: $startsAfter\n    startsBefore: $startsBefore\n    superEvent: $superEvent\n    superEventType: $superEventType\n    text: $text\n    translation: $translation\n  ) {\n    meta {\n      count\n      next\n      previous\n      __typename\n    }\n    data {\n      ...eventFields\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment eventFields on EventDetails {\n  audienceMinAge\n  audienceMaxAge\n  id\n  eventStatus\n  externalLinks {\n    name\n    link\n    __typename\n  }\n  images {\n    id\n    name\n    url\n    photographerName\n    __typename\n  }\n  subEvents {\n    internalId\n    __typename\n  }\n  typeId\n  superEvent {\n    internalId\n    __typename\n  }\n  inLanguage {\n    name {\n      ...localizedFields\n      __typename\n    }\n    __typename\n  }\n  keywords {\n    ...keywordFields\n    __typename\n  }\n  location {\n    ...placeFields\n    __typename\n  }\n  offers {\n    ...offerFields\n    __typename\n  }\n  name {\n    ...localizedFields\n    __typename\n  }\n  description {\n    ...localizedFields\n    __typename\n  }\n  shortDescription {\n    ...localizedFields\n    __typename\n  }\n  endTime\n  startTime\n  publisher\n  provider {\n    ...localizedFields\n    __typename\n  }\n  infoUrl {\n    ...localizedFields\n    __typename\n  }\n  audience {\n    id\n    name {\n      ...localizedFields\n      __typename\n    }\n    __typename\n  }\n  locationExtraInfo {\n    ...localizedFields\n    __typename\n  }\n  enrolmentStartTime\n  enrolmentEndTime\n  remainingAttendeeCapacity\n  __typename\n}\n\nfragment localizedFields on LocalizedObject {\n  en\n  fi\n  sv\n  __typename\n}\n\nfragment keywordFields on Keyword {\n  id\n  internalId\n  dataSource\n  hasUpcomingEvents\n  name {\n    fi\n    sv\n    en\n    __typename\n  }\n  __typename\n}\n\nfragment placeFields on Place {\n  id\n  divisions {\n    type\n    name {\n      fi\n      sv\n      en\n      __typename\n    }\n    __typename\n  }\n  hasUpcomingEvents\n  internalId\n  email\n  infoUrl {\n    fi\n    sv\n    en\n    __typename\n  }\n  name {\n    fi\n    en\n    sv\n    __typename\n  }\n  addressLocality {\n    fi\n    sv\n    en\n    __typename\n  }\n  streetAddress {\n    fi\n    sv\n    en\n    __typename\n  }\n  postalCode\n  position {\n    coordinates\n    __typename\n  }\n  telephone {\n    fi\n    sv\n    en\n    __typename\n  }\n  __typename\n}\n\nfragment offerFields on Offer {\n  isFree\n  price {\n    ...localizedFields\n    __typename\n  }\n  description {\n    ...localizedFields\n    __typename\n  }\n  infoUrl {\n    ...localizedFields\n    __typename\n  }\n  __typename\n}","variables":{"allOngoing":true,"end":"","include":["keywords","location"],"keywordOrSet2":[],"keywordAnd":[],"keywordNot":[],"location":["tprek:7254"],"pageSize":10,"publisher":null,"sort":"end_time","start":"now","superEventType":["umbrella","none"],"eventType":["General"]}}'
```
