### PR TITLE
feat(sports): show venue's short description in venue detail page

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueContent/VenueContent.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueContent/VenueContent.tsx
@@ -24,8 +24,7 @@ interface Props {
 
 const VenueContent: React.FC<Props> = ({ venue, className }) => {
   const { t } = useVenueTranslation();
-  const { description } = venue;
-  const shortDescription = null;
+  const { description, shortDescription } = venue;
   return (
     <PageSection className={classNames(styles.eventContent, className)}>
       <ContentContainer>


### PR DESCRIPTION
## Description

### feat(sports): show venue's short description in venue detail page

shortDescription was added to the venue-graphql-proxy recently, so it is
now available

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
