### PR TITLE
LIIKUNTA-344 | fix: order target groups in dropdown similarly as in target groups' page

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/SearchForm.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/SearchForm.tsx
@@ -36,9 +36,7 @@ export function useFormValues() {
     string[]
   >(formValues.targetGroups);
   const [targetGroupInput, setTargetGroupInput] = React.useState('');
-  const targetGroups = getTargetGroupOptions(t).sort(
-    sortExtendedCategoryOptions
-  );
+  const targetGroups = getTargetGroupOptions(t);
 
   // On page load, initialize the form with values
   // that are available only after the page has fully loaded

--- a/apps/sports-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -194,12 +194,13 @@ export enum EVENT_SEARCH_FILTERS {
 export const CATEGORY_CATALOG = {
   targetGroups: {
     default: [
-      TARGET_GROUPS.ADAPTED_GROUPS,
-      TARGET_GROUPS.ADULTS,
+      // Same order as in https://liikunta.hel.fi/en/pages/target-groups
       TARGET_GROUPS.CHILDREN_AND_FAMILIES,
-      TARGET_GROUPS.PARTNERS,
-      TARGET_GROUPS.SENIORS,
       TARGET_GROUPS.YOUTH,
+      TARGET_GROUPS.ADULTS,
+      TARGET_GROUPS.SENIORS,
+      TARGET_GROUPS.ADAPTED_GROUPS,
+      TARGET_GROUPS.PARTNERS,
     ],
   },
   sportsCategories: {


### PR DESCRIPTION
## Description

### fix: order target groups in dropdown similarly as in target groups' page

target groups are now shown in the same order in the target groups'
dropdown as in https://liikunta.hel.fi/en/pages/target-groups when read
left-to-right top-to-bottom.

refs LIIKUNTA-344

## Issues

### Closes

**[LIIKUNTA-344](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-344)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Finnish
![target-groups-fi](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/4a7582b4-18cf-434f-a593-b606fbb40e4c)

https://liikunta.hel.fi/fi/pages/kohderyhmat

![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/73fe57e1-b5d8-4b30-afd5-e52a985acbc9)

### English
![target-groups-en](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/55a89a72-5037-4fa6-a834-a6d00c7dc668)
https://liikunta.hel.fi/en/pages/target-groups

### Swedish
![target-groups-sv](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/43930805-67b1-400d-81b7-63c627cd35cb)
https://liikunta.hel.fi/sv/sidor/malgrupper

## Additional notes


[LIIKUNTA-344]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ