### PR TITLE
feat(search): add order venues by accessibility -option when filtering with accessibility

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/SearchForm.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/SearchForm.tsx
@@ -1,4 +1,7 @@
-import type { AutosuggestMenuOption } from '@events-helsinki/components';
+import type {
+  AutosuggestMenuOption,
+  Option,
+} from '@events-helsinki/components';
 import {
   useSearchTranslation,
   MultiSelectDropdown,
@@ -23,8 +26,12 @@ export const SimpleSearchForm: React.FC<SearchComponentType> = ({
   const { t } = useSearchTranslation();
   const { t: tAppSports } = useAppSportsTranslation();
 
-  const { resetFormValues, setFormValues, updateRouteToSearchPage } =
-    useCombinedSearchContext();
+  const {
+    resetFormValues,
+    setFormValues,
+    setFormValue,
+    updateRouteToSearchPage,
+  } = useCombinedSearchContext();
 
   const {
     autosuggestInput,
@@ -69,6 +76,13 @@ export const SimpleSearchForm: React.FC<SearchComponentType> = ({
     const value = option.text;
     setAutosuggestInput(value);
     handleSubmit();
+  };
+
+  const handleAccessibilityProfileOnChange = (option: Option) => {
+    setSelectedAccessibilityProfile(option?.value);
+    if (option?.value) {
+      setFormValue('venueOrderBy', option.value);
+    }
   };
 
   return (
@@ -127,9 +141,7 @@ export const SimpleSearchForm: React.FC<SearchComponentType> = ({
                   )}
                   options={accessibilityProfiles}
                   value={accessibilityProfileValue}
-                  onChange={(option) =>
-                    setSelectedAccessibilityProfile(option?.value)
-                  }
+                  onChange={handleAccessibilityProfileOnChange}
                   icon={<IconPersonWheelchair aria-hidden />}
                   theme={
                     {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
@@ -15,6 +15,7 @@ import {
   isSportsCategory,
   isTargetGroup,
 } from '@events-helsinki/components/types';
+import { isAccessibilityProfile } from '@events-helsinki/components/utils/accessibilityProfile/typeguards';
 import { appToUnifiedSearchLanguageMap } from '../../eventSearch/types';
 import { initialVenueSearchAdapterValues } from '../constants';
 import type {
@@ -40,6 +41,7 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
   administrativeDivisionIds?: VenueSearchParams['administrativeDivisionIds'];
   orderByName: VenueSearchParams['orderByName'];
   orderByDistance: VenueSearchParams['orderByDistance'];
+  orderByAccessibilityProfile: VenueSearchParams['orderByAccessibilityProfile'];
   after?: VenueSearchParams['after'];
   first?: VenueSearchParams['first'];
 
@@ -80,6 +82,11 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
           ? SortOrder.Descending
           : SortOrder.Ascending,
       } as OrderByDistance;
+    } else if (
+      input.venueOrderBy &&
+      isAccessibilityProfile(input.venueOrderBy)
+    ) {
+      this.orderByAccessibilityProfile = input.venueOrderBy;
     }
   }
 

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
@@ -82,10 +82,7 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
           ? SortOrder.Descending
           : SortOrder.Ascending,
       } as OrderByDistance;
-    } else if (
-      input.venueOrderBy &&
-      isAccessibilityProfile(input.venueOrderBy)
-    ) {
+    } else if (isAccessibilityProfile(input.venueOrderBy)) {
       this.orderByAccessibilityProfile = input.venueOrderBy;
     }
   }

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -133,6 +133,7 @@ export type VenueSearchParams = Pick<
   | 'openAt'
   | 'orderByName'
   | 'orderByDistance'
+  | 'orderByAccessibilityProfile'
   | 'after'
   | 'first'
 >;

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/UnifiedSearchOrderBySelect.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/UnifiedSearchOrderBySelect.tsx
@@ -17,13 +17,11 @@ import useHandleUnifiedSearchOrderChange from '../../../../hooks/useHandleUnifie
 import { useCombinedSearchContext } from '../../combinedSearch/adapters/CombinedSearchContext';
 import styles from './unifiedSearchOrderBySelect.module.scss';
 
-const UnifiedSearchOrderBySelect: React.FC = () => {
+const useUnifiedSearchOrderBySelectOptions = () => {
   const { t } = useSearchTranslation();
   const {
-    formValues: { venueOrderBy, accessibilityProfile },
+    formValues: { accessibilityProfile },
   } = useCombinedSearchContext();
-  const geolocation: GeolocationContextType = useGeolocation({ skip: true });
-  const handleUnifiedSearchOrderChange = useHandleUnifiedSearchOrderChange();
 
   const defaultOption: Option = {
     text: t('search:orderBy.relevance'),
@@ -50,6 +48,19 @@ const UnifiedSearchOrderBySelect: React.FC = () => {
       value: accessibilityProfile,
     });
   }
+
+  return { orderByOptions, defaultOption };
+};
+
+const UnifiedSearchOrderBySelect: React.FC = () => {
+  const { t } = useSearchTranslation();
+  const {
+    formValues: { venueOrderBy, accessibilityProfile },
+  } = useCombinedSearchContext();
+  const geolocation: GeolocationContextType = useGeolocation({ skip: true });
+  const handleUnifiedSearchOrderChange = useHandleUnifiedSearchOrderChange();
+  const { orderByOptions, defaultOption } =
+    useUnifiedSearchOrderBySelectOptions();
 
   const selectedOrderByOption = React.useMemo(
     () =>
@@ -92,6 +103,7 @@ const UnifiedSearchOrderBySelect: React.FC = () => {
       options={orderByOptions}
       icon={geolocation.loading ? <SmallSpinner /> : null}
       className={styles.unifiedSearchOrderBySelect}
+      disabled={!!accessibilityProfile}
     />
   );
 };

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/UnifiedSearchOrderBySelect.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/UnifiedSearchOrderBySelect.tsx
@@ -55,7 +55,7 @@ const useUnifiedSearchOrderBySelectOptions = () => {
 const UnifiedSearchOrderBySelect: React.FC = () => {
   const { t } = useSearchTranslation();
   const {
-    formValues: { venueOrderBy, accessibilityProfile },
+    formValues: { venueOrderBy },
   } = useCombinedSearchContext();
   const geolocation: GeolocationContextType = useGeolocation({ skip: true });
   const handleUnifiedSearchOrderChange = useHandleUnifiedSearchOrderChange();
@@ -65,15 +65,6 @@ const UnifiedSearchOrderBySelect: React.FC = () => {
   const selectedOrderByOption = React.useMemo(
     () =>
       orderByOptions.find((option) => {
-        // If accessbility profile search-filter is used,
-        // the order by value is fixed to the value of the accessibilityProfile.
-        if (
-          accessibilityProfile &&
-          isAccessibilityProfile(accessibilityProfile)
-        ) {
-          return option.value === accessibilityProfile;
-        }
-        // Otherwise, use the venueOrderBy-parameter to select an order by option
         if (venueOrderBy) {
           if (isAccessibilityProfile(venueOrderBy)) {
             return option.value === venueOrderBy;
@@ -84,8 +75,7 @@ const UnifiedSearchOrderBySelect: React.FC = () => {
           return option.value === selectedOptionValue;
         }
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [accessibilityProfile, venueOrderBy]
+    [orderByOptions, venueOrderBy]
   );
 
   return (
@@ -103,7 +93,6 @@ const UnifiedSearchOrderBySelect: React.FC = () => {
       options={orderByOptions}
       icon={geolocation.loading ? <SmallSpinner /> : null}
       className={styles.unifiedSearchOrderBySelect}
-      disabled={!!accessibilityProfile}
     />
   );
 };

--- a/apps/sports-helsinki/src/hooks/useHandleUnifiedSearchOrderChange.ts
+++ b/apps/sports-helsinki/src/hooks/useHandleUnifiedSearchOrderChange.ts
@@ -10,7 +10,7 @@ import type {
   Coordinates,
   Option,
 } from '@events-helsinki/components';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useCombinedSearchContext } from '../domain/search/combinedSearch/adapters/CombinedSearchContext';
 
 const useHandleUnifiedSearchOrderChange = () => {
@@ -18,19 +18,8 @@ const useHandleUnifiedSearchOrderChange = () => {
   const {
     setFormValues,
     updateRouteToSearchPage,
-    formValues: { accessibilityProfile, venueOrderBy },
+    formValues: { accessibilityProfile },
   } = useCombinedSearchContext();
-
-  // Sync the accessibility profile search form value with the venue search query parameter
-  React.useEffect(() => {
-    if (accessibilityProfile !== venueOrderBy) {
-      setFormValues({
-        venueOrderBy: accessibilityProfile,
-      });
-      // Update the URL
-      updateRouteToSearchPage({ shallow: true });
-    }
-  }, [accessibilityProfile, venueOrderBy]);
 
   // Provide a callback for onChange-handler
   return useCallback(

--- a/apps/sports-helsinki/src/hooks/useHandleUnifiedSearchOrderChange.ts
+++ b/apps/sports-helsinki/src/hooks/useHandleUnifiedSearchOrderChange.ts
@@ -1,5 +1,6 @@
 import {
   UnifiedSearchOrderBy,
+  isAccessibilityProfile,
   useGeolocation,
 } from '@events-helsinki/components';
 import type {
@@ -9,45 +10,68 @@ import type {
   Coordinates,
   Option,
 } from '@events-helsinki/components';
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { useCombinedSearchContext } from '../domain/search/combinedSearch/adapters/CombinedSearchContext';
 
 const useHandleUnifiedSearchOrderChange = () => {
   const geolocation: GeolocationContextType = useGeolocation({ skip: true });
-  const { setFormValues, updateRouteToSearchPage } = useCombinedSearchContext();
+  const {
+    setFormValues,
+    updateRouteToSearchPage,
+    formValues: { accessibilityProfile, venueOrderBy },
+  } = useCombinedSearchContext();
+
+  // Sync the accessibility profile search form value with the venue search query parameter
+  React.useEffect(() => {
+    if (accessibilityProfile !== venueOrderBy) {
+      setFormValues({
+        venueOrderBy: accessibilityProfile,
+      });
+      // Update the URL
+      updateRouteToSearchPage({ shallow: true });
+    }
+  }, [accessibilityProfile, venueOrderBy]);
+
+  // Provide a callback for onChange-handler
   return useCallback(
     async (option: Option) => {
       const [orderBy, orderDir] = option.value.split('-') as [
         UnifiedSearchOrderByType,
         OrderDirType
       ];
+      if (isAccessibilityProfile(option.value)) {
+        // Update the combined search form context
+        setFormValues({
+          venueOrderBy: option.value,
+        });
+      } else {
+        // If the user wants to order by distance, try and resolve geolocation
+        if (orderBy === UnifiedSearchOrderBy.distance) {
+          let location: Coordinates | null = geolocation.coordinates;
 
-      // If the user wants to order by distance, try and resolve geolocation
-      if (orderBy === UnifiedSearchOrderBy.distance) {
-        let location: Coordinates | null = geolocation.coordinates;
+          if (!geolocation.called || !geolocation.coordinates) {
+            // Wait until position is resolved. This defers querying search
+            // results until location is resolved, which will result in less UI
+            // states and a slightly better UX.
+            location = await geolocation.resolve();
+          }
 
-        if (!geolocation.called || !geolocation.coordinates) {
-          // Wait until position is resolved. This defers querying search
-          // results until location is resolved, which will result in less UI
-          // states and a slightly better UX.
-          location = await geolocation.resolve();
+          // If location could not be found, return early and do not change
+          // ordering.
+          if (!location) {
+            return null;
+          }
         }
 
-        // If location could not be found, return early and do not change
-        // ordering.
-        if (!location) {
-          return null;
-        }
+        // Update the combined search form context
+        setFormValues({
+          venueOrderBy: orderDir === 'desc' ? `-${orderBy}` : orderBy,
+        });
       }
-
-      // Update the combined search form context
-      setFormValues({
-        venueOrderBy: orderDir === 'desc' ? `-${orderBy}` : orderBy,
-      });
       // Update the URL
       updateRouteToSearchPage({ shallow: true });
     },
-    [geolocation]
+    [geolocation, accessibilityProfile]
   );
 };
 

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -5,6 +5,7 @@
   "errorLoadMore": "Failed to load events",
   "orderBy": {
     "alphabetical": "Alphabetical order",
+    "accessibility": "Accessibility",
     "relevance": "Relevance",
     "distance": "Proximity",
     "endTime": "End time",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -18,6 +18,7 @@
   },
   "orderBy": {
     "alphabetical": "Aakkosjärjestyksessä",
+    "accessibility": "Esteettömyys",
     "relevance": "Osuvuuden mukaan",
     "distance": "Lähimmät ensin",
     "endTime": "Loppumisaika",

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -5,6 +5,7 @@
   "errorLoadMore": "Det gick inte att ladda evenemangen",
   "orderBy": {
     "alphabetical": "I alfabetisk ordning",
+    "accessibility": "Tillgänglighet",
     "relevance": "Efter relevans",
     "distance": "Närmaste först",
     "endTime": "Sluttid",

--- a/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
+++ b/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
@@ -16,6 +16,7 @@ export const SEARCH_LIST_QUERY = gql`
     $openAt: String
     $orderByDistance: OrderByDistance
     $orderByName: OrderByName
+    $orderByAccessibilityProfile: AccessibilityProfile
     $includeHaukiFields: Boolean = true
   ) {
     unifiedSearch(
@@ -34,6 +35,7 @@ export const SEARCH_LIST_QUERY = gql`
       openAt: $openAt
       orderByDistance: $orderByDistance
       orderByName: $orderByName
+      orderByAccessibilityProfile: $orderByAccessibilityProfile
     ) {
       count
       pageInfo {

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -13744,6 +13744,7 @@ export type SearchListQueryVariables = Exact<{
   openAt?: InputMaybe<Scalars['String']['input']>;
   orderByDistance?: InputMaybe<OrderByDistance>;
   orderByName?: InputMaybe<OrderByName>;
+  orderByAccessibilityProfile?: InputMaybe<AccessibilityProfile>;
   includeHaukiFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
@@ -15341,6 +15342,7 @@ export const SearchListDocument = gql`
     $openAt: String
     $orderByDistance: OrderByDistance
     $orderByName: OrderByName
+    $orderByAccessibilityProfile: AccessibilityProfile
     $includeHaukiFields: Boolean = true
   ) {
     unifiedSearch(
@@ -15359,6 +15361,7 @@ export const SearchListDocument = gql`
       openAt: $openAt
       orderByDistance: $orderByDistance
       orderByName: $orderByName
+      orderByAccessibilityProfile: $orderByAccessibilityProfile
     ) {
       count
       pageInfo {
@@ -15472,6 +15475,7 @@ export const SearchListDocument = gql`
  *      openAt: // value for 'openAt'
  *      orderByDistance: // value for 'orderByDistance'
  *      orderByName: // value for 'orderByName'
+ *      orderByAccessibilityProfile: // value for 'orderByAccessibilityProfile'
  *      includeHaukiFields: // value for 'includeHaukiFields'
  *   },
  * });

--- a/packages/components/src/utils/accessibilityProfile/typeguards.ts
+++ b/packages/components/src/utils/accessibilityProfile/typeguards.ts
@@ -1,7 +1,9 @@
 import { AccessibilityProfile } from '../../types';
 
 export function isAccessibilityProfile(
-  value: string
+  value: unknown
 ): value is AccessibilityProfile {
-  return Object.values<string>(AccessibilityProfile).includes(value);
+  return Object.values<AccessibilityProfile>(AccessibilityProfile).includes(
+    value as AccessibilityProfile
+  );
 }

--- a/packages/components/src/utils/accessibilityProfile/typeguards.ts
+++ b/packages/components/src/utils/accessibilityProfile/typeguards.ts
@@ -1,0 +1,7 @@
+import { AccessibilityProfile } from '../../types';
+
+export function isAccessibilityProfile(
+  value: string
+): value is AccessibilityProfile {
+  return Object.values<string>(AccessibilityProfile).includes(value);
+}

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -26,3 +26,4 @@ export { default as stringifyUrlObject } from './stringifyUrlObject';
 export { default as getTranslation } from './getTranslation';
 export { default as getLinkArrowLabel } from './getLinkArrowLabel';
 export { default as getLocaleFromPathname } from './getLocaleFromPathname';
+export * from './accessibilityProfile/typeguards';


### PR DESCRIPTION
Add the order by value: LIIKUNTA-568 LIIKUNTA-567. 

Connect with UnifiedSearch / venue search: LIIKUNTA-569 LIIKUNTA-570.

Continues from #518.

When the accessibility profile is selected in the search context,
the venue ordering should always be a orderByAccessibilityProfile
with the current accessibility profile.

This can be achieved by controlling the venueOrderBy-parameter of the search form.
Every time when the accessibility profile is set and it does not match the venueOrderBy,
the venueOrderBy is set and the URL is refreshed.

~~Also, when the accessibility profile is set and the ordering should be forced
to accessibility profile, the ordering selector is disabled.~~ The venueOrderBy can be rechanged to something else after accessibilityProfile selection.

<img width="1394" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/e8a41239-9461-4569-8168-5dfde93520a0">

### The functions

1. Select an accessibility profile and the venue tab's order by should be forced to the value of an accessibility profile, visually shown as "Esteettömyys" and the right parameter in the URL 
<img width="550" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/ae0d70c7-1220-4a07-bdcb-e198d2d3bf97">
2. Change a search tab and come back: the selection should be remembered and the value should be restored.
3. ~~The order by field should be disabled when the accessibility profile is selected. It changes back to active when the accessibility profile selection is cleared.~~ _this feature is deleted by 1 of the latest commits_
