### PR TITLE
LIIKUNTA-564 | feat(sports): hide empty service owner info section in venue detail page

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueInfo/VenueInfo.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueInfo/VenueInfo.tsx
@@ -207,6 +207,9 @@ const VenueInfo = ({ venue }: { venue: Venue }) => {
     container: venueInfoContainer,
     className: styles.focusVisible,
   });
+  const isServiceOwnerInfoVisible =
+    isVenueHelsinkiCityOwned(venue) || venue?.displayedServiceOwner;
+
   return (
     <div className={styles.venueInfo} ref={venueInfoContainer}>
       <div className={styles.contentWrapper}>
@@ -214,7 +217,7 @@ const VenueInfo = ({ venue }: { venue: Venue }) => {
         <ContactDetailsInfo venue={venue} />
         <VenueInformationLinksContainer venue={venue} />
         <VenueRouteInfo venue={venue} />
-        <ServiceOwnerInfo venue={venue} />
+        {isServiceOwnerInfoVisible && <ServiceOwnerInfo venue={venue} />}
       </div>
     </div>
   );


### PR DESCRIPTION
### feat(sports): hide empty service owner info section in venue detail page

refs LIIKUNTA-564

## Description

## Issues

### Closes

**[LIIKUNTA-564](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-564)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
