### PR TITLE
chore: upgrade HCRC-lib

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha229",
+    "react-helsinki-headless-cms": "1.0.0-alpha229-canary-98a672e",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha229",
+    "react-helsinki-headless-cms": "1.0.0-alpha229-canary-98a672e",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -80,7 +80,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha229",
+    "react-helsinki-headless-cms": "1.0.0-alpha229-canary-98a672e",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha229",
+    "react-helsinki-headless-cms": "1.0.0-alpha229-canary-98a672e",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,7 +3328,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha229"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha229-canary-98a672e"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -13880,7 +13880,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha229"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha229-canary-98a672e"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -15748,7 +15748,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha229"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha229-canary-98a672e"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -22909,9 +22909,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha229":
-  version: 1.0.0-alpha229
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha229"
+"react-helsinki-headless-cms@npm:1.0.0-alpha229-canary-98a672e":
+  version: 1.0.0-alpha229-canary-98a672e
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha229-canary-98a672e"
   dependencies:
     hds-core: "npm:^3.1.0"
     hds-design-tokens: "npm:^3.1.0"
@@ -22929,7 +22929,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: 54fa10b59189e2742aa01ae1a6c43263a1bedd7c9eb2636bc526c0f2e6849cf53776d1a98b62d851a1387a1b5dd8c878908caab546edfa52496df5419dd329c4
+  checksum: 62fceec86824409773c233d447367cd970c64bf1b4f5d859cbb544a87af8af783a7a22d43df97f4cd6a629037c07e0066bc2aaf2def7a202408dc29349c335b6
   languageName: node
   linkType: hard
 
@@ -24980,7 +24980,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha229"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha229-canary-98a672e"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"


### PR DESCRIPTION
LIIKUNTA-577.

Upgrade HCRC-lib to get event search carousel start-param handling for past dates. HCRC changes in https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/134.
