### PR TITLE
LIIKUNTA-555 | feat(cookies): set cookie domain to hostname i.e. <application>.hel.fi

### DIFF
--- a/apps/events-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/events-helsinki/src/domain/app/AppConfig.ts
@@ -63,6 +63,13 @@ class AppConfig {
   }
 
   /**
+   * The own hostname of the app.
+   */
+  static get hostname() {
+    return new URL(this.origin).hostname;
+  }
+
+  /**
    * The app uses multiple domains from the Headless CMS API.
    * It serves posts / articles from 1 root and e.g the pages from another.
    * The CMS needs to be configured so, that the URI of an object it serves

--- a/apps/events-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
+++ b/apps/events-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
@@ -12,6 +12,16 @@ afterAll(() => {
 });
 
 it.each([
+  { origin: 'http://localhost:8080', expectedHostname: 'localhost' },
+  { origin: 'https://a.example.org/', expectedHostname: 'a.example.org' },
+  { origin: 'https://a.example.org', expectedHostname: 'a.example.org' },
+  { origin: 'https://a.b.c:8080/1/2/3?a=1&b=2', expectedHostname: 'a.b.c' },
+])('provides hostname from $origin', ({ origin, expectedHostname }) => {
+  process.env.NEXT_PUBLIC_APP_ORIGIN = origin;
+  expect(AppConfig.hostname).toStrictEqual(expectedHostname);
+});
+
+it.each([
   {
     field: 'origin',
     mockEnvValue: 'https://localhost',

--- a/apps/events-helsinki/src/pages/_app.tsx
+++ b/apps/events-helsinki/src/pages/_app.tsx
@@ -52,6 +52,7 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
         <BaseApp
           appName={appName}
           cmsHelper={cmsHelper}
+          cookieDomain={AppConfig.hostname}
           routerHelper={routerHelper}
           matomoConfiguration={AppConfig.matomoConfiguration}
           askemFeedbackConfiguration={AppConfig.askemFeedbackConfiguration(

--- a/apps/events-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/events-helsinki/src/pages/cookie-consent/index.tsx
@@ -21,7 +21,7 @@ export default function CookieConsent() {
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useCommonTranslation();
   const router = useRouter();
-  /* 
+  /*
   // bug or feature: query is empty in handleRedirect
   const router = useRouter();
   const params: { returnPath?: string } = router.query; */

--- a/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/hobbies-helsinki/src/domain/app/AppConfig.ts
@@ -63,6 +63,13 @@ class AppConfig {
   }
 
   /**
+   * The own hostname of the app.
+   */
+  static get hostname() {
+    return new URL(this.origin).hostname;
+  }
+
+  /**
    * The app uses multiple domains from the Headless CMS API.
    * It serves posts / articles from 1 root and e.g the pages from another.
    * The CMS needs to be configured so, that the URI of an object it serves

--- a/apps/hobbies-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
@@ -12,6 +12,16 @@ afterAll(() => {
 });
 
 it.each([
+  { origin: 'http://localhost:8080', expectedHostname: 'localhost' },
+  { origin: 'https://a.example.org/', expectedHostname: 'a.example.org' },
+  { origin: 'https://a.example.org', expectedHostname: 'a.example.org' },
+  { origin: 'https://a.b.c:8080/1/2/3?a=1&b=2', expectedHostname: 'a.b.c' },
+])('provides hostname from $origin', ({ origin, expectedHostname }) => {
+  process.env.NEXT_PUBLIC_APP_ORIGIN = origin;
+  expect(AppConfig.hostname).toStrictEqual(expectedHostname);
+});
+
+it.each([
   {
     field: 'origin',
     mockEnvValue: 'https://localhost',

--- a/apps/hobbies-helsinki/src/pages/_app.tsx
+++ b/apps/hobbies-helsinki/src/pages/_app.tsx
@@ -52,6 +52,7 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
         <BaseApp
           appName={appName}
           cmsHelper={cmsHelper}
+          cookieDomain={AppConfig.hostname}
           routerHelper={routerHelper}
           matomoConfiguration={AppConfig.matomoConfiguration}
           askemFeedbackConfiguration={AppConfig.askemFeedbackConfiguration(

--- a/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
@@ -21,7 +21,7 @@ export default function CookieConsent() {
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useCommonTranslation();
   const router = useRouter();
-  /* 
+  /*
   // bug or feature: query is empty in handleRedirect
   const router = useRouter();
   const params: { returnPath?: string } = router.query; */

--- a/apps/sports-helsinki/src/domain/app/AppConfig.ts
+++ b/apps/sports-helsinki/src/domain/app/AppConfig.ts
@@ -67,6 +67,13 @@ class AppConfig {
   }
 
   /**
+   * The own hostname of the app.
+   */
+  static get hostname() {
+    return new URL(this.origin).hostname;
+  }
+
+  /**
    * The app uses multiple domains from the Headless CMS API.
    * It serves posts / articles from 1 root and e.g the pages from another.
    * The CMS needs to be configured so, that the URI of an object it serves

--- a/apps/sports-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
+++ b/apps/sports-helsinki/src/domain/app/__tests__/AppConfig.test.tsx
@@ -11,6 +11,16 @@ afterAll(() => {
 });
 
 it.each([
+  { origin: 'http://localhost:8080', expectedHostname: 'localhost' },
+  { origin: 'https://a.example.org/', expectedHostname: 'a.example.org' },
+  { origin: 'https://a.example.org', expectedHostname: 'a.example.org' },
+  { origin: 'https://a.b.c:8080/1/2/3?a=1&b=2', expectedHostname: 'a.b.c' },
+])('provides hostname from $origin', ({ origin, expectedHostname }) => {
+  process.env.NEXT_PUBLIC_APP_ORIGIN = origin;
+  expect(AppConfig.hostname).toStrictEqual(expectedHostname);
+});
+
+it.each([
   {
     field: 'origin',
     mockEnvValue: 'https://localhost',

--- a/apps/sports-helsinki/src/pages/_app.tsx
+++ b/apps/sports-helsinki/src/pages/_app.tsx
@@ -52,6 +52,7 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
         <BaseApp
           appName={appName}
           cmsHelper={cmsHelper}
+          cookieDomain={AppConfig.hostname}
           routerHelper={routerHelper}
           matomoConfiguration={AppConfig.matomoConfiguration}
           askemFeedbackConfiguration={AppConfig.askemFeedbackConfiguration(

--- a/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
@@ -21,7 +21,7 @@ export default function CookieConsent() {
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useCommonTranslation();
   const router = useRouter();
-  /* 
+  /*
   // bug or feature: query is empty in handleRedirect
   const router = useRouter();
   const params: { returnPath?: string } = router.query; */

--- a/packages/components/src/app/BaseApp.tsx
+++ b/packages/components/src/app/BaseApp.tsx
@@ -18,6 +18,7 @@ import AskemProvider from '../components/askem/AskemProvider';
 import ErrorFallback from '../components/errorPages/ErrorFallback';
 import EventsCookieConsent from '../components/eventsCookieConsent/EventsCookieConsent';
 import ResetFocus from '../components/resetFocus/ResetFocus';
+import { CookieConfigurationProvider } from '../cookieConfigurationProvider';
 import { GeolocationProvider } from '../geolocation';
 import { NavigationProvider } from '../navigationProvider';
 import type { NavigationProviderProps } from '../navigationProvider';
@@ -32,6 +33,7 @@ import type { CmsRoutedAppHelper, HeadlessCMSHelper } from '../utils';
 export type Props = {
   children: React.ReactNode;
   cmsHelper: HeadlessCMSHelper;
+  cookieDomain: string;
   routerHelper: CmsRoutedAppHelper;
   appName: string;
   matomoConfiguration: Parameters<typeof createMatomoInstance>[0];
@@ -68,6 +70,7 @@ function BaseApp({
   languages,
   appName,
   cmsHelper,
+  cookieDomain,
   routerHelper,
   matomoConfiguration,
   askemFeedbackConfiguration,
@@ -83,7 +86,7 @@ function BaseApp({
   getPlainEventUrl,
   getKeywordOnClickHandler,
 }: Props) {
-  const { getAllConsents } = useCookies();
+  const { getAllConsents } = useCookies({ cookieDomain });
 
   // Unset hidden visibility that was applied to hide the first server render
   // that does not include styles from HDS. HDS applies styling by injecting
@@ -135,45 +138,47 @@ function BaseApp({
   );
 
   return (
-    <AppThemeProvider
-      defaultButtonTheme={defaultButtonTheme}
-      defaultButtonVariant={defaultButtonVariant}
-    >
-      <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
-        <AppRoutingProvider
-          getCardUrl={getCardUrl}
-          getEventUrl={getEventUrl}
-          getEventListLinkUrl={getEventListLinkUrl}
-          getOrganizationSearchUrl={getOrganizationSearchUrl}
-          getHelsinkiOnlySearchUrl={getHelsinkiOnlySearchUrl}
-          getPlainEventUrl={getPlainEventUrl}
-          getKeywordOnClickHandler={getKeywordOnClickHandler}
-        >
-          <MatomoProvider value={matomoInstance}>
-            <AskemProvider value={askemFeedbackInstance}>
-              <GeolocationProvider>
-                <NavigationProvider
-                  headerMenu={headerMenu}
-                  footerMenu={footerMenu}
-                  languages={languages}
-                >
-                  <ResetFocus />
-                  {children}
-                  {withConsent && (
-                    <EventsCookieConsent
-                      onConsentGiven={handleConsentGiven}
-                      allowLanguageSwitch={false}
-                      appName={appName}
-                    />
-                  )}
-                  <DynamicToastContainer />
-                </NavigationProvider>
-              </GeolocationProvider>
-            </AskemProvider>
-          </MatomoProvider>
-        </AppRoutingProvider>
-      </CmsHelperProvider>
-    </AppThemeProvider>
+    <CookieConfigurationProvider cookieDomain={cookieDomain}>
+      <AppThemeProvider
+        defaultButtonTheme={defaultButtonTheme}
+        defaultButtonVariant={defaultButtonVariant}
+      >
+        <CmsHelperProvider cmsHelper={cmsHelper} routerHelper={routerHelper}>
+          <AppRoutingProvider
+            getCardUrl={getCardUrl}
+            getEventUrl={getEventUrl}
+            getEventListLinkUrl={getEventListLinkUrl}
+            getOrganizationSearchUrl={getOrganizationSearchUrl}
+            getHelsinkiOnlySearchUrl={getHelsinkiOnlySearchUrl}
+            getPlainEventUrl={getPlainEventUrl}
+            getKeywordOnClickHandler={getKeywordOnClickHandler}
+          >
+            <MatomoProvider value={matomoInstance}>
+              <AskemProvider value={askemFeedbackInstance}>
+                <GeolocationProvider>
+                  <NavigationProvider
+                    headerMenu={headerMenu}
+                    footerMenu={footerMenu}
+                    languages={languages}
+                  >
+                    <ResetFocus />
+                    {children}
+                    {withConsent && (
+                      <EventsCookieConsent
+                        onConsentGiven={handleConsentGiven}
+                        allowLanguageSwitch={false}
+                        appName={appName}
+                      />
+                    )}
+                    <DynamicToastContainer />
+                  </NavigationProvider>
+                </GeolocationProvider>
+              </AskemProvider>
+            </MatomoProvider>
+          </AppRoutingProvider>
+        </CmsHelperProvider>
+      </AppThemeProvider>
+    </CookieConfigurationProvider>
   );
 }
 

--- a/packages/components/src/components/eventsCookieConsent/EventsCookieConsent.tsx
+++ b/packages/components/src/components/eventsCookieConsent/EventsCookieConsent.tsx
@@ -3,6 +3,7 @@ import type { ContentSource } from 'hds-react';
 import { CookiePage, useCookies, CookieModal } from 'hds-react';
 import React, { useCallback } from 'react';
 import { MAIN_CONTENT_ID } from '../../constants';
+import { useCookieConfigurationContext } from '../../cookieConfigurationProvider';
 import { useConsentTranslation } from '../../hooks';
 import useLocale from '../../hooks/useLocale';
 
@@ -23,7 +24,8 @@ const EventsCookieConsent: React.FC<Props> = ({
   const { t, i18n } = useConsentTranslation();
   const [language, setLanguage] =
     React.useState<ContentSource['currentLanguage']>(locale);
-  const { getAllConsents } = useCookies();
+  const { cookieDomain } = useCookieConfigurationContext();
+  const { getAllConsents } = useCookies({ cookieDomain });
   const { pushInstruction } = useMatomo();
   const [showCookieConsentModal, setShowCookieConsentModal] = React.useState(
     !Object.keys(getAllConsents()).length
@@ -189,9 +191,14 @@ const EventsCookieConsent: React.FC<Props> = ({
   return (
     <>
       {isModal && showCookieConsentModal && (
-        <CookieModal contentSource={contentSource} />
+        <CookieModal
+          contentSource={contentSource}
+          cookieDomain={cookieDomain}
+        />
       )}
-      {!isModal && <CookiePage contentSource={contentSource} />}
+      {!isModal && (
+        <CookiePage contentSource={contentSource} cookieDomain={cookieDomain} />
+      )}
     </>
   );
 };

--- a/packages/components/src/components/mapBox/MapBox.tsx
+++ b/packages/components/src/components/mapBox/MapBox.tsx
@@ -2,6 +2,7 @@ import { IconLocation, useCookies } from 'hds-react';
 import router from 'next/router';
 import React from 'react';
 import { Link, SecondaryLink } from 'react-helsinki-headless-cms';
+import { useCookieConfigurationContext } from '../../cookieConfigurationProvider';
 import { useCommonTranslation } from '../../hooks';
 import CookiesRequired from '../cookieConsent/CookiesRequired';
 import Text from '../text/Text';
@@ -31,7 +32,8 @@ function MapBox({
   consentUrl,
 }: Props) {
   const { t } = useCommonTranslation();
-  const { getAllConsents } = useCookies();
+  const { cookieDomain } = useCookieConfigurationContext();
+  const { getAllConsents } = useCookies({ cookieDomain });
   const getConsentStatus = (cookieId: string) => {
     const consents = getAllConsents();
     return consents[cookieId];

--- a/packages/components/src/components/matomoWrapper/MatomoWrapper.tsx
+++ b/packages/components/src/components/matomoWrapper/MatomoWrapper.tsx
@@ -3,6 +3,7 @@ import { useCookies } from 'hds-react';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import React, { useEffect } from 'react';
+import { useCookieConfigurationContext } from '../../cookieConfigurationProvider';
 
 interface Props {
   children?: ReactNode | undefined;
@@ -11,7 +12,8 @@ interface Props {
 const MatomoWrapper: React.FC<Props> = ({ children }) => {
   const { trackPageView, pushInstruction } = useMatomo();
   const { asPath: pathname } = useRouter();
-  const { getAllConsents } = useCookies();
+  const { cookieDomain } = useCookieConfigurationContext();
+  const { getAllConsents } = useCookies({ cookieDomain });
 
   // Track page changes when pathnname changes
   useEffect(() => {

--- a/packages/components/src/cookieConfigurationProvider/CookieConfigurationContext.tsx
+++ b/packages/components/src/cookieConfigurationProvider/CookieConfigurationContext.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export type CookieConfigurationContextProps = {
+  cookieDomain: string;
+};
+
+const defaultCookieDomain = '';
+
+const CookieConfigurationContext =
+  React.createContext<CookieConfigurationContextProps>({
+    cookieDomain: defaultCookieDomain,
+  });
+
+export default CookieConfigurationContext;

--- a/packages/components/src/cookieConfigurationProvider/CookieConfigurationProvider.tsx
+++ b/packages/components/src/cookieConfigurationProvider/CookieConfigurationProvider.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { CookieConfigurationContextProps } from './CookieConfigurationContext';
+import CookieConfigurationContext from './CookieConfigurationContext';
+
+export type CookieConfigurationProviderProps =
+  CookieConfigurationContextProps & {
+    children: React.ReactNode;
+  };
+
+export default function CookieConfigurationProvider({
+  cookieDomain,
+  children,
+}: CookieConfigurationProviderProps) {
+  const context = { cookieDomain };
+  return (
+    <CookieConfigurationContext.Provider value={context}>
+      {children}
+    </CookieConfigurationContext.Provider>
+  );
+}

--- a/packages/components/src/cookieConfigurationProvider/index.ts
+++ b/packages/components/src/cookieConfigurationProvider/index.ts
@@ -1,0 +1,4 @@
+export type { CookieConfigurationProviderProps } from './CookieConfigurationProvider';
+export { default as CookieConfigurationContext } from './CookieConfigurationContext';
+export { default as CookieConfigurationProvider } from './CookieConfigurationProvider';
+export { default as useCookieConfigurationContext } from './useCookieConfigurationContext';

--- a/packages/components/src/cookieConfigurationProvider/useCookieConfigurationContext.tsx
+++ b/packages/components/src/cookieConfigurationProvider/useCookieConfigurationContext.tsx
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import cookieConfigurationContext from './CookieConfigurationContext';
+
+export default function useCookieConfigurationContext() {
+  return useContext(cookieConfigurationContext);
+}


### PR DESCRIPTION
## Description

### feat(cookies): set cookie domain to hostname i.e. `<application>.hel.fi`

now cookie consents given to tapahtumat.hel.fi, harrastukset.hel.fi and
liikunta.hel.fi should not be removed when navigating to www.hel.fi

closes LIIKUNTA-555

## Issues

### Closes

**[LIIKUNTA-555](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-555)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-555]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ