### PR TITLE
chore(router): upgrade the Apollo router docker image

### DIFF
--- a/proxies/events-graphql-federation/Dockerfile
+++ b/proxies/events-graphql-federation/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/apollographql/router:v1.22.0 AS router
+FROM ghcr.io/apollographql/router:v1.35.0 AS router
 
 COPY ./supergraph.graphql /dist/schema/supergraph.graphql
 COPY ./router.yaml /dist/config/router.yaml


### PR DESCRIPTION
LIIKUNTA-505.

Upgrade from the Apollo Router 1.22.0 to 1.35.0.

It seems that most of the changes are some fixes to CI
environments or authorization headers.
They should have no effect to our application.

The release notes are here: https://github.com/apollographql/router/releases.
