### PR TITLE
Disable the source maps in the production package to improve SSG

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/VenuePageContainer.tsx
+++ b/apps/sports-helsinki/src/domain/venue/VenuePageContainer.tsx
@@ -37,7 +37,7 @@ const VenueUpcomingEvents = dynamic(
 
 export interface VenuePageContainerProps {
   loading: boolean;
-  venue: Venue;
+  venue: Venue | undefined;
   showUpcomingEvents?: boolean;
   showSimilarVenues?: boolean;
 }
@@ -48,7 +48,7 @@ const VenuePageContainer: React.FC<VenuePageContainerProps> = ({
   showUpcomingEvents = true,
   showSimilarVenues = true,
 }) => {
-  const { id: venueId } = venue;
+  const venueId = venue?.id ?? '';
   const { t } = useTranslation('event');
   const router = useRouter();
   const locale = useLocale();

--- a/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -21,7 +21,7 @@ import EventPageContainer from '../../../domain/event/EventPageContainer';
 
 import serverSideTranslationsWithCommon from '../../../domain/i18n/serverSideTranslationsWithCommon';
 
-const Event: NextPage<{
+const EventPage: NextPage<{
   event: EventFields;
   loading: boolean;
 }> = ({ event, loading }) => {
@@ -46,7 +46,7 @@ const Event: NextPage<{
     </MatomoWrapper>
   );
 };
-export default Event;
+export default EventPage;
 
 // export default eventsWithApollo(Event);
 export async function getStaticPaths() {
@@ -56,16 +56,33 @@ export async function getStaticPaths() {
   };
 }
 
+function getIdProp(params: GetStaticPropsContext['params']) {
+  const id = (params?.eventId as string) ?? '';
+  // If the fallback is set to 'blocking' and
+  // the source maps are enabled in the prod package,
+  // the source map filename is used as an id.
+  if (id.endsWith('.map')) {
+    return undefined;
+  }
+  return id;
+}
+
 export async function getStaticProps(context: GetStaticPropsContext) {
   return getSportsStaticProps(context, async ({ apolloClient }) => {
     const language = getLanguageOrDefault(context.locale);
+    const id = getIdProp(context.params);
+    if (!id) {
+      return {
+        notFound: true,
+      };
+    }
     const { data: eventData, loading } = await apolloClient.query<
       EventDetailsQuery,
       EventDetailsQueryVariables
     >({
       query: EventDetailsDocument,
       variables: {
-        id: (context.params?.eventId as string) || '',
+        id,
         include: ['in_language', 'keywords', 'location', 'audience'],
       },
     });

--- a/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
@@ -57,16 +57,33 @@ export async function getStaticPaths() {
   };
 }
 
+function getIdProp(params: GetStaticPropsContext['params']) {
+  const id = (params?.venueId as string) ?? '';
+  // If the fallback is set to 'blocking' and
+  // the source maps are enabled in the prod package,
+  // the source map filename is used as an id.
+  if (id.endsWith('.map')) {
+    return undefined;
+  }
+  return id;
+}
+
 export async function getStaticProps(context: GetStaticPropsContext) {
   return getSportsStaticProps(context, async ({ apolloClient }) => {
     const language = getLanguageOrDefault(context.locale);
+    const id = getIdProp(context.params);
+    if (!id) {
+      return {
+        notFound: true,
+      };
+    }
     const { data: venueData, loading } = await apolloClient.query<
       VenueQuery,
       VenueQueryVariables
     >({
       query: VenueDocument,
       variables: {
-        id: (context.params?.venueId as string) || '',
+        id,
         includeHaukiFields: AppConfig.isHaukiEnabled,
       },
       context: {

--- a/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
@@ -21,7 +21,7 @@ import getSportsStaticProps from '../../../domain/app/getSportsStaticProps';
 import serverSideTranslationsWithCommon from '../../../domain/i18n/serverSideTranslationsWithCommon';
 import VenuePageContainer from '../../../domain/venue/VenuePageContainer';
 
-const Event: NextPage<{
+const VenuePage: NextPage<{
   venue: Venue;
   loading: boolean;
 }> = ({ venue, loading }) => {
@@ -48,7 +48,7 @@ const Event: NextPage<{
     </MatomoWrapper>
   );
 };
-export default Event;
+export default VenuePage;
 
 export async function getStaticPaths() {
   return {

--- a/azure-pipelines-harrastukset-federation-router-release.yml
+++ b/azure-pipelines-harrastukset-federation-router-release.yml
@@ -57,8 +57,10 @@ extends:
       FEDERATION_EVENTS_ROUTING_URL: https://events-graphql-proxy.api.hel.fi/proxy/graphql
       FEDERATION_UNIFIED_SEARCH_ROUTING_URL: https://kuva-unified-search.api.hel.fi/search
       FEDERATION_VENUES_ROUTING_URL: https://venue-graphql-proxy.api.hel.fi/proxy/graphql
+      NEXT_DISABLE_SOURCEMAPS: 1
     configMapStage: # pod environment variables for staging
       FEDERATION_CMS_ROUTING_URL: https://harrastus.content.api.hel.fi/graphql
       FEDERATION_UNIFIED_SEARCH_ROUTING_URL: https://kuva-unified-search.api.stage.hel.ninja/search
       FEDERATION_EVENTS_ROUTING_URL: https://events-graphql-proxy.stage.hel.ninja/proxy/graphql
       FEDERATION_VENUES_ROUTING_URL: https://venue-graphql-proxy.stage.hel.ninja/proxy/graphql
+      NEXT_DISABLE_SOURCEMAPS: 1

--- a/azure-pipelines-liikunta-federation-router-release.yml
+++ b/azure-pipelines-liikunta-federation-router-release.yml
@@ -57,8 +57,10 @@ extends:
       FEDERATION_UNIFIED_SEARCH_ROUTING_URL: https://kuva-unified-search.api.hel.fi/search
       FEDERATION_EVENTS_ROUTING_URL: https://events-graphql-proxy.api.hel.fi/proxy/graphql
       FEDERATION_VENUES_ROUTING_URL: https://venue-graphql-proxy.api.hel.fi/proxy/graphql
+      NEXT_DISABLE_SOURCEMAPS: 1
     configMapStage: # pod environment variables for staging
       FEDERATION_CMS_ROUTING_URL: https://liikunta2.content.api.hel.fi/graphql
       FEDERATION_UNIFIED_SEARCH_ROUTING_URL: https://kuva-unified-search.api.stage.hel.ninja/search
       FEDERATION_EVENTS_ROUTING_URL: https://events-graphql-proxy.stage.hel.ninja/proxy/graphql
       FEDERATION_VENUES_ROUTING_URL: https://venue-graphql-proxy.stage.hel.ninja/proxy/graphql
+      NEXT_DISABLE_SOURCEMAPS: 1

--- a/azure-pipelines-tapahtumat-federation-router-release.yml
+++ b/azure-pipelines-tapahtumat-federation-router-release.yml
@@ -57,8 +57,10 @@ extends:
       FEDERATION_UNIFIED_SEARCH_ROUTING_URL: https://kuva-unified-search.api.hel.fi/search
       FEDERATION_EVENTS_ROUTING_URL: https://events-graphql-proxy.api.hel.fi/proxy/graphql
       FEDERATION_VENUES_ROUTING_URL: https://venue-graphql-proxy.api.hel.fi/proxy/graphql
+      NEXT_DISABLE_SOURCEMAPS: 1
     configMapStage: # pod environment variables for staging
       FEDERATION_CMS_ROUTING_URL: https://tapahtumat.content.api.hel.fi/graphql
       FEDERATION_UNIFIED_SEARCH_ROUTING_URL: https://kuva-unified-search.api.stage.hel.ninja/search
       FEDERATION_EVENTS_ROUTING_URL: https://events-graphql-proxy.stage.hel.ninja/proxy/graphql
       FEDERATION_VENUES_ROUTING_URL: https://venue-graphql-proxy.stage.hel.ninja/proxy/graphql
+      NEXT_DISABLE_SOURCEMAPS: 1

--- a/next.base.config.js
+++ b/next.base.config.js
@@ -35,6 +35,13 @@ const NEXTJS_SENTRY_TRACING = trueEnv.includes(
  * A way to allow CI optimization when the build done there is not used
  * to deliver an image or deploy the files.
  * @link https://nextjs.org/docs/advanced-features/source-maps
+ *
+ * If the SSG fallback is set to 'blocking' and the
+ * source maps are in use in the prod build,
+ * the getStaticProps gets called first time when the page
+ * is rendered and not during the build time.
+ * This can make some Apollo queries to fail, because the
+ * source map file name is used as an id-param.
  */
 const disableSourceMaps = trueEnv.includes(
   process.env?.NEXT_DISABLE_SOURCEMAPS ?? 'false'


### PR DESCRIPTION
LIIKUNTA-560.

Remove the source map files from production package and add some safe handlers for them.

### False venue id

When the SSG pages fallback is set to 'blocking', it means that the getStaticProps is called only when the page is accessed and it's getting rendered for the first time. This means that also the source map files are generated only during that process and not during the build process. When this process happens, the getStaticProps gets called so that the source map filename is set as an page id searchparam. Those cases needs to be handled explicitly.

I also tested the get static paths with fallback set to `true` instead of `'blocking'`. Then the venue page, for example, was rendered as 404 or as a halfly rendered page, when it was opened first time. The 'blocking' still gave much better user experience with the current code base (design and architecture). The advantage of using the fallback : true would have been, that the source map file was created during a build time or at least in the background so that a false request was not made.

### Fix the null-id handling on Venue page container

Because of an unknown reason, the venue sometimes went to VenuePageContainer as an undefined and the venue field destructing failed. This is now refactored so that the possible error is fixed.