### PR TITLE
refactor: upgrade the HCRC to fix infinite loop with layout cards modules

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha221",
+    "react-helsinki-headless-cms": "1.0.0-alpha224",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -23,7 +23,6 @@ import { useContext } from 'react';
 import type {
   Breadcrumb,
   CollectionType,
-  PageContentProps,
   ArticleType,
 } from 'react-helsinki-headless-cms';
 import {
@@ -70,7 +69,7 @@ const NextCmsArticle: NextPage<{
           <>
             <RouteMeta origin={AppConfig.origin} page={article} />
             <RHHCPageContent
-              page={article as PageContentProps['page']}
+              page={article}
               heroContainer={<KorosWrapper />}
               breadcrumbs={
                 breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
@@ -153,7 +152,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         }
         const language = getLanguageOrDefault(context.locale);
         logger.info(
-          'pages/articles/[..slug].tsx',
+          'pages/articles/[...slug].tsx',
           'getStaticProps',
           'getEventsStaticProps',
           `Revalidating ${article.uri}.`

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -22,7 +22,6 @@ import { useContext } from 'react';
 import type {
   Breadcrumb,
   CollectionType,
-  PageContentProps,
   PageType,
 } from 'react-helsinki-headless-cms';
 import {
@@ -65,7 +64,7 @@ const NextCmsPage: NextPage<{
           <>
             <RouteMeta origin={AppConfig.origin} page={page} />
             <HCRCPageContent
-              page={page as PageContentProps['page']}
+              page={page}
               collections={
                 collections
                   ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
@@ -140,7 +139,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         }
         const language = getLanguageOrDefault(context.locale);
         logger.info(
-          'pages/pages/[..slug].tsx',
+          'pages/pages/[...slug].tsx',
           'getStaticProps',
           'getEventsStaticProps',
           `Revalidating ${page.uri}.`

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha221",
+    "react-helsinki-headless-cms": "1.0.0-alpha224",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -23,7 +23,6 @@ import { useContext } from 'react';
 import type {
   Breadcrumb,
   CollectionType,
-  PageContentProps,
   ArticleType,
 } from 'react-helsinki-headless-cms';
 import {
@@ -69,7 +68,7 @@ const NextCmsArticle: NextPage<{
           <>
             <RouteMeta origin={AppConfig.origin} page={article} />
             <RHHCPageContent
-              page={article as PageContentProps['page']}
+              page={article}
               heroContainer={<KorosWrapper />}
               breadcrumbs={
                 breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
@@ -152,7 +151,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         }
         const language = getLanguageOrDefault(context.locale);
         logger.info(
-          'pages/articles/[..slug].tsx',
+          'pages/articles/[...slug].tsx',
           'getStaticProps',
           'getHobbiesStaticProps',
           `Revalidating ${article.uri}.`

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -21,7 +21,6 @@ import { useContext } from 'react';
 import type {
   Breadcrumb,
   CollectionType,
-  PageContentProps,
   PageType,
 } from 'react-helsinki-headless-cms';
 import {
@@ -65,7 +64,7 @@ const NextCmsPage: NextPage<{
           <>
             <RouteMeta origin={AppConfig.origin} page={page} />
             <HCRCPageContent
-              page={page as PageContentProps['page']}
+              page={page}
               collections={
                 collections
                   ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
@@ -140,7 +139,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         }
         const language = getLanguageOrDefault(context.locale);
         logger.info(
-          'pages/pages/[..slug].tsx',
+          'pages/pages/[...slug].tsx',
           'getStaticProps',
           'getHobbiesStaticProps',
           `Revalidating ${page.uri}.`

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -80,7 +80,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha221",
+    "react-helsinki-headless-cms": "1.0.0-alpha224",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -23,7 +23,6 @@ import { useContext } from 'react';
 import type {
   Breadcrumb,
   CollectionType,
-  PageContentProps,
   ArticleType,
 } from 'react-helsinki-headless-cms';
 import {
@@ -69,7 +68,7 @@ const NextCmsArticle: NextPage<{
           <>
             <RouteMeta origin={AppConfig.origin} page={article} />
             <RHHCPageContent
-              page={article as PageContentProps['page']}
+              page={article}
               heroContainer={<KorosWrapper />}
               breadcrumbs={
                 breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
@@ -152,7 +151,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         }
         const language = getLanguageOrDefault(context.locale);
         logger.info(
-          'pages/articles/[..slug].tsx',
+          'pages/articles/[...slug].tsx',
           'getStaticProps',
           'getSportsStaticProps',
           `Revalidating ${article.uri}.`

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -22,7 +22,6 @@ import { useContext } from 'react';
 import type {
   Breadcrumb,
   CollectionType,
-  PageContentProps,
   PageType,
 } from 'react-helsinki-headless-cms';
 import {
@@ -65,7 +64,7 @@ const NextCmsPage: NextPage<{
           <>
             <RouteMeta origin={AppConfig.origin} page={page} />
             <HCRCPageContent
-              page={page as PageContentProps['page']}
+              page={page}
               collections={
                 collections
                   ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
@@ -140,7 +139,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         }
         const language = getLanguageOrDefault(context.locale);
         logger.info(
-          'pages/pages/[..slug].tsx',
+          'pages/pages/[...slug].tsx',
           'getStaticProps',
           'getSportsStaticProps',
           `Revalidating ${page.uri}.`

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "v1.0.0-alpha221",
+    "react-helsinki-headless-cms": "1.0.0-alpha224",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,7 +3325,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha221"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha224"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -13656,7 +13656,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha221"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha224"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -15489,7 +15489,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha221"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha224"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -22539,9 +22539,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:v1.0.0-alpha221":
-  version: 1.0.0-alpha221
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha221"
+"react-helsinki-headless-cms@npm:1.0.0-alpha224":
+  version: 1.0.0-alpha224
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha224"
   dependencies:
     hds-core: "npm:^2.17.0"
     hds-design-tokens: "npm:^2.17.0"
@@ -22559,7 +22559,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: 377435479c839226556a58c0ddf8ebe264282ff94f6e09fca0563130465a860a2b851b71a4ff7f677494b20ba5709687e3a110d91994eda033b53c83a81731f2
+  checksum: 0b8e8f9dc0be0fa673a3a84f0ba3ea27640799c03c1920f794a5c484dc29c9ed9f5d0f66a360276de4306cb1aa96d743fcc9d48eb60fa85fa0d334b0ec9615a8
   languageName: node
   linkType: hard
 
@@ -24599,7 +24599,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:v1.0.0-alpha221"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha224"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"


### PR DESCRIPTION
HCRC-106 HCRC-108.

Fix the HCRC layout cards -module which made an infinite rerendering loop in CMS pages. Relates to https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/132