### PR TITLE
LIIKUNTA-554 | fix(sports): fix clearing filter summary i.e. filters under search bar

### DIFF
--- a/apps/sports-helsinki/src/domain/app/appConstants.ts
+++ b/apps/sports-helsinki/src/domain/app/appConstants.ts
@@ -6,7 +6,4 @@ export const Sources = {
 // Add ID that matches the sports ontology tree branch that has the Culture,
 // sports and leisure department (KuVa) as its parent.
 // https://www.hel.fi/palvelukarttaws/rest/v4/ontologytree/551
-export const SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID = 551;
-
-export const HELSINKI_OCD_DIVISION_ID =
-  'ocd-division/country:fi/kunta:helsinki';
+export const SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID = 551 as const;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchProvider.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchProvider.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { initialCombinedSearchFormValues } from '../constants';
 import { useCombinedSearchController } from '../hooks/useCombinedSearchController';
 import type { CombinedSearchAdapterInput } from '../types';
+import { combinedSearchAdapterInputFallbacks } from '../types';
 import type { CombinedSearchContextType } from './CombinedSearchContext';
 import { CombinedSearchContext } from './CombinedSearchContext';
 import type CombinedSearchFormAdapter from './CombinedSearchFormAdapter';
@@ -28,8 +29,18 @@ function useGetCombinedSearchContext(): UseGetCombinedSearchContextReturnType {
       [field]: value,
     });
 
+  /**
+   * Remove fallback (i.e. for backward compatibility only) query parameters from URL.
+   */
+  const removeFallbackQueryParams = () => {
+    for (const fallbackQueryParam of combinedSearchAdapterInputFallbacks) {
+      combinedSearchFormAdapter.searchParams.delete(fallbackQueryParam);
+    }
+  };
+
   const resetFormValues = () => {
     setFormValues(initialCombinedSearchFormValues);
+    removeFallbackQueryParams();
     updateRouteToSearchPage({ shallow: true });
   };
 

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
@@ -1,12 +1,11 @@
-import { EVENT_SORT_OPTIONS } from '@events-helsinki/components/constants';
+import type { TargetGroup } from '@events-helsinki/components';
 import {
   EventTypeId,
   UnifiedSearchLanguage,
-} from '@events-helsinki/components/types';
-import {
+  EVENT_SORT_OPTIONS,
   HELSINKI_OCD_DIVISION_ID,
-  SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID,
-} from '../../app/appConstants';
+} from '@events-helsinki/components';
+import { SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID } from '../../app/appConstants';
 import { SPORT_COURSES_KEYWORDS } from '../eventSearch/constants';
 import type {
   CombinedSearchAdapterInput,
@@ -15,43 +14,45 @@ import type {
 } from './types';
 
 export const PARAM_SEARCH_TYPE = 'searchType';
-export const initialCombinedSearchFormValues: CombinedSearchAdapterInput = {
+
+export const initialCombinedSearchFormValues = {
   text: '',
   venueOrderBy: undefined,
   eventOrderBy: undefined,
   courseOrderBy: undefined,
-  sportsCategories: [],
-  targetGroups: [],
+  sportsCategories: [] as string[],
+  targetGroups: [] as string[],
   helsinkiOnly: undefined,
   organization: undefined,
   place: undefined,
-  keywords: [],
-};
-export const initialVenueSearchAdapterValues: VenueSearchParams = {
+  keywords: [] as string[],
+} as const satisfies CombinedSearchAdapterInput;
+
+export const initialVenueSearchAdapterValues = {
   includeHaukiFields: false,
   language: UnifiedSearchLanguage.Finnish,
   q: '*',
-  ontologyTreeIds: [SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID.toString()],
-  ontologyWordIds: [],
-  targetGroups: [],
-  administrativeDivisionIds: [HELSINKI_OCD_DIVISION_ID],
+  ontologyTreeIds: [SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID.toString()] as string[],
+  ontologyWordIds: [] as string[],
+  targetGroups: [] as TargetGroup[],
+  administrativeDivisionIds: [HELSINKI_OCD_DIVISION_ID] as string[],
   providerTypes: undefined,
   serviceOwnerTypes: undefined,
   openAt: null,
   after: '',
   first: 10,
-};
+} as const satisfies VenueSearchParams;
 
-export const initialEventSearchAdapterValues: EventSearchParams = {
-  allOngoingAnd: [],
+export const initialEventSearchAdapterValues = {
+  allOngoingAnd: [] as string[],
   start: 'now',
   end: '',
-  include: ['keywords', 'location'],
-  keywordAnd: [],
-  keywordNot: [],
+  include: ['keywords', 'location'] as string[],
+  keywordAnd: [] as string[],
+  keywordNot: [] as string[],
   keywordOrSet1: SPORT_COURSES_KEYWORDS,
-  keywordOrSet2: [],
-  location: [],
+  keywordOrSet2: [] as string[],
+  location: [] as string[],
   sort: EVENT_SORT_OPTIONS.END_TIME,
   eventType: EventTypeId.General,
   superEventType: undefined, // Don't use superEventType when experimenting LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
@@ -59,4 +60,4 @@ export const initialEventSearchAdapterValues: EventSearchParams = {
   publisher: null,
   publisherAncestor: null,
   pageSize: 10,
-};
+} as const satisfies EventSearchParams;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -3,6 +3,7 @@ import type {
   EventListQueryVariables,
   SearchListQueryVariables,
   UnifiedSearchVenue,
+  KeysOfArrayFields,
 } from '@events-helsinki/components';
 import type { FormEvent } from 'react';
 import type { Config } from 'react-helsinki-headless-cms';
@@ -63,6 +64,30 @@ export type CombinedSearchAdapterInput = {
 } & CombinedSearchAdapterInputForVenues &
   CombinedSearchAdapterInputForEvents &
   CombinedSearchAdapterInputForCourses;
+
+export type CombinedSearchAdapterInputArrayFields =
+  KeysOfArrayFields<CombinedSearchAdapterInput>;
+
+export type CombinedSearchAdapterInputNonArrayFields = Exclude<
+  keyof CombinedSearchAdapterInput,
+  CombinedSearchAdapterInputArrayFields
+>;
+
+/**
+ * List of backward compatibility fallback fields for combined search adapter
+ * input fields.
+ */
+export const combinedSearchAdapterInputFallbacks = [
+  'orderBy',
+  'places',
+  'publisher',
+  'q',
+  'sort',
+] as const;
+
+/** Backward compatibility fallback fields for combined search adapter input fields. */
+export type CombinedSearchAdapterInputFallback =
+  (typeof combinedSearchAdapterInputFallbacks)[number];
 
 /** The fields that are used by the Event and Course search. */
 export type EventSearchParams = Pick<

--- a/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
@@ -32,7 +32,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
     targetGroups,
     organization,
     helsinkiOnly,
-    text: q,
+    text,
     place,
   } = formValues;
 
@@ -69,7 +69,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
     !!helsinkiOnly ||
     !!organization ||
     !!place ||
-    !!q?.length;
+    !!text?.length;
 
   if (!hasFilters) return null;
 

--- a/packages/components/src/constants/venue-constants.ts
+++ b/packages/components/src/constants/venue-constants.ts
@@ -4,4 +4,4 @@ export const Sources = {
 } as const;
 
 export const HELSINKI_OCD_DIVISION_ID =
-  'ocd-division/country:fi/kunta:helsinki';
+  'ocd-division/country:fi/kunta:helsinki' as const;


### PR DESCRIPTION
## Description

### fix(sports): fix clearing filter summary i.e. filters under search bar

This works by removing all the backward compatible input fields as well
as the currently used input fields from the URL search parameters.

also:
 - add type safety to CombinedSearchFormAdapter's input handling with
   use of getSingleValueInput and getMultiValueInput functions
 - use "as const" with initialCombinedSearchFormValues but still ensure
   it is compatible with CombinedSearchAdapterInput with the use of
   satisfies operator, likewise for the other initial search adapter
   values

refs LIIKUNTA-554

## Issues

### Closes

**[LIIKUNTA-554](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-554)**

### Related

## Testing

### Automated tests

### Manual testing

Tested locally that clearing all filters works if used `publisher` or `places` URL search parameter.

## Screenshots

## Additional notes


[LIIKUNTA-554]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ