### PR TITLE
fix: keep Helsinki city owned icon on same row as the preceding text

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueCard/LargeVenueCard.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueCard/LargeVenueCard.tsx
@@ -4,8 +4,9 @@ import {
   useVenueTranslation,
   ArrowRightWithLoadingIndicator,
   useClickCapture,
+  HelsinkiCityOwnedIcon,
 } from '@events-helsinki/components';
-import { IconCheckCircleFill, IconLocation } from 'hds-react';
+import { IconLocation } from 'hds-react';
 import { useRouter } from 'next/router';
 import React from 'react';
 import {
@@ -71,12 +72,7 @@ const LargeVenueCard: React.FC<Props> = ({
           <div className={styles.infoWrapper}>
             <div className={styles.eventName}>
               {title}
-              {isHelsinkiCityOwned && (
-                <IconCheckCircleFill
-                  className={styles.helsinkiCityOwnedIcon}
-                  aria-hidden
-                />
-              )}
+              {isHelsinkiCityOwned && <HelsinkiCityOwnedIcon />}
             </div>
             <div className={styles.eventLocation}>
               <IconLocation aria-hidden />

--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -7,17 +7,12 @@ import {
   useVenueTranslation,
   getLocaleFromPathname,
   isVenueHelsinkiCityOwned,
+  HelsinkiCityOwnedIcon,
 } from '@events-helsinki/components';
 import type { ReturnParams } from '@events-helsinki/components/utils/eventQueryString.util';
 import { extractLatestReturnPath } from '@events-helsinki/components/utils/eventQueryString.util';
 import classNames from 'classnames';
-import {
-  IconArrowLeft,
-  IconCheckCircleFill,
-  IconClock,
-  IconLocation,
-  IconTicket,
-} from 'hds-react';
+import { IconArrowLeft, IconClock, IconLocation, IconTicket } from 'hds-react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -124,12 +119,7 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
                 </div>
                 <h1 className={styles.title}>
                   {venue.name}
-                  {isHelsinkiCityOwned && (
-                    <IconCheckCircleFill
-                      className={styles.helsinkiCityOwnedIcon}
-                      aria-hidden
-                    />
-                  )}
+                  {isHelsinkiCityOwned && <HelsinkiCityOwnedIcon />}
                 </h1>
                 <div className={styles.additionalInfo}>
                   <div className={styles.location}>

--- a/apps/sports-helsinki/src/domain/venue/venueInfo/VenueInfo.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueInfo/VenueInfo.tsx
@@ -8,9 +8,9 @@ import {
   isVenueHelsinkiCityOwned,
   useAppRoutingContext,
   useLocale,
+  HelsinkiCityOwnedIcon,
 } from '@events-helsinki/components';
 import {
-  IconCheckCircleFill,
   IconClock,
   IconCompany,
   IconInfoCircle,
@@ -179,10 +179,7 @@ const ServiceOwnerInfo = ({ venue }: { venue: Venue }) => {
         {isHelsinkiCityOwned && (
           <div className={styles.helsinkiCityOwnedText}>
             {commonT('common:cityOfHelsinki')}
-            <IconCheckCircleFill
-              className={styles.helsinkiCityOwnedIcon}
-              aria-hidden
-            />
+            <HelsinkiCityOwnedIcon />
           </div>
         )}
         <div>{cleanedServiceOwnerName}</div>

--- a/packages/components/src/components/domain/event/eventInfo/OrganizationInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/OrganizationInfo.tsx
@@ -1,4 +1,4 @@
-import { IconCheckCircleFill, IconFaceSmile, IconLayers } from 'hds-react';
+import { IconFaceSmile, IconLayers } from 'hds-react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -15,6 +15,7 @@ import {
   isEventHelsinkiCityOwned,
 } from '../../../../utils/eventUtils';
 import { translateValue } from '../../../../utils/translateUtils';
+import HelsinkiCityOwnedIcon from '../../../helsinkiCityOwnedIcon/HelsinkiCityOwnedIcon';
 import styles from './eventInfo.module.scss';
 
 interface Props {
@@ -49,10 +50,7 @@ const OrganizationInfo: React.FC<Props> = ({ event }) => {
             {isHelsinkiCityOwned && (
               <div className={styles.helsinkiCityOwnedText}>
                 {commonT('common:cityOfHelsinki')}
-                <IconCheckCircleFill
-                  className={styles.helsinkiCityOwnedIcon}
-                  aria-hidden
-                />
+                <HelsinkiCityOwnedIcon />
               </div>
             )}
             {organizationName && (

--- a/packages/components/src/components/eventName/EventName.tsx
+++ b/packages/components/src/components/eventName/EventName.tsx
@@ -1,4 +1,3 @@
-import { IconCheckCircleFill } from 'hds-react';
 import React from 'react';
 
 import { useEventTranslation, useLocale } from '../../hooks';
@@ -8,6 +7,7 @@ import {
   isEventCancelled,
   isEventHelsinkiCityOwned,
 } from '../../utils';
+import HelsinkiCityOwnedIcon from '../helsinkiCityOwnedIcon/HelsinkiCityOwnedIcon';
 import styles from './eventName.module.scss';
 
 interface EventNameProps {
@@ -30,12 +30,7 @@ const EventName: React.FC<EventNameProps> = ({ event }) => {
         </span>
       )}
       {name}
-      {isHelsinkiCityOwned && (
-        <IconCheckCircleFill
-          className={styles.helsinkiCityOwnedIcon}
-          aria-hidden
-        />
-      )}
+      {isHelsinkiCityOwned && <HelsinkiCityOwnedIcon />}
     </>
   );
 };

--- a/packages/components/src/components/helsinkiCityOwnedIcon/HelsinkiCityOwnedIcon.tsx
+++ b/packages/components/src/components/helsinkiCityOwnedIcon/HelsinkiCityOwnedIcon.tsx
@@ -1,0 +1,17 @@
+import { IconCheckCircleFill } from 'hds-react';
+import React from 'react';
+import styles from './helsinkiCityOwnedIcon.module.scss';
+
+const HelsinkiCityOwnedIcon: React.FC = () => {
+  return (
+    <span className={styles.helsinkiCityOwnedSpan}>
+      &#xFEFF; {/* Zero width no-break space */}
+      <IconCheckCircleFill
+        className={styles.helsinkiCityOwnedIcon}
+        aria-hidden
+      />
+    </span>
+  );
+};
+
+export default HelsinkiCityOwnedIcon;

--- a/packages/components/src/components/helsinkiCityOwnedIcon/helsinkiCityOwnedIcon.module.scss
+++ b/packages/components/src/components/helsinkiCityOwnedIcon/helsinkiCityOwnedIcon.module.scss
@@ -1,0 +1,10 @@
+.helsinkiCityOwnedSpan {
+  white-space: nowrap;
+}
+
+.helsinkiCityOwnedIcon {
+  margin-bottom: 0.1em;
+  margin-left: 0.1em;
+  color: var(--color-coat-of-arms);
+  vertical-align: middle;
+}

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -10,6 +10,7 @@ export { default as EventsCookieConsent } from './eventsCookieConsent/EventsCook
 export { default as EventsOrderBySelect } from './orderBySelect/EventsOrderBySelect';
 export * from './filterButton';
 export { default as FooterSection } from './footer/Footer';
+export { default as HelsinkiCityOwnedIcon } from './helsinkiCityOwnedIcon/HelsinkiCityOwnedIcon';
 export { default as HeroComponent } from './hero/HeroComponent';
 export { default as HeroImage } from './hero/HeroImage';
 export { default as IconButton } from './iconButton/IconButton';

--- a/packages/components/src/styles/helsinkiCityOwned.scss
+++ b/packages/components/src/styles/helsinkiCityOwned.scss
@@ -1,10 +1,3 @@
-.helsinkiCityOwnedIcon {
-  margin-bottom: 0.1em;
-  margin-left: 0.1em;
-  color: var(--color-coat-of-arms);
-  vertical-align: middle;
-}
-
 .helsinkiCityOwnedText {
   color: var(--color-coat-of-arms-dark);
 }


### PR DESCRIPTION
## Description

### fix: keep Helsinki city owned icon on same row as the preceding text

refs LIIKUNTA-528

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
