### PR TITLE
Add reservable venue search filter

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
@@ -73,6 +73,7 @@ class CombinedSearchFormAdapter
   sportsCategories: string[];
   targetGroups: string[];
   helsinkiOnly?: boolean | string | null;
+  reservable?: boolean | string | null;
   accessibilityProfile?: string | null;
   organization?: string | null;
   place?: string | null;
@@ -118,6 +119,7 @@ class CombinedSearchFormAdapter
     this.targetGroups = this.getMultiValueInput<'targetGroups'>('targetGroups');
     this.helsinkiOnly =
       this.getSingleValueInput<'helsinkiOnly'>('helsinkiOnly');
+    this.reservable = this.getSingleValueInput<'reservable'>('reservable');
     this.organization = this.getSingleValueInput<'organization'>(
       'organization',
       'publisher'
@@ -281,6 +283,10 @@ class CombinedSearchFormAdapter
 
   public cleanHelsinkiOnly() {
     this.helsinkiOnly = toTrueOrUndefined(this.helsinkiOnly);
+  }
+
+  public cleanReservable() {
+    this.reservable = toTrueOrUndefined(this.reservable);
   }
 
   public cleanOrganization() {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
@@ -37,6 +37,7 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
   ontologyWordIdOrSets: VenueSearchParams['ontologyWordIdOrSets'];
   providerTypes: VenueSearchParams['providerTypes'];
   serviceOwnerTypes: VenueSearchParams['serviceOwnerTypes'];
+  mustHaveReservableResource: VenueSearchParams['mustHaveReservableResource'];
   openAt?: VenueSearchParams['openAt'];
   administrativeDivisionIds?: VenueSearchParams['administrativeDivisionIds'];
   orderByName: VenueSearchParams['orderByName'];
@@ -71,6 +72,7 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
     this.serviceOwnerTypes = input.helsinkiOnly
       ? [ServiceOwnerType.MunicipalService]
       : initialVenueSearchAdapterValues.serviceOwnerTypes;
+    this.mustHaveReservableResource = !!input.reservable;
     if (input.venueOrderBy?.includes('name')) {
       this.orderByName = input.venueOrderBy.startsWith('-')
         ? { order: SortOrder.Descending }

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -119,6 +119,7 @@ describe('CombinedSearchFormAdapter', () => {
         {
           includeHaukiFields: false,
           language: UnifiedSearchLanguage.Finnish,
+          mustHaveReservableResource: false,
           text: outputQuery.text,
           ontologyWordIdOrSets:
             outputQuery.keywords.length > 0 ? [outputQuery.keywords] : [],

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/VenueSearchAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/VenueSearchAdapter.test.ts
@@ -24,6 +24,7 @@ describe('VenueSearchAdapter', () => {
       const adapter = new VenueSearchAdapter(input, locale);
       const expectedQueryVariables = {
         language: 'FINNISH',
+        mustHaveReservableResource: false,
         includeHaukiFields: false,
         text: input.text,
         ontologyWordIdOrSets: input.keywords.length > 0 ? [input.keywords] : [],

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
@@ -22,6 +22,7 @@ export const initialCombinedSearchFormValues = {
   sportsCategories: [] as string[],
   targetGroups: [] as string[],
   helsinkiOnly: undefined,
+  reservable: undefined,
   organization: undefined,
   place: undefined,
   keywords: [] as string[],

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -59,6 +59,7 @@ export type CombinedSearchAdapterInput = {
   targetGroups: string[];
   organization?: string | null;
   helsinkiOnly?: boolean | string | null;
+  reservable?: boolean | string | null;
   place?: string | null;
   keywords: string[];
   accessibilityProfile?: string | null;
@@ -127,6 +128,7 @@ export type VenueSearchParams = Pick<
   | 'ontologyWordIdOrSets'
   | 'providerTypes'
   | 'serviceOwnerTypes'
+  | 'mustHaveReservableResource'
   | 'targetGroups'
   | 'administrativeDivisionIds'
   | 'openAt'

--- a/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/filterSummary/FilterSummary.tsx
@@ -1,6 +1,7 @@
 import {
   useLocale,
   HelsinkiOnlyFilter,
+  ReservableFilter,
   OrganizationFilter,
   FilterButton,
   translateValue,
@@ -33,6 +34,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
     targetGroups,
     organization,
     helsinkiOnly,
+    reservable,
     text,
     place,
     accessibilityProfile,
@@ -69,6 +71,7 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
     !!sportsCategories.length ||
     !!targetGroups.length ||
     !!helsinkiOnly ||
+    !!reservable ||
     !!organization ||
     !!place ||
     !!accessibilityProfile ||
@@ -114,6 +117,11 @@ const FilterSummary: React.FC<Props> = ({ onClear }) => {
       {helsinkiOnly && (
         <HelsinkiOnlyFilter
           onRemove={() => handleFilterRemove('helsinkiOnly', 'true')}
+        />
+      )}
+      {reservable && (
+        <ReservableFilter
+          onRemove={() => handleFilterRemove('reservable', 'true')}
         />
       )}
       {place && (

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -50,7 +50,8 @@
       "exactAge": "For a {{age}}-year-old"
     },
     "labelAccessibilityProfile": "Accessibility",
-    "ariaLabelClearAccessibilityProfile": "Remove the accessibility shortcoming selection"
+    "ariaLabelClearAccessibilityProfile": "Remove the accessibility shortcoming selection",
+    "reservable": "Reservable"
   },
   "textFoundEvents": "{{count}} search results",
   "buttonLoadMore": "Show more ({{count}})",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -63,7 +63,8 @@
       "exactAge": "{{age}}-vuotiaalle"
     },
     "labelAccessibilityProfile": "Esteettömyys",
-    "ariaLabelClearAccessibilityProfile": "Poista esteettömyysvalinta"
+    "ariaLabelClearAccessibilityProfile": "Poista esteettömyysvalinta",
+    "reservable": "Tilattavissa"
   },
   "goToVenue": "Näytä sivu",
   "openStreetMapContributors": "osallistujat",

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -50,7 +50,8 @@
       "exactAge": "För en {{age}}-åring"
     },
     "labelAccessibilityProfile": "Tillgänglighet",
-    "ariaLabelClearAccessibilityProfile": "Ta bort valet av tillgänglighet"
+    "ariaLabelClearAccessibilityProfile": "Ta bort valet av tillgänglighet",
+    "reservable": "Kan reserveras"
   },
   "textFoundEvents": "{{count}} sökresultat",
   "betaButtonArialLabel": "Vill du ge oss respons på utvecklingsversionen av hobbysöksidan?",

--- a/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
+++ b/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
@@ -17,6 +17,7 @@ export const SEARCH_LIST_QUERY = gql`
     $orderByName: OrderByName
     $orderByAccessibilityProfile: AccessibilityProfile
     $showAccessibilityShortcomingsFor: AccessibilityProfile
+    $mustHaveReservableResource: Boolean
     $includeHaukiFields: Boolean = true
   ) {
     unifiedSearch(
@@ -30,6 +31,7 @@ export const SEARCH_LIST_QUERY = gql`
       ontologyWordIdOrSets: $ontologyWordIdOrSets
       providerTypes: $providerTypes
       serviceOwnerTypes: $serviceOwnerTypes
+      mustHaveReservableResource: $mustHaveReservableResource
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -54,9 +56,19 @@ export const SEARCH_LIST_QUERY = gql`
             }
             description {
               fi
+              sv
+              en
             }
             images {
               url
+            }
+            reservation {
+              reservable
+              externalReservationUrl {
+                fi
+                sv
+                en
+              }
             }
             openingHours @include(if: $includeHaukiFields) {
               today {

--- a/packages/components/src/components/filterButton/types.ts
+++ b/packages/components/src/components/filterButton/types.ts
@@ -8,6 +8,7 @@ export type DateFilterType = 'date' | 'dateType';
  */
 type CombinedSearchInputSubset =
   | 'helsinkiOnly'
+  | 'reservable'
   | 'organization'
   | 'place'
   | 'sportsCategories'

--- a/packages/components/src/components/filters/ReservableFilter.tsx
+++ b/packages/components/src/components/filters/ReservableFilter.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useSearchTranslation } from '../../hooks';
+import { FilterButton } from '../filterButton';
+import type { FilterType } from '../filterButton';
+
+interface Props {
+  onRemove: (value: string, type: FilterType) => void;
+}
+
+const ReservableFilter: React.FC<Props> = ({ onRemove }) => {
+  const { t } = useSearchTranslation();
+
+  return (
+    <FilterButton
+      onRemove={onRemove}
+      text={t('search:search.reservable')}
+      type="reservable"
+      value={'true'}
+    />
+  );
+};
+
+export default ReservableFilter;

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -48,6 +48,7 @@ export { default as Document } from './document/Document';
 export { default as AgeFilter } from './filters/AgeFilter';
 export { default as DateFilter } from './filters/DateFilter';
 export { default as HelsinkiOnlyFilter } from './filters/HelsinkiOnlyFilter';
+export { default as ReservableFilter } from './filters/ReservableFilter';
 export { default as OrganizationFilter } from './filters/OrganizationFilter';
 export { default as PlaceFilter } from './filters/PlaceFilter';
 export { default as PublisherFilter } from './filters/PublisherFilter';

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -8569,6 +8569,12 @@ export type ReleaseToRevisionConnectionWhereArgs = {
   title?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type Reservation = {
+  __typename?: 'Reservation';
+  externalReservationUrl?: Maybe<LanguageString>;
+  reservable?: Maybe<Scalars['Boolean']['output']>;
+};
+
 /** Input for the resetUserPassword mutation. */
 export type ResetUserPasswordInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
@@ -8590,28 +8596,6 @@ export type ResetUserPasswordPayload = {
   user?: Maybe<User>;
 };
 
-export type Resource = {
-  __typename?: 'Resource';
-  description?: Maybe<LanguageString>;
-  externalReservationUrl?: Maybe<Scalars['String']['output']>;
-  genericTerms?: Maybe<LanguageString>;
-  id?: Maybe<Scalars['ID']['output']>;
-  name?: Maybe<LanguageString>;
-  paymentTerms?: Maybe<LanguageString>;
-  reservable?: Maybe<Scalars['Boolean']['output']>;
-  reservationInfo?: Maybe<LanguageString>;
-  responsibleContactInfo?: Maybe<LanguageString>;
-  specificTerms?: Maybe<LanguageString>;
-  type?: Maybe<ResourceType>;
-  userPermissions?: Maybe<ResourceUserPermissions>;
-};
-
-export enum ResourceMainType {
-  Item = 'item',
-  Person = 'person',
-  Space = 'space',
-}
-
 export enum ResourceState {
   Closed = 'closed',
   EnterOnly = 'enter_only',
@@ -8625,18 +8609,6 @@ export enum ResourceState {
   WithKeyAndReservation = 'with_key_and_reservation',
   WithReservation = 'with_reservation',
 }
-
-export type ResourceType = {
-  __typename?: 'ResourceType';
-  id?: Maybe<Scalars['ID']['output']>;
-  mainType?: Maybe<ResourceMainType>;
-  name?: Maybe<LanguageString>;
-};
-
-export type ResourceUserPermissions = {
-  __typename?: 'ResourceUserPermissions';
-  canMakeReservations?: Maybe<Scalars['Boolean']['output']>;
-};
 
 /** Input for the restoreComment mutation. */
 export type RestoreCommentInput = {
@@ -11143,8 +11115,7 @@ export type UnifiedSearchVenue = {
   ontologyWords?: Maybe<Array<Maybe<OntologyWord>>>;
   openingHours?: Maybe<OpeningHours>;
   partOf?: Maybe<UnifiedSearchVenue>;
-  reservationPolicy?: Maybe<VenueReservationPolicy>;
-  resources: Array<Resource>;
+  reservation?: Maybe<Reservation>;
   serviceOwner?: Maybe<ServiceOwner>;
   targetGroups?: Maybe<Array<Maybe<TargetGroup>>>;
 };
@@ -12447,12 +12418,6 @@ export type VenueFacility = {
   name: Scalars['String']['output'];
 };
 
-/** TODO: this comes from respa resource/unit types */
-export type VenueReservationPolicy = {
-  __typename?: 'VenueReservationPolicy';
-  todo?: Maybe<Scalars['String']['output']>;
-};
-
 /** Information about pagination in a connection. */
 export type WpPageInfo = {
   __typename?: 'WPPageInfo';
@@ -13752,6 +13717,7 @@ export type SearchListQueryVariables = Exact<{
   orderByName?: InputMaybe<OrderByName>;
   orderByAccessibilityProfile?: InputMaybe<AccessibilityProfile>;
   showAccessibilityShortcomingsFor?: InputMaybe<AccessibilityProfile>;
+  mustHaveReservableResource?: InputMaybe<Scalars['Boolean']['input']>;
   includeHaukiFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
@@ -13782,11 +13748,23 @@ export type SearchListQuery = {
           description?: {
             __typename?: 'LanguageString';
             fi?: string | null;
+            sv?: string | null;
+            en?: string | null;
           } | null;
           images?: Array<{
             __typename?: 'LocationImage';
             url?: string | null;
           } | null> | null;
+          reservation?: {
+            __typename?: 'Reservation';
+            reservable?: boolean | null;
+            externalReservationUrl?: {
+              __typename?: 'LanguageString';
+              fi?: string | null;
+              sv?: string | null;
+              en?: string | null;
+            } | null;
+          } | null;
           openingHours?: {
             __typename?: 'OpeningHours';
             today?: Array<{
@@ -15359,6 +15337,7 @@ export const SearchListDocument = gql`
     $orderByName: OrderByName
     $orderByAccessibilityProfile: AccessibilityProfile
     $showAccessibilityShortcomingsFor: AccessibilityProfile
+    $mustHaveReservableResource: Boolean
     $includeHaukiFields: Boolean = true
   ) {
     unifiedSearch(
@@ -15372,6 +15351,7 @@ export const SearchListDocument = gql`
       ontologyWordIdOrSets: $ontologyWordIdOrSets
       providerTypes: $providerTypes
       serviceOwnerTypes: $serviceOwnerTypes
+      mustHaveReservableResource: $mustHaveReservableResource
       targetGroups: $targetGroups
       openAt: $openAt
       orderByDistance: $orderByDistance
@@ -15396,9 +15376,19 @@ export const SearchListDocument = gql`
             }
             description {
               fi
+              sv
+              en
             }
             images {
               url
+            }
+            reservation {
+              reservable
+              externalReservationUrl {
+                fi
+                sv
+                en
+              }
             }
             openingHours @include(if: $includeHaukiFields) {
               today {
@@ -15497,6 +15487,7 @@ export const SearchListDocument = gql`
  *      orderByName: // value for 'orderByName'
  *      orderByAccessibilityProfile: // value for 'orderByAccessibilityProfile'
  *      showAccessibilityShortcomingsFor: // value for 'showAccessibilityShortcomingsFor'
+ *      mustHaveReservableResource: // value for 'mustHaveReservableResource'
  *      includeHaukiFields: // value for 'includeHaukiFields'
  *   },
  * });

--- a/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
+++ b/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
@@ -435,14 +435,13 @@ type UnifiedSearchVenue {
   location: LocationDescription @cacheControl(inheritMaxAge: true)
   description: LanguageString
   serviceOwner: ServiceOwner
-  resources: [Resource!]!
   targetGroups: [TargetGroup]
   descriptionResources: DescriptionResources
   partOf: UnifiedSearchVenue
   openingHours: OpeningHours
   manager: LegalEntity
   contactDetails: ContactInfo
-  reservationPolicy: VenueReservationPolicy
+  reservation: Reservation
   accessibility: Accessibility
 
   """
@@ -562,35 +561,9 @@ type Accessibility {
   shortcomings: [AccessibilityShortcoming!]!
 }
 
-enum ResourceMainType {
-  item
-  person
-  space
-}
-
-type ResourceType {
-  id: ID
-  mainType: ResourceMainType
-  name: LanguageString
-}
-
-type ResourceUserPermissions {
-  canMakeReservations: Boolean
-}
-
-type Resource {
-  id: ID
-  name: LanguageString
-  description: LanguageString
-  type: ResourceType
-  userPermissions: ResourceUserPermissions
+type Reservation {
   reservable: Boolean
-  reservationInfo: LanguageString
-  genericTerms: LanguageString
-  paymentTerms: LanguageString
-  specificTerms: LanguageString
-  responsibleContactInfo: LanguageString
-  externalReservationUrl: String
+  externalReservationUrl: LanguageString
 }
 
 """
@@ -705,13 +678,6 @@ type MediaResource {
 enum CacheControlScope {
   PUBLIC
   PRIVATE
-}
-
-"""
-TODO: this comes from respa resource/unit types
-"""
-type VenueReservationPolicy {
-  todo: String
 }
 
 """

--- a/proxies/events-graphql-federation/supergraph.graphql
+++ b/proxies/events-graphql-federation/supergraph.graphql
@@ -12559,6 +12559,13 @@ input ReleaseToRevisionConnectionWhereArgs
   title: String
 }
 
+type Reservation
+  @join__type(graph: UNIFIED_SEARCH)
+{
+  reservable: Boolean
+  externalReservationUrl: LanguageString
+}
+
 """Input for the resetUserPassword mutation."""
 input ResetUserPasswordInput
   @join__type(graph: CMS)
@@ -12591,31 +12598,6 @@ type ResetUserPasswordPayload
   user: User
 }
 
-type Resource
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  id: ID
-  name: LanguageString
-  description: LanguageString
-  type: ResourceType
-  userPermissions: ResourceUserPermissions
-  reservable: Boolean
-  reservationInfo: LanguageString
-  genericTerms: LanguageString
-  paymentTerms: LanguageString
-  specificTerms: LanguageString
-  responsibleContactInfo: LanguageString
-  externalReservationUrl: String
-}
-
-enum ResourceMainType
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  item @join__enumValue(graph: UNIFIED_SEARCH)
-  person @join__enumValue(graph: UNIFIED_SEARCH)
-  space @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
 enum ResourceState
   @join__type(graph: VENUES)
 {
@@ -12630,20 +12612,6 @@ enum ResourceState
   enter_only @join__enumValue(graph: VENUES)
   exit_only @join__enumValue(graph: VENUES)
   weather_permitting @join__enumValue(graph: VENUES)
-}
-
-type ResourceType
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  id: ID
-  mainType: ResourceMainType
-  name: LanguageString
-}
-
-type ResourceUserPermissions
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  canMakeReservations: Boolean
 }
 
 """Input for the restoreComment mutation."""
@@ -16432,14 +16400,13 @@ type UnifiedSearchVenue
   location: LocationDescription
   description: LanguageString
   serviceOwner: ServiceOwner
-  resources: [Resource!]!
   targetGroups: [TargetGroup]
   descriptionResources: DescriptionResources
   partOf: UnifiedSearchVenue
   openingHours: OpeningHours
   manager: LegalEntity
   contactDetails: ContactInfo
-  reservationPolicy: VenueReservationPolicy
+  reservation: Reservation
   accessibility: Accessibility
 
   """Accessibility shortcoming for a specific accessibility profile."""
@@ -18463,13 +18430,6 @@ type VenueFacility
   meta: NodeMeta
   name: String!
   categories: [KeywordString!]
-}
-
-"""TODO: this comes from respa resource/unit types"""
-type VenueReservationPolicy
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  todo: String
 }
 
 """Information about pagination in a connection."""


### PR DESCRIPTION
**Requires the Unified-Search upgrade https://github.com/City-of-Helsinki/unified-search/pull/136.**

The new filter can be used with [/search?searchType=Venue&reservable=true](http://localhost:3000/fi/search?searchType=Venue&reservable=true).

<img width="1455" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/cecdad60-261a-4e82-9fa7-fb2aabf0d09e">


----

.env.local

```
FEDERATION_ROUTER_ENDPOINT="http://localhost:4000"
```

package.json

```
"docker:graphql-router:sports:serve": "cross-env FEDERATION_CMS_ROUTING_URL=https://liikunta.hkih.stage.geniem.io/graphql FEDERATION_EVENTS_ROUTING_URL=https://events-graphql-proxy.test.hel.ninja/proxy/graphql FEDERATION_UNIFIED_SEARCH_ROUTING_URL=http://docker.for.mac.localhost:4002/search FEDERATION_VENUES_ROUTING_URL=https://venue-graphql-proxy.test.hel.ninja/proxy/graphql docker-compose -f docker-compose.router.yml up",
```


Unified-Search docker-compose port-forwarding:

```
services:
  # ...
  search-api:
    # ...
    ports:
      - "4002:4000"
    # ...
```


```
docker compose up
```

To update all the Unified-Search location data:

```
docker compose exec sources bash
```

```
python manage.py ingest_data location
```
