### PR TITLE
feat: use custom X-Ignored-Error-Code header with event list queries

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_EVENT_SORT_OPTION,
   isEventSortOption,
   EventList,
+  ignoredErrorCodesHeader,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -70,6 +71,9 @@ const SearchPage: React.FC<{
   } = useEventListQuery({
     ssr: false,
     variables: eventFilters,
+    context: {
+      headers: ignoredErrorCodesHeader,
+    },
   });
   const eventsList = eventsData?.eventList;
 

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -11,6 +11,7 @@ import {
   MAIN_CONTENT_ID,
   EVENT_SORT_OPTIONS,
   EventList,
+  ignoredErrorCodesHeader,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -64,6 +65,9 @@ const SearchPage: React.FC<{
   } = useEventListQuery({
     ssr: false,
     variables: eventFilters,
+    context: {
+      headers: ignoredErrorCodesHeader,
+    },
   });
 
   const eventsList = eventsData?.eventList;

--- a/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
@@ -4,6 +4,7 @@ import {
   useIsSmallScreen,
   useEventListQuery,
   getLargeEventCardId,
+  ignoredErrorCodesHeader,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -28,6 +29,9 @@ function useEventSearchPageQuery(eventType: EventTypeId) {
       eventType === EventTypeId.Course
         ? searchVariables.course
         : searchVariables.event,
+    context: {
+      headers: ignoredErrorCodesHeader,
+    },
   });
 
   const handleLoadMore = async () => {

--- a/packages/components/src/components/domain/event/queryUtils.ts
+++ b/packages/components/src/components/domain/event/queryUtils.ts
@@ -1,3 +1,4 @@
+import type { DefaultContext } from '@apollo/client/core/types';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { toast } from 'react-toastify';
@@ -16,6 +17,10 @@ import type {
 } from '../../../types/generated/graphql';
 import { useEventListQuery } from '../../../types/generated/graphql';
 import { getEventIdFromUrl } from '../../../utils/eventUtils';
+
+export const ignoredErrorCodesHeader: DefaultContext['headers'] = {
+  'X-Ignored-Error-Code': 'UNPOPULATED_MANDATORY_DATA',
+};
 
 /**
  * Get next page number from linkedevents response meta field
@@ -82,6 +87,9 @@ export const useSimilarEventsQuery = (
   const { data: eventsData, loading } = useEventListQuery({
     ssr: false,
     variables,
+    context: {
+      headers: ignoredErrorCodesHeader,
+    },
   });
   const data = _filterSimilarEvents(event, eventsData?.eventList?.data || []);
   return { data, loading };
@@ -143,6 +151,9 @@ export const useSubEvents = (
     skip: !superEventId,
     ssr: false,
     variables,
+    context: {
+      headers: ignoredErrorCodesHeader,
+    },
   });
   const handleLoadMore = React.useCallback(
     async (page: number) => {
@@ -222,5 +233,11 @@ export const useLocationUpcomingEventsQuery = ({
     superEventType: 'none',
     pageSize,
   };
-  return useEventListQuery({ variables, ssr: false });
+  return useEventListQuery({
+    variables,
+    ssr: false,
+    context: {
+      headers: ignoredErrorCodesHeader,
+    },
+  });
 };

--- a/proxies/events-graphql-federation/router.yaml
+++ b/proxies/events-graphql-federation/router.yaml
@@ -15,6 +15,10 @@ headers:
       request:
         - propagate: # propagate all headers. Note that Accept-Language is the most important.
             matching: .*
+    events: # Header rules for just the events subgraph
+      request:
+        - propagate: # propagate all headers. Note that there are some custom X-Headers.
+            matching: .*
 include_subgraph_errors:
   all: true # Propagate errors from all subgraphs
 cors:


### PR DESCRIPTION
HH-325.

### Apollo Router

Change the router configuration: Propagate all headers to the Events-proxy.

### Clients

Set `X-Ignored-Error-Code: 'UNPOPULATED_MANDATORY_DATA'` to every event list query.
Relates to https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/456.

----

### Test instrocutions

It's easiest to use the local router. The errenous article that is good for testing is in the production CMS.

```
    "docker:graphql-router:events:serve": "cross-env FEDERATION_CMS_ROUTING_URL=https://tapahtumat.content.api.hel.fi/graphql FEDERATION_EVENTS_ROUTING_URL=http://docker.for.mac.localhost:4100/proxy/graphql FEDERATION_UNIFIED_SEARCH_ROUTING_URL=https://kuva-unified-search.api.test.hel.ninja/search FEDERATION_VENUES_ROUTING_URL=https://venue-graphql-proxy.test.hel.ninja/proxy/graphql docker-compose -f docker-compose.router.yml up",
```

Changing the .env.local might be needed to allow unauthorized requests: `NEXT_PUBLIC_ALLOW_UNAUTHORIZED_REQUESTS=0`

Then navigate to http://localhost:3000/sv/artiklar/film/hosten-kommer-med-ett-rikt-program-i-kulturcentralerna

Test result:

When the new header is used, the router is propagating all the headers to events-proxy and the event-proxy has the #456 features on, the errenous page is shown

<img width="1043" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/71a957e9-ad52-4f5b-a5d0-a75a920e9561">
