### PR TITLE
fix: error toast init value

### DIFF
--- a/packages/components/src/components/apolloErrorNotification/useApolloErrorHandler.tsx
+++ b/packages/components/src/components/apolloErrorNotification/useApolloErrorHandler.tsx
@@ -3,7 +3,9 @@ import { useApolloErrorsReducer } from './apolloErrorsReducer';
 
 export default function useApolloErrorHandler() {
   const [errors, errorsDispatch] = useApolloErrorsReducer();
-  const [showErrorNotification, setShowErrorNotification] = useState(!!errors);
+  const [showErrorNotification, setShowErrorNotification] = useState(
+    !!errors.length
+  );
   useEffect(() => {
     setShowErrorNotification(!!errors.length);
   }, [errors.length]);


### PR DESCRIPTION
HH-329.

The error toast was shown on every page load
because it's init value was to do that.
