### PR TITLE
fix: outline color of the collapse search form button in the venue map

### DIFF
--- a/apps/sports-helsinki/src/domain/search/searchHeader/searchHeader.module.scss
+++ b/apps/sports-helsinki/src/domain/search/searchHeader/searchHeader.module.scss
@@ -79,7 +79,12 @@
       margin-left: auto;
       background-color: white;
 
+      &:focus {
+        outline: 2px solid var(--color-coat-of-arms); /* todo: use color-primary-black instead */
+      }
+
       @include breakpoints.respond-above(m) {
+        margin-right: var(--spacing-s);
         width: unset;
         border: 2px solid;
         height: 45px;


### PR DESCRIPTION
LIIKUNTA-559.

<img width="1235" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/2dbef147-abfc-45a7-a0f0-beb28872a1a2">

<img width="435" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/ac7d71c3-5c26-4b3f-bb89-4f69079170aa">
