### PR TITLE
feat: use custom X-Ignored-Error-Code header with Apollo queries

### DIFF
--- a/apps/events-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/events-helsinki/src/domain/app/AppConfig.ts
@@ -1,4 +1,8 @@
-import { getEnvOrError, EventTypeId } from '@events-helsinki/components';
+import {
+  getEnvOrError,
+  EventTypeId,
+  ignoredErrorCodesHeader,
+} from '@events-helsinki/components';
 import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { ROUTES } from '../../constants';
@@ -241,6 +245,15 @@ class AppConfig {
     // Ignore HTTP410 - Not found, which is raised e.g.
     // when an event has been deleted from the LinkedEvents
     return [410];
+  }
+
+  /**
+   * The Apollo-client context headers.
+   * NOTE: The federation router needs to propagate all the defined headers
+   * if they should be used in a request to a GraphQL subgraph.
+   */
+  static get apolloFederationContextHeaders() {
+    return { ...ignoredErrorCodesHeader };
   }
 }
 

--- a/apps/events-helsinki/src/domain/clients/eventsApolloClient.ts
+++ b/apps/events-helsinki/src/domain/clients/eventsApolloClient.ts
@@ -16,6 +16,7 @@ export default function initializeEventsApolloClient(
     federationGraphqlEndpoint: AppConfig.federationGraphqlEndpoint,
     ignoredErrorHandlerStatusCodes:
       AppConfig.apolloErrorHandlerIgnoredStatusCodes,
+    contextHeaders: AppConfig.apolloFederationContextHeaders,
   });
 }
 

--- a/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
@@ -1,4 +1,8 @@
-import { getEnvOrError, EventTypeId } from '@events-helsinki/components';
+import {
+  getEnvOrError,
+  EventTypeId,
+  ignoredErrorCodesHeader,
+} from '@events-helsinki/components';
 import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { ROUTES } from '../../constants';
@@ -241,6 +245,15 @@ class AppConfig {
     // Ignore HTTP410 - Not found, which is raised e.g.
     // when an event has been deleted from the LinkedEvents
     return [410];
+  }
+
+  /**
+   * The Apollo-client context headers.
+   * NOTE: The federation router needs to propagate all the defined headers
+   * if they should be used in a request to a GraphQL subgraph.
+   */
+  static get apolloFederationContextHeaders() {
+    return { ...ignoredErrorCodesHeader };
   }
 }
 

--- a/apps/hobbies-helsinki/src/domain/clients/hobbiesApolloClient.ts
+++ b/apps/hobbies-helsinki/src/domain/clients/hobbiesApolloClient.ts
@@ -16,6 +16,7 @@ export default function initializeHobbiesApolloClient(
     federationGraphqlEndpoint: AppConfig.federationGraphqlEndpoint,
     ignoredErrorHandlerStatusCodes:
       AppConfig.apolloErrorHandlerIgnoredStatusCodes,
+    contextHeaders: AppConfig.apolloFederationContextHeaders,
   });
 }
 

--- a/apps/sports-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/sports-helsinki/src/domain/app/AppConfig.ts
@@ -1,4 +1,7 @@
-import { getEnvOrError } from '@events-helsinki/components';
+import {
+  getEnvOrError,
+  ignoredErrorCodesHeader,
+} from '@events-helsinki/components';
 import type { CommonButtonProps } from 'hds-react';
 import getConfig from 'next/config';
 import { i18n } from '../../../next-i18next.config';
@@ -267,6 +270,15 @@ class AppConfig {
     // Ignore HTTP410 - Not found, which is raised e.g.
     // when an event has been deleted from the LinkedEvents
     return [410];
+  }
+
+  /**
+   * The Apollo-client context headers.
+   * NOTE: The federation router needs to propagate all the defined headers
+   * if they should be used in a request to a GraphQL subgraph.
+   */
+  static get apolloFederationContextHeaders() {
+    return { ...ignoredErrorCodesHeader };
   }
 }
 

--- a/apps/sports-helsinki/src/domain/clients/sportsApolloClient.ts
+++ b/apps/sports-helsinki/src/domain/clients/sportsApolloClient.ts
@@ -16,6 +16,7 @@ export default function initializeSportsApolloClient(
     federationGraphqlEndpoint: AppConfig.federationGraphqlEndpoint,
     ignoredErrorHandlerStatusCodes:
       AppConfig.apolloErrorHandlerIgnoredStatusCodes,
+    contextHeaders: AppConfig.apolloFederationContextHeaders,
   });
 }
 

--- a/packages/components/src/apollo/EventsFederationApolloClient.ts
+++ b/packages/components/src/apollo/EventsFederationApolloClient.ts
@@ -24,6 +24,7 @@ import { graphqlClientLogger } from '../loggers/logger';
 import type { LanguageString } from '../types';
 import type { CmsRoutedAppHelper } from '../utils';
 import isClient from '../utils/isClient';
+
 import {
   excludeArgs,
   initializeApolloClient,
@@ -37,18 +38,11 @@ export type EventsFederationApolloClientConfig = {
   routerHelper: CmsRoutedAppHelper;
   handleError?: (error: Error) => void;
   ignoredErrorHandlerStatusCodes?: number[];
+  contextHeaders?: Record<string, string>;
 };
 
 type GraphQLErrorsExtensionResponse = {
   status: number;
-};
-
-/**
- * The Events-graphql-proxy offers a way to ignore some custom ignorable graphql errors.
- * The 'X-Ignored-Error-Code' header is used to list the errors wanted to be ignored.
- * */
-export const ignoredErrorCodesHeader = {
-  'X-Ignored-Error-Code': 'UNPOPULATED_MANDATORY_DATA',
 };
 
 class EventsFederationApolloClient {
@@ -180,7 +174,7 @@ class EventsFederationApolloClient {
       operation.setContext(({ headers = {} }) => ({
         headers: {
           ...headers,
-          ...ignoredErrorCodesHeader,
+          ...this.config.contextHeaders,
         },
       }));
       return forward(operation);

--- a/packages/components/src/apollo/constants.ts
+++ b/packages/components/src/apollo/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * The Events-graphql-proxy offers a way to ignore some custom ignorable graphql errors.
+ * The 'X-Ignored-Error-Code' header is used to list the errors wanted to be ignored.
+ * */
+export const ignoredErrorCodesHeader = {
+  'X-Ignored-Error-Code': 'UNPOPULATED_MANDATORY_DATA',
+};

--- a/packages/components/src/apollo/index.ts
+++ b/packages/components/src/apollo/index.ts
@@ -1,2 +1,3 @@
 export * from './utils';
+export * from './constants';
 export { default as EventsFederationApolloClient } from './EventsFederationApolloClient';

--- a/proxies/events-graphql-federation/README.md
+++ b/proxies/events-graphql-federation/README.md
@@ -139,6 +139,48 @@ To compose a new supergraph, use:
 rover supergraph compose --config ./supergraph-config.yaml
 ```
 
+## Router configuration
+
+The router configuration is done with `router.yaml` file.
+
+### Override the subgraph urls with environment variables
+
+The URLs of the subgraph can be defined with the environment variables:
+
+```
+override_subgraph_url:
+  cms: ${env.FEDERATION_CMS_ROUTING_URL}
+  events: ${env.FEDERATION_EVENTS_ROUTING_URL}
+  unified-search: ${env.FEDERATION_UNIFIED_SEARCH_ROUTING_URL}
+  venues: ${env.FEDERATION_VENUES_ROUTING_URL}
+```
+
+**Those values will override the values set in `supergraph-config.yaml`.**
+
+### Headers propagation
+
+Configure which headers the Apollo Router sends to which subgraphs: The propagate config enables you to selectively pass along headers that were included in the client's request to the router.
+
+Some of the subgraphs needs some HTTP headers in the request. Here are some examples:
+
+1. The venues-graphql-proxy needs a `Accept-Language` HTTP header in order to return some of the i18n-values properly.
+2. The events-graphql-proxy has a feature to ignore some custom graphql errors and the ignoring is done with some custom headers like `'X-Ignored-Error-Code=UNPOPULATED_MANDATORY_DATA'`.
+
+Examples configuration:
+
+```
+headers:
+  subgraphs:
+    venues: # Header rules for just the venues subgraph
+      request:
+        - propagate: # propagate all headers. Note that Accept-Language is the most important.
+            matching: .*
+    events: # Header rules for just the events subgraph
+      request:
+        - propagate: # propagate all headers. Note that there are some custom X-Headers.
+            matching: .*
+```
+
 # Documentation related to the Apollo federation
 
 ## External articles for basics:

--- a/proxies/events-graphql-proxy/README.md
+++ b/proxies/events-graphql-proxy/README.md
@@ -19,7 +19,7 @@ GraphQL playground will run on http://localhost:4000/proxy/graphql
 
 In the project directory, you can run:
 
-### `yarn start`
+### `yarn dev`
 
 Runs the app in the development mode.<br />
 Open [http://localhost:4000/proxy/graphql](http://localhost:4000/proxy/graphql) to view it in the browser.
@@ -47,3 +47,13 @@ Run eslint to all files on
 ### `yarn format-code`
 
 Fix all the eslint errors
+
+## Custom request headers
+
+The Events-graphql-proxy offers a way to ignore some custom ignorable graphql errors.
+
+The 'X-Ignored-Error-Code' header is used to list the errors wanted to be ignored. It is used for example to ignore the custom made error code `UNPOPULATED_MANDATORY_DATA` which is thrown if the LinkedEvents data has some mandatory data unpopulated. (The feature is there to make the app more false tolerant when the endpoint has some data issues and the development team might have slow response to fix them.)
+
+The `UNPOPULATED_MANDATORY_DATA`, that was given as an example, is created with a custom made error class named `IgnorableGraphQLError`, which can be used to create more of these ignorable error codes.
+
+**NOTE: Remember to [propagate the HTTP headers in the router](../events-graphql-federation/README.md)**. Otherwise the heaers are not included in the request that is made from the Apollo router to the subgraph, because the Apollo router don't pass them.


### PR DESCRIPTION
An alternative to #457 .

HH-325.

### Apollo Router
Change the router configuration: Propagate all headers to the Events-proxy.

### Clients
Set `X-Ignored-Error-Code: 'UNPOPULATED_MANDATORY_DATA'` to query by using a Apollo-client middleware. It does not matter if the header is in every query, but it's mostly needed with the event list queries and at this point it's only handled by the events-graphql-proxy.

Relates to #456.

----

### Test instrocutions

It's easiest to use the local router. The errenous article that is good for testing is in the production CMS.

```
    "docker:graphql-router:events:serve": "cross-env FEDERATION_CMS_ROUTING_URL=https://tapahtumat.content.api.hel.fi/graphql FEDERATION_EVENTS_ROUTING_URL=http://docker.for.mac.localhost:4100/proxy/graphql FEDERATION_UNIFIED_SEARCH_ROUTING_URL=https://kuva-unified-search.api.test.hel.ninja/search FEDERATION_VENUES_ROUTING_URL=https://venue-graphql-proxy.test.hel.ninja/proxy/graphql docker-compose -f docker-compose.router.yml up" 
```
Changing the .env.local might be needed to allow unauthorized requests: `NEXT_PUBLIC_ALLOW_UNAUTHORIZED_REQUESTS=0`

Then navigate to http://localhost:3000/fi/artikkelit/musiikki/iloa-ja-valoa-kulttuurikeskuksista

You can configure the used headers from the `AppConfig`.

Test result:

When the new header is used, the router is propagating all the headers to events-proxy and the event-proxy has the #456 features on, the errenous page is shown

<img width="443" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/696393d0-ccb0-4d06-8e7d-e77e22c1e797">


![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/d82c2fd7-24d6-4431-b0cb-d22581bcbeef)
