### PR TITLE
LIIKUNTA-568 | fix: show outline in hobbies/events search's order by select

### DIFF
--- a/packages/components/src/components/orderBySelect/EventsOrderBySelect.tsx
+++ b/packages/components/src/components/orderBySelect/EventsOrderBySelect.tsx
@@ -54,7 +54,6 @@ const EventsOrderBySelect: React.FC<{
       value={selectedOrderByOption ?? defaultOption}
       onChange={customOnChangeHandler ?? setSortQueryParamToOptionValue}
       options={orderByOptions}
-      noOutline
       className={styles.eventsOrderBySelect}
     />
   );


### PR DESCRIPTION
## Description

### fix: show outline in hobbies/events search's order by select

The outline handling was changed in
c7f5d7c60db4548c0d465f95e4a33a8f8e00502c which made the outline
disappear, add back the outline to the hobbies/events search's order by
select by removing the noOutline attribute

refs LIIKUNTA-568

## Issues

### Closes

### Related

[LIIKUNTA-568](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-568)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-568]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ