### PR TITLE
Fix a forever loop on CMS modules if an error occurs

### DIFF
--- a/apps/events-helsinki/src/domain/app/EventsApolloProvider.tsx
+++ b/apps/events-helsinki/src/domain/app/EventsApolloProvider.tsx
@@ -2,7 +2,7 @@ import { ApolloProvider as BaseApolloProvider } from '@apollo/client';
 import 'nprogress/nprogress.css';
 import {
   ApolloErrorNotification,
-  useApolloErrorsReducer,
+  useApolloErrorHandler,
 } from '@events-helsinki/components';
 import React from 'react';
 import { ConfigProvider as RHHCConfigProvider } from 'react-helsinki-headless-cms';
@@ -14,27 +14,18 @@ export type Props = {
 };
 
 function EventsApolloProvider({ children }: Props) {
-  const [errors, errorsDispatch] = useApolloErrorsReducer();
-  const showErrorNotification = !!errors.length;
-
-  const handleError = React.useCallback((error: Error) => {
-    errorsDispatch({ type: 'addError', error });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+  const { showErrorNotification, handleError, onCloseErrorHandler } =
+    useApolloErrorHandler();
   const apolloClient = useEventsApolloClient({ handleError });
   const rhhcConfig = useEventsRHHCConfig({ apolloClient });
-  const onCloseErrorHandler = () => errorsDispatch({ type: 'clearErrors' });
 
   return (
-    <>
-      <BaseApolloProvider client={apolloClient}>
-        <RHHCConfigProvider config={rhhcConfig}>{children}</RHHCConfigProvider>
-      </BaseApolloProvider>
+    <BaseApolloProvider client={apolloClient}>
+      <RHHCConfigProvider config={rhhcConfig}>{children}</RHHCConfigProvider>
       {showErrorNotification && (
         <ApolloErrorNotification onClose={onCloseErrorHandler} />
       )}
-    </>
+    </BaseApolloProvider>
   );
 }
 

--- a/apps/hobbies-helsinki/src/domain/app/HobbiesApolloProvider.tsx
+++ b/apps/hobbies-helsinki/src/domain/app/HobbiesApolloProvider.tsx
@@ -2,7 +2,7 @@ import { ApolloProvider as BaseApolloProvider } from '@apollo/client';
 import 'nprogress/nprogress.css';
 import {
   ApolloErrorNotification,
-  useApolloErrorsReducer,
+  useApolloErrorHandler,
 } from '@events-helsinki/components';
 import React from 'react';
 import { ConfigProvider as RHHCConfigProvider } from 'react-helsinki-headless-cms';
@@ -14,27 +14,18 @@ export type Props = {
 };
 
 function HobbiesApolloProvider({ children }: Props) {
-  const [errors, errorsDispatch] = useApolloErrorsReducer();
-  const showErrorNotification = !!errors.length;
-
-  const handleError = React.useCallback((error: Error) => {
-    errorsDispatch({ type: 'addError', error });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+  const { showErrorNotification, handleError, onCloseErrorHandler } =
+    useApolloErrorHandler();
   const apolloClient = useHobbiesApolloClient({ handleError });
   const rhhcConfig = useHobbiesRHHCConfig({ apolloClient });
-  const onCloseErrorHandler = () => errorsDispatch({ type: 'clearErrors' });
 
   return (
-    <>
-      <BaseApolloProvider client={apolloClient}>
-        <RHHCConfigProvider config={rhhcConfig}>{children}</RHHCConfigProvider>
-      </BaseApolloProvider>
+    <BaseApolloProvider client={apolloClient}>
+      <RHHCConfigProvider config={rhhcConfig}>{children}</RHHCConfigProvider>
       {showErrorNotification && (
         <ApolloErrorNotification onClose={onCloseErrorHandler} />
       )}
-    </>
+    </BaseApolloProvider>
   );
 }
 

--- a/apps/sports-helsinki/src/domain/app/SportsApolloProvider.tsx
+++ b/apps/sports-helsinki/src/domain/app/SportsApolloProvider.tsx
@@ -2,7 +2,7 @@ import { ApolloProvider as BaseApolloProvider } from '@apollo/client';
 import 'nprogress/nprogress.css';
 import {
   ApolloErrorNotification,
-  useApolloErrorsReducer,
+  useApolloErrorHandler,
 } from '@events-helsinki/components';
 import React from 'react';
 import { ConfigProvider as RHHCConfigProvider } from 'react-helsinki-headless-cms';
@@ -14,27 +14,18 @@ export type Props = {
 };
 
 function SportsApolloProvider({ children }: Props) {
-  const [errors, errorsDispatch] = useApolloErrorsReducer();
-  const showErrorNotification = !!errors.length;
-
-  const handleError = React.useCallback((error: Error) => {
-    errorsDispatch({ type: 'addError', error });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+  const { showErrorNotification, handleError, onCloseErrorHandler } =
+    useApolloErrorHandler();
   const apolloClient = useSportsApolloClient({ handleError });
   const rhhcConfig = useSportsRHHCConfig({ apolloClient });
-  const onCloseErrorHandler = () => errorsDispatch({ type: 'clearErrors' });
 
   return (
-    <>
-      <BaseApolloProvider client={apolloClient}>
-        <RHHCConfigProvider config={rhhcConfig}>{children}</RHHCConfigProvider>
-      </BaseApolloProvider>
+    <BaseApolloProvider client={apolloClient}>
+      <RHHCConfigProvider config={rhhcConfig}>{children}</RHHCConfigProvider>
       {showErrorNotification && (
         <ApolloErrorNotification onClose={onCloseErrorHandler} />
       )}
-    </>
+    </BaseApolloProvider>
   );
 }
 

--- a/packages/components/src/components/apolloErrorNotification/apolloErrorsReducer.tsx
+++ b/packages/components/src/components/apolloErrorNotification/apolloErrorsReducer.tsx
@@ -15,7 +15,8 @@ export function apolloErrorsReducer(
   switch (action.type) {
     case 'addError': {
       if (state.find((error) => error.message === action.error.message))
-        return [...state];
+        // NOTE: If nothing changes, don't create a new object to prevent state chagnes.
+        return state;
       return [...state, action.error];
     }
     case 'removeError': {

--- a/packages/components/src/components/apolloErrorNotification/useApolloErrorHandler.tsx
+++ b/packages/components/src/components/apolloErrorNotification/useApolloErrorHandler.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { useApolloErrorsReducer } from './apolloErrorsReducer';
+
+export default function useApolloErrorHandler() {
+  const [errors, errorsDispatch] = useApolloErrorsReducer();
+  const [showErrorNotification, setShowErrorNotification] = useState(
+    !!errors.length
+  );
+  const handleError = (error: Error) =>
+    errorsDispatch({ type: 'addError', error });
+  const onCloseErrorHandler = () => errorsDispatch({ type: 'clearErrors' });
+
+  useEffect(() => {
+    setShowErrorNotification(!!errors.length);
+  }, [errors.length]);
+
+  return { handleError, onCloseErrorHandler, showErrorNotification };
+}

--- a/packages/components/src/components/apolloErrorNotification/useApolloErrorHandler.tsx
+++ b/packages/components/src/components/apolloErrorNotification/useApolloErrorHandler.tsx
@@ -3,16 +3,12 @@ import { useApolloErrorsReducer } from './apolloErrorsReducer';
 
 export default function useApolloErrorHandler() {
   const [errors, errorsDispatch] = useApolloErrorsReducer();
-  const [showErrorNotification, setShowErrorNotification] = useState(
-    !!errors.length
-  );
-  const handleError = (error: Error) =>
-    errorsDispatch({ type: 'addError', error });
-  const onCloseErrorHandler = () => errorsDispatch({ type: 'clearErrors' });
-
+  const [showErrorNotification, setShowErrorNotification] = useState(!!errors);
   useEffect(() => {
     setShowErrorNotification(!!errors.length);
   }, [errors.length]);
-
+  const handleError = (error: Error) =>
+    errorsDispatch({ type: 'addError', error });
+  const onCloseErrorHandler = () => errorsDispatch({ type: 'clearErrors' });
   return { handleError, onCloseErrorHandler, showErrorNotification };
 }

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -56,6 +56,7 @@ export {
   apolloErrorsReducer,
   useApolloErrorsReducer,
 } from './apolloErrorNotification/apolloErrorsReducer';
+export { default as useApolloErrorHandler } from './apolloErrorNotification/useApolloErrorHandler';
 export type { ToastableErrorActions } from './apolloErrorNotification/apolloErrorsReducer';
 export { default as EventCard } from './eventCard/EventCard';
 export { default as LargeEventCard } from './eventCard/LargeEventCard';


### PR DESCRIPTION
HH-326.

1. Move the reusable Apollo error handler init to new hook

2. The Apollo error reducer should not create a new state object
when nothing changes, or otherwise it will be dealt as a new
state in the component / provider as well.

NOTE: There is still a reloading issue in pages that uses CMS
modules like event carousels, but it won't lead to a forever loop anymore. Because of a reload the error toaster will just appear again.