### PR TITLE
fix: apollo cache should manage multiple identical event search carousels

### DIFF
--- a/packages/components/src/apollo/EventsFederationApolloClient.ts
+++ b/packages/components/src/apollo/EventsFederationApolloClient.ts
@@ -23,6 +23,7 @@ import capitalize from 'lodash/capitalize';
 import { graphqlClientLogger } from '../loggers/logger';
 import type { LanguageString } from '../types';
 import type { CmsRoutedAppHelper } from '../utils';
+import { appendUnique } from '../utils/arrayUtils';
 import isClient from '../utils/isClient';
 
 import {
@@ -225,7 +226,9 @@ class EventsFederationApolloClient {
               (existing, incoming) => {
                 if (!incoming) return existing;
                 return {
-                  data: [...(existing?.data ?? []), ...incoming.data],
+                  data: appendUnique<{
+                    __ref: string;
+                  }>(existing?.data ?? [], incoming.data, '__ref'),
                   meta: incoming.meta,
                 };
               }

--- a/packages/components/src/utils/__tests__/arrayUtils.test.ts
+++ b/packages/components/src/utils/__tests__/arrayUtils.test.ts
@@ -1,0 +1,28 @@
+import { appendUnique } from '../arrayUtils';
+
+describe('appendUnique', () => {
+  it.each([
+    [
+      [{ x: 1 }, { x: 2 }, { x: 3 }],
+      [{ x: 2 }, { x: 3 }, { x: 4 }],
+      [{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }],
+    ],
+    [
+      [{ x: 3 }, { x: 4 }, { x: 5 }],
+      [{ x: 1 }, { x: 2 }, { x: 6 }, { x: 4 }],
+      [{ x: 3 }, { x: 4 }, { x: 5 }, { x: 1 }, { x: 2 }, { x: 6 }],
+    ],
+    [
+      [{ x: 1 }, { x: 2 }, { x: 3 }],
+      [{ a: 2 }, { b: 3 }, { c: 4 }],
+      [{ x: 1 }, { x: 2 }, { x: 3 }],
+    ],
+  ])(
+    'appends a list with the objects that does not exist there yet and has the compared property - %#',
+    (existing, incoming, result) => {
+      expect(
+        appendUnique(existing, incoming as typeof existing, 'x')
+      ).toStrictEqual(result);
+    }
+  );
+});

--- a/packages/components/src/utils/arrayUtils.ts
+++ b/packages/components/src/utils/arrayUtils.ts
@@ -1,0 +1,17 @@
+export function appendUnique<T>(
+  existing: T[],
+  incoming: T[],
+  comparedProperty: keyof T
+) {
+  const existingValues = new Set(
+    existing.map((e) => e[comparedProperty]) ?? []
+  );
+  return [
+    ...existing,
+    ...incoming.filter(
+      (i) =>
+        Object.hasOwnProperty.call(i, comparedProperty) &&
+        !existingValues.has(i[comparedProperty])
+    ),
+  ];
+}

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './season';
 export * from './time';
 export { default as buildQueryFromObject } from './buildQueryFromObject';
 export * from './dateUtils';
+export * from './arrayUtils';
 export * from './eventUtils';
 export { default as getDateArray } from './getDateArray';
 export { default as getDateRangeStr } from './getDateRangeStr';


### PR DESCRIPTION
LIIKUNTA-605.

> The Apollo client (shared by all the monorepo apps) cache configuration seems to not support cases where there are multiple identical event search carousels. All the event search carousels are using the EventList query and the cache is written so that the key is concatenated string of all the used request parameters. Now when there are 7 identical carousels, they all will use the same cache key. The cache key generation excludes 1 key-parameter which is the page-parameter. All this leads to a situation where the Apollo client actually thinks that the 7 different carousels are 7 different page requests, so it actually multiplies the stored value related to the cache key. That’s why there are “thousands“ of pages in a carousel, because the carousel data is actually read from the stored cache.

After this fix, there can be multiple identical carousels in 1 page:
![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/b5624874-06ad-4d43-bb63-dcb08ab310f6)
