### PR TITLE
LIIKUNTA-555 | test(cookies): add test for AppConfig.hostname so cookieDomain will work

### DIFF
--- a/apps/events-helsinki/src/domain/app/__tests__/Hostname.test.tsx
+++ b/apps/events-helsinki/src/domain/app/__tests__/Hostname.test.tsx
@@ -1,0 +1,14 @@
+import os from 'os';
+import AppConfig from '../AppConfig';
+
+it('AppConfig.hostname is hostname (or localhost in local development)', () => {
+  // If this test fails the cookieDomain setting won't work with CookieModal/CookiePage
+  // and trying to close the cookie consent modal/page will fail
+  const isLocalDevelopment =
+    AppConfig.debug && process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT == 'develop';
+  const allowedHostnames = [
+    os.hostname(),
+    ...(isLocalDevelopment ? ['localhost'] : []),
+  ];
+  expect(allowedHostnames).toContain(AppConfig.hostname);
+});

--- a/apps/hobbies-helsinki/src/domain/app/__tests__/Hostname.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/app/__tests__/Hostname.test.tsx
@@ -1,0 +1,14 @@
+import os from 'os';
+import AppConfig from '../AppConfig';
+
+it('AppConfig.hostname is hostname (or localhost in local development)', () => {
+  // If this test fails the cookieDomain setting won't work with CookieModal/CookiePage
+  // and trying to close the cookie consent modal/page will fail
+  const isLocalDevelopment =
+    AppConfig.debug && process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT == 'develop';
+  const allowedHostnames = [
+    os.hostname(),
+    ...(isLocalDevelopment ? ['localhost'] : []),
+  ];
+  expect(allowedHostnames).toContain(AppConfig.hostname);
+});

--- a/apps/sports-helsinki/src/domain/app/__tests__/Hostname.test.tsx
+++ b/apps/sports-helsinki/src/domain/app/__tests__/Hostname.test.tsx
@@ -1,0 +1,14 @@
+import os from 'os';
+import AppConfig from '../AppConfig';
+
+it('AppConfig.hostname is hostname (or localhost in local development)', () => {
+  // If this test fails the cookieDomain setting won't work with CookieModal/CookiePage
+  // and trying to close the cookie consent modal/page will fail
+  const isLocalDevelopment =
+    AppConfig.debug && process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT == 'develop';
+  const allowedHostnames = [
+    os.hostname(),
+    ...(isLocalDevelopment ? ['localhost'] : []),
+  ];
+  expect(allowedHostnames).toContain(AppConfig.hostname);
+});


### PR DESCRIPTION
## Description

### test(cookies): add test for AppConfig.hostname so cookieDomain will work

refs LIIKUNTA-555 (started to use cookieDomain)

## Issues

### Closes

[LIIKUNTA-555](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-555)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-555]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ