### PR TITLE
LIIKUNTA-590 | feat(sports): set english app name to "Sports and recreation"

### DIFF
--- a/packages/common-i18n/src/locales/en/appSports.json
+++ b/packages/common-i18n/src/locales/en/appSports.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Sports",
+  "appName": "Sports and recreation",
   "footer": {
     "titleSportsCategories": "Popular sports categories"
   },


### PR DESCRIPTION
## Description

### feat(sports): set english app name to "Sports and recreation"

refs LIIKUNTA-590

## Issues

### Closes

[LIIKUNTA-590](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-590)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

![Screenshot 2023-11-23 094118](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/633e24be-9e00-4712-9782-062133037dfd)

## Additional notes


[LIIKUNTA-590]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ