### PR TITLE
LIIKUNTA-27 | chore: update unified-search & venues subgraph, supergraph and types

### DIFF
--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -37,9 +37,9 @@ export type Accessibility = {
   __typename?: 'Accessibility';
   email?: Maybe<Scalars['String']['output']>;
   phone?: Maybe<Scalars['String']['output']>;
-  sentences?: Maybe<Array<Maybe<AccessibilitySentence>>>;
-  shortcomings?: Maybe<Array<Maybe<AccessibilityShortcoming>>>;
-  viewpoints?: Maybe<Array<Maybe<AccessibilityViewpoint>>>;
+  sentences: Array<AccessibilitySentence>;
+  shortcomings: Array<AccessibilityShortcoming>;
+  viewpoints: Array<AccessibilityViewpoint>;
   www?: Maybe<Scalars['String']['output']>;
 };
 
@@ -68,15 +68,15 @@ export type AccessibilitySentences = {
 export type AccessibilityShortcoming = {
   __typename?: 'AccessibilityShortcoming';
   count?: Maybe<Scalars['Int']['output']>;
-  profile?: Maybe<AccessibilityProfile>;
+  profile: AccessibilityProfile;
 };
 
 export type AccessibilityViewpoint = {
   __typename?: 'AccessibilityViewpoint';
-  id?: Maybe<Scalars['ID']['output']>;
-  name?: Maybe<LanguageString>;
-  shortages?: Maybe<Array<Maybe<LanguageString>>>;
-  value?: Maybe<AccessibilityViewpointValue>;
+  id: Scalars['ID']['output'];
+  name: LanguageString;
+  shortages: Array<LanguageString>;
+  value: AccessibilityViewpointValue;
 };
 
 export enum AccessibilityViewpointValue {
@@ -8198,9 +8198,6 @@ export type QueryTranslationsArgs = {
 
 /** The root entry point into the Graph */
 export type QueryUnifiedSearchArgs = {
-  accessibilityProfilesWithoutShortcomings?: InputMaybe<
-    Array<InputMaybe<AccessibilityProfile>>
-  >;
   administrativeDivisionId?: InputMaybe<Scalars['ID']['input']>;
   administrativeDivisionIds?: InputMaybe<
     Array<InputMaybe<Scalars['ID']['input']>>
@@ -8217,6 +8214,7 @@ export type QueryUnifiedSearchArgs = {
   ontologyTreeIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   ontologyWordIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   openAt?: InputMaybe<Scalars['String']['input']>;
+  orderByAccessibilityProfile?: InputMaybe<AccessibilityProfile>;
   orderByDistance?: InputMaybe<OrderByDistance>;
   orderByName?: InputMaybe<OrderByName>;
   providerTypes?: InputMaybe<Array<InputMaybe<ProviderType>>>;
@@ -11137,11 +11135,21 @@ export type UnifiedSearchVenue = {
   name?: Maybe<LanguageString>;
   ontologyWords?: Maybe<Array<Maybe<OntologyWord>>>;
   openingHours?: Maybe<OpeningHours>;
+  orderedByAccessibilityShortcoming?: Maybe<AccessibilityShortcoming>;
   partOf?: Maybe<UnifiedSearchVenue>;
   reservationPolicy?: Maybe<VenueReservationPolicy>;
   resources: Array<Resource>;
   serviceOwner?: Maybe<ServiceOwner>;
   targetGroups?: Maybe<Array<Maybe<TargetGroup>>>;
+};
+
+/**
+ * A place that forms a unit and can be used for some specific purpose -
+ * respa unit or resource, service map unit, beta.kultus venue, linked
+ * events place, Kukkuu venue
+ */
+export type UnifiedSearchVenueOrderedByAccessibilityShortcomingArgs = {
+  profile?: InputMaybe<AccessibilityProfile>;
 };
 
 /** Any node that has a URI */

--- a/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
+++ b/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
@@ -159,6 +159,13 @@ type Query {
     ontologyTreeIds: [ID]
 
     """
+    Optional, filter to match only these ontology tree ids,
+    if ontologyTreeIds is also given then it must match separately i.e.
+    at least one ontology tree ID must match in both sets separately.
+    """
+    ontologyTreeIdsOrSet2: [ID]
+
+    """
     Optional, filter to match only these ontology word ids
     """
     ontologyWordIds: [ID]
@@ -183,12 +190,6 @@ type Query {
     If not given or false, all venues are shown.
     """
     mustHaveReservableResource: Boolean
-
-    """
-    Optional, filter to show only venues that have no known shortcomings for any of
-    the given accessibility profiles.
-    """
-    accessibilityProfilesWithoutShortcomings: [AccessibilityProfile]
 
     """
     Optional search index.
@@ -233,14 +234,26 @@ type Query {
     openAt: String
 
     """
-    Order results by distance to given coordinates. Cannot be used with "orderByName".
+    Order results by distance to given coordinates.
+    Mutually exclusive with other orderBy* parameters.
     """
     orderByDistance: OrderByDistance
 
     """
-    Order results by venue name in language given as the first value in "languages" argument. Cannot be used with "orderByDistance".
+    Order results by venue name in language given as the first value in "languages" argument.
+    Mutually exclusive with other orderBy* parameters.
     """
     orderByName: OrderByName
+
+    """
+    Optional, order venues by given accessibility profile's shortcomings,
+    first the results that have no accessibility shortcomings for the given profile,
+    then the ones with 1 shortcoming, 2 shortcomings, ..., N shortcomings and
+    last the ones with unknown shortcomings (i.e. no data for or against).
+
+    Mutually exclusive with other orderBy* parameters.
+    """
+    orderByAccessibilityProfile: AccessibilityProfile
   ): SearchResultConnection
   unifiedSearchCompletionSuggestions(
     """
@@ -451,6 +464,9 @@ type UnifiedSearchVenue {
   contactDetails: ContactInfo
   reservationPolicy: VenueReservationPolicy
   accessibility: Accessibility
+  orderedByAccessibilityShortcoming(
+    profile: AccessibilityProfile
+  ): AccessibilityShortcoming
   arrivalInstructions: String
   additionalInfo: String
   facilities: [VenueFacility!]
@@ -527,10 +543,10 @@ enum AccessibilityViewpointValue {
 }
 
 type AccessibilityViewpoint {
-  id: ID
-  name: LanguageString
-  value: AccessibilityViewpointValue
-  shortages: [LanguageString]
+  id: ID!
+  name: LanguageString!
+  value: AccessibilityViewpointValue!
+  shortages: [LanguageString!]!
 }
 
 enum AccessibilityProfile {
@@ -543,7 +559,7 @@ enum AccessibilityProfile {
 }
 
 type AccessibilityShortcoming {
-  profile: AccessibilityProfile
+  profile: AccessibilityProfile!
   count: Int
 }
 
@@ -557,9 +573,9 @@ type Accessibility {
   email: String
   phone: String
   www: String
-  viewpoints: [AccessibilityViewpoint]
-  sentences: [AccessibilitySentence]
-  shortcomings: [AccessibilityShortcoming]
+  viewpoints: [AccessibilityViewpoint!]!
+  sentences: [AccessibilitySentence!]!
+  shortcomings: [AccessibilityShortcoming!]!
 }
 
 enum ResourceMainType {

--- a/proxies/events-graphql-federation/subgraphs/venues/venues.graphql
+++ b/proxies/events-graphql-federation/subgraphs/venues/venues.graphql
@@ -103,11 +103,32 @@ type VenueConnection {
   url: String
 }
 
+type VenueDepartment {
+  abbreviation: String
+  addressCity: String
+  addressPostalFull: String
+  addressZip: String
+  businessId: String
+  email: String
+  hierarchyLevel: Int
+  id: ID!
+  municipalityCode: Int
+  name: String
+  oid: ID
+  organizationId: ID
+  organizationType: String
+  parentId: ID
+  phone: String
+  streetAddress: String
+  www: String
+}
+
 type Venue {
   addressLocality: String
   addressPostalFull: String
   dataSource: String
   departmentId: ID
+  department: VenueDepartment
   description: String
   displayedServiceOwner: String
   displayedServiceOwnerType: String
@@ -117,28 +138,15 @@ type Venue {
   infoUrl: String
   name: String
   organizationId: ID
+  organization: VenueDepartment
   position: Point
   postalCode: String
   providerType: String
   shortDescription: String
   streetAddress: String
   telephone: String
-
-  """
-  This field is currently disabled because the Hauki integration is not enabled
-  """
   openingHours: [OpeningHour!]
-    @deprecated(
-      reason: "Hauki integration is currently disabled so this field can not be accessed"
-    )
-
-  """
-  This field is currently disabled because the Hauki integration is not enabled
-  """
   isOpen: Boolean
-    @deprecated(
-      reason: "Hauki integration is currently disabled so this field can not be accessed"
-    )
   ontologyTree: [Ontology]!
   ontologyWords: [Ontology]!
   accessibilitySentences: [AccessibilitySentences]!

--- a/proxies/events-graphql-federation/supergraph.graphql
+++ b/proxies/events-graphql-federation/supergraph.graphql
@@ -27,9 +27,9 @@ type Accessibility
   email: String
   phone: String
   www: String
-  viewpoints: [AccessibilityViewpoint]
-  sentences: [AccessibilitySentence]
-  shortcomings: [AccessibilityShortcoming]
+  viewpoints: [AccessibilityViewpoint!]!
+  sentences: [AccessibilitySentence!]!
+  shortcomings: [AccessibilityShortcoming!]!
 }
 
 enum AccessibilityProfile
@@ -61,17 +61,17 @@ type AccessibilitySentences
 type AccessibilityShortcoming
   @join__type(graph: UNIFIED_SEARCH)
 {
-  profile: AccessibilityProfile
+  profile: AccessibilityProfile!
   count: Int
 }
 
 type AccessibilityViewpoint
   @join__type(graph: UNIFIED_SEARCH)
 {
-  id: ID
-  name: LanguageString
-  value: AccessibilityViewpointValue
-  shortages: [LanguageString]
+  id: ID!
+  name: LanguageString!
+  value: AccessibilityViewpointValue!
+  shortages: [LanguageString!]!
 }
 
 enum AccessibilityViewpointValue
@@ -12010,6 +12010,13 @@ type Query
     """Optional, filter to match only these ontology tree ids"""
     ontologyTreeIds: [ID]
 
+    """
+    Optional, filter to match only these ontology tree ids,
+    if ontologyTreeIds is also given then it must match separately i.e.
+    at least one ontology tree ID must match in both sets separately.
+    """
+    ontologyTreeIdsOrSet2: [ID]
+
     """Optional, filter to match only these ontology word ids"""
     ontologyWordIds: [ID]
 
@@ -12027,12 +12034,6 @@ type Query
     If not given or false, all venues are shown.
     """
     mustHaveReservableResource: Boolean
-
-    """
-    Optional, filter to show only venues that have no known shortcomings for any of
-    the given accessibility profiles.
-    """
-    accessibilityProfilesWithoutShortcomings: [AccessibilityProfile]
 
     """Optional search index."""
     index: String
@@ -12069,14 +12070,26 @@ type Query
     openAt: String
 
     """
-    Order results by distance to given coordinates. Cannot be used with "orderByName".
+    Order results by distance to given coordinates.
+    Mutually exclusive with other orderBy* parameters.
     """
     orderByDistance: OrderByDistance
 
     """
-    Order results by venue name in language given as the first value in "languages" argument. Cannot be used with "orderByDistance".
+    Order results by venue name in language given as the first value in "languages" argument.
+    Mutually exclusive with other orderBy* parameters.
     """
     orderByName: OrderByName
+
+    """
+    Optional, order venues by given accessibility profile's shortcomings,
+    first the results that have no accessibility shortcomings for the given profile,
+    then the ones with 1 shortcoming, 2 shortcomings, ..., N shortcomings and
+    last the ones with unknown shortcomings (i.e. no data for or against).
+    
+    Mutually exclusive with other orderBy* parameters.
+    """
+    orderByAccessibilityProfile: AccessibilityProfile
   ): SearchResultConnection @join__field(graph: UNIFIED_SEARCH)
   unifiedSearchCompletionSuggestions(
     """
@@ -16446,6 +16459,7 @@ type UnifiedSearchVenue
   contactDetails: ContactInfo
   reservationPolicy: VenueReservationPolicy
   accessibility: Accessibility
+  orderedByAccessibilityShortcoming(profile: AccessibilityProfile): AccessibilityShortcoming
   arrivalInstructions: String
   additionalInfo: String
   facilities: [VenueFacility!]
@@ -18402,6 +18416,7 @@ type Venue
   addressPostalFull: String
   dataSource: String
   departmentId: ID
+  department: VenueDepartment
   description: String
   displayedServiceOwner: String
   displayedServiceOwnerType: String
@@ -18411,22 +18426,15 @@ type Venue
   infoUrl: String
   name: String
   organizationId: ID
+  organization: VenueDepartment
   position: Point
   postalCode: String
   providerType: String
   shortDescription: String
   streetAddress: String
   telephone: String
-
-  """
-  This field is currently disabled because the Hauki integration is not enabled
-  """
-  openingHours: [OpeningHour!] @deprecated(reason: "Hauki integration is currently disabled so this field can not be accessed")
-
-  """
-  This field is currently disabled because the Hauki integration is not enabled
-  """
-  isOpen: Boolean @deprecated(reason: "Hauki integration is currently disabled so this field can not be accessed")
+  openingHours: [OpeningHour!]
+  isOpen: Boolean
   ontologyTree: [Ontology]!
   ontologyWords: [Ontology]!
   accessibilitySentences: [AccessibilitySentences]!
@@ -18440,6 +18448,28 @@ type VenueConnection
   name: String
   phone: String
   url: String
+}
+
+type VenueDepartment
+  @join__type(graph: VENUES)
+{
+  abbreviation: String
+  addressCity: String
+  addressPostalFull: String
+  addressZip: String
+  businessId: String
+  email: String
+  hierarchyLevel: Int
+  id: ID!
+  municipalityCode: Int
+  name: String
+  oid: ID
+  organizationId: ID
+  organizationType: String
+  parentId: ID
+  phone: String
+  streetAddress: String
+  www: String
 }
 
 """TODO: combine beta.kultus Venue stuff with respa equipment type"""


### PR DESCRIPTION
## Description

Depends on:
 - https://github.com/City-of-Helsinki/unified-search/pull/108 which depends on https://github.com/City-of-Helsinki/unified-search/pull/107
 - https://github.com/City-of-Helsinki/unified-search/pull/109

### chore: update unified-search & venues subgraph, supergraph and types

update unified-search & venues subgraphs, compose supergraph and update
generated types after the following changes:
 - https://github.com/City-of-Helsinki/unified-search/pull/108
 - https://github.com/City-of-Helsinki/unified-search/pull/109

refs LIIKUNTA-27 (unified search PR #109)
refs LIIKUNTA-344 (unified search PR #109)
refs US-113 (unified search PR #108)

## Issues

### Closes

### Related

**[LIIKUNTA-27](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-27)**
**[LIIKUNTA-344](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-344)**
**[US-113](https://helsinkisolutionoffice.atlassian.net/browse/US-113)**

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-27]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[US-113]: https://helsinkisolutionoffice.atlassian.net/browse/US-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIIKUNTA-344]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ