### PR TITLE
LIIKUNTA-597 | fix(navigation): fix retaining URL search parameters on language change

### DIFF
--- a/packages/components/src/components/navigation/Navigation.tsx
+++ b/packages/components/src/components/navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import type { ArticleType, PageType } from 'react-helsinki-headless-cms';
 import {
   Navigation as RHHCNavigation,
@@ -43,6 +43,17 @@ export default function Navigation({
     languages ??
     languagesQuery.data?.languages?.filter(isLanguage);
 
+  // router.query has no query parameters, even if the current URL does when serving
+  // server-side generated pages. Using window.location.search when available and not
+  // always relying on router.query makes the query parameters more available.
+  const getCurrentParsedUrlQuery = useCallback(
+    () =>
+      window
+        ? Object.fromEntries(new URLSearchParams(window.location.search))
+        : router.query,
+    [router?.query]
+  );
+
   return (
     <>
       <RHHCNavigation
@@ -73,7 +84,7 @@ export default function Navigation({
                       cmsHelper.removeContextPathFromUri(translatedPage.uri)
                     ) ?? '',
                 }
-              : router.query,
+              : getCurrentParsedUrlQuery(),
             slug as AppLanguage
           );
         }}


### PR DESCRIPTION
## Description

### fix(navigation): fix retaining URL search parameters on language change

The problem was that router.query had no query parameters, even if the
current URL did when serving server-side pages. Using
window.location.search if it is available and router.query only as a
fallback fixes this.

refs LIIKUNTA-597

## Issues

### Closes

[LIIKUNTA-597](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-597)

### Related

## Testing

### Automated tests

### Manual testing

Started with Finnish search:
 - https://liikunta-pr574.dev.hel.ninja/fi/search?accessibilityProfile=wheelchair&searchType=Venue&sportsCategories=skiing&text=hiihto&venueOrderBy=wheelchair
 - Changed to Swedish using "Svenska" text in header
 - Got redirected to https://liikunta-pr574.dev.hel.ninja/sv/sok?accessibilityProfile=wheelchair&searchType=Venue&sportsCategories=skiing&text=hiihto&venueOrderBy=wheelchair
 - Changed back to Finnish using "Suomi" text in header
 - Got redirected to https://liikunta-pr574.dev.hel.ninja/fi/haku?accessibilityProfile=wheelchair&searchType=Venue&sportsCategories=skiing&text=hiihto&venueOrderBy=wheelchair
 - Changed to Swedish using "Svenska" text in header
 - Got redirected to https://liikunta-pr574.dev.hel.ninja/sv/sok?accessibilityProfile=wheelchair&searchType=Venue&sportsCategories=skiing&text=hiihto&venueOrderBy=wheelchair
 - Looped this action between Finnish and Swedish multiple times and the URL search parameters were retained each time
 - Tried different languages Finnish, English, Swedish, switched between them multiple times and the URL search parameters were retained
 - Avot! Seems to work!

## Screenshots

## Additional notes


[LIIKUNTA-597]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ