### PR TITLE
build: cache image uses node20 as normal image

### DIFF
--- a/DockerfileCache
+++ b/DockerfileCache
@@ -32,8 +32,8 @@ COPY --chown=appuser:appuser . /docker-context
 
 # mount type bind is not supported on current version (4.10.35) of OpenShift build
 # RUN --mount=type=bind,source=./,target=/docker-context \
-RUN rsync -amv --delete \
-    --owner=appuser --group=appuser \
+RUN rsync -amv \
+    --chown=appuser:appuser \
     --exclude='node_modules' \
     --exclude='*/node_modules' \
     --include='package.json' \

--- a/DockerfileCache
+++ b/DockerfileCache
@@ -8,7 +8,7 @@
 #      ignore: all **/node_modules folders and .yarn/cache        #
 ###################################################################
 
-FROM helsinkitest/node:16-slim AS deps
+FROM helsinkitest/node:20-slim AS deps
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends rsync
@@ -73,7 +73,7 @@ RUN apt-get remove -y rsync && \
 # This is used to speedup OpenShift builds                        #
 ###################################################################
 # Build cache layer
-FROM helsinkitest/node:16-slim  AS build_cache
+FROM helsinkitest/node:20-slim  AS build_cache
 # Build ARGS
 ARG PROJECT
 ARG CMS_ORIGIN
@@ -120,7 +120,7 @@ RUN yarn workspace ${PROJECT} build
 
 # Create cache image
 #FROM gcr.io/distroless/static-debian11 AS cache
-FROM helsinkitest/node:16-slim AS cache
+FROM helsinkitest/node:20-slim AS cache
 ARG PROJECT
 
 WORKDIR /app/.yarn/cache/


### PR DESCRIPTION
## Description
Set base image to node20 in DockerfileCache

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
