### PR TITLE
feat(router): propagate all headers to events-proxy

### DIFF
--- a/proxies/events-graphql-federation/router.yaml
+++ b/proxies/events-graphql-federation/router.yaml
@@ -15,6 +15,10 @@ headers:
       request:
         - propagate: # propagate all headers. Note that Accept-Language is the most important.
             matching: .*
+    events: # Header rules for just the events subgraph
+      request:
+        - propagate: # propagate all headers. Note that there are some custom X-Headers.
+            matching: .*
 include_subgraph_errors:
   all: true # Propagate errors from all subgraphs
 cors:


### PR DESCRIPTION
HH-325

Propagate the new custom headers that the events-graphql-proxy started to support. Otherwise the router won't have those headers when the request is routed from the router to the events subgraph.
