### PR TITLE
fix: order of the show on map on mobile

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/combinedSearchPage.module.scss
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/combinedSearchPage.module.scss
@@ -119,7 +119,16 @@ $buttonWidth: 180px;
     justify-content: space-between;
 
     @include respond-below(l) {
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: 1fr;
+      & > div:nth-child(2) {
+        order: 2;
+      }
+
+      & > button {
+        order: 1;
+        margin: 0 0 var(--spacing-xs) 0;
+      }
     }
 
     @include respond-below(l) {


### PR DESCRIPTION
## Description

Move Show on map button on top of the filters list in mobile

<img width="419" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/16116141/5ea479a0-2796-4dff-b9da-410457c7866f">


## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
