### PR TITLE
Refactor pages to be more consistent and to not make needless Apollo queries

### DIFF
--- a/apps/events-helsinki/src/hooks/useEventsRHHCConfig.tsx
+++ b/apps/events-helsinki/src/hooks/useEventsRHHCConfig.tsx
@@ -10,6 +10,7 @@ import {
   useCommonCmsConfig,
   HelsinkiCityOwnedIcon,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_PREFIXES,
+  useAppEventsTranslation,
 } from '@events-helsinki/components';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -41,6 +42,7 @@ export default function useEventsRHHCConfig(args: {
 }) {
   const { apolloClient } = args;
   const { t: commonTranslation } = useCommonTranslation();
+  const { t: appTranslation } = useAppEventsTranslation();
   const { t: eventTranslation } = useEventTranslation();
   const locale = useLocale();
   const commonConfig = useCommonCmsConfig();
@@ -84,7 +86,7 @@ export default function useEventsRHHCConfig(args: {
           <HelsinkiCityOwnedIcon {...props} />
         ),
       },
-      siteName: commonTranslation('appEvents:appName'),
+      siteName: appTranslation('appEvents:appName'),
       currentLanguageCode: locale.toUpperCase(),
       apolloClient,
       eventsApolloClient: apolloClient,
@@ -126,5 +128,12 @@ export default function useEventsRHHCConfig(args: {
       },
       internalHrefOrigins,
     } as unknown as Config;
-  }, [commonConfig, commonTranslation, eventTranslation, locale, apolloClient]);
+  }, [
+    commonConfig,
+    appTranslation,
+    commonTranslation,
+    eventTranslation,
+    locale,
+    apolloClient,
+  ]);
 }

--- a/apps/events-helsinki/src/pages/_app.tsx
+++ b/apps/events-helsinki/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import type { NavigationProviderProps } from '@events-helsinki/components';
 import {
   useLocale,
   BaseApp,
-  useCommonTranslation,
+  useAppEventsTranslation,
 } from '@events-helsinki/components';
 import { FallbackComponent } from '@events-helsinki/components/app/BaseApp';
 import type { AppProps as NextAppProps } from 'next/app';
@@ -38,7 +38,7 @@ export type AppProps<P = any> = {
 export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
-  const { t } = useCommonTranslation();
+  const { t } = useAppEventsTranslation();
   const locale = useLocale();
   const { asPath, pathname } = useRouter();
   const appName = t('appEvents:appName');

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -4,7 +4,6 @@ import {
   ShareLinks,
   getAllArticles,
   Navigation,
-  MatomoWrapper,
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
@@ -60,40 +59,38 @@ const NextCmsArticle: NextPage<{
   if (!article) return null;
 
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="article-page"
-        navigation={<Navigation page={article} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={article} />
-            <RHHCPageContent
-              page={article}
-              breadcrumbs={
-                breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
-              }
-              shareLinks={
-                <ShareLinks title={commonTranslation('common:share.article')} />
-              }
-              collections={
-                collections
-                  ? cmsHelper.getDefaultCollections(
-                      article,
-                      getRoutedInternalHref
-                    )
-                  : []
-              }
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={appTranslation('appEvents:appName')}
+    <RHHCPage
+      className="article-page"
+      navigation={<Navigation page={article} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={article} />
+          <RHHCPageContent
+            page={article}
+            breadcrumbs={
+              breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
+            }
+            shareLinks={
+              <ShareLinks title={commonTranslation('common:share.article')} />
+            }
+            collections={
+              collections
+                ? cmsHelper.getDefaultCollections(
+                    article,
+                    getRoutedInternalHref
+                  )
+                : []
+            }
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={appTranslation('appEvents:appName')}
+        />
+      }
+    />
   );
 };
 

--- a/apps/events-helsinki/src/pages/articles/index.tsx
+++ b/apps/events-helsinki/src/pages/articles/index.tsx
@@ -152,7 +152,7 @@ export default function ArticleArchive({
                       keywords={
                         itemCategories?.edges
                           ?.filter((category: any) => category?.node?.name)
-                          .map((category: any) => category?.node?.name || '') ||
+                          .map((category: any) => category?.node?.name || '') ??
                         []
                       }
                     />
@@ -180,7 +180,7 @@ export default function ArticleArchive({
                       keywords={
                         itemCategories?.edges
                           ?.filter((category: any) => category?.node?.name)
-                          .map((category: any) => category?.node?.name || '') ||
+                          .map((category: any) => category?.node?.name || '') ??
                         []
                       }
                     />

--- a/apps/events-helsinki/src/pages/articles/index.tsx
+++ b/apps/events-helsinki/src/pages/articles/index.tsx
@@ -6,7 +6,6 @@ import {
   skipFalsyType,
   useDebounce,
   Navigation,
-  MatomoWrapper,
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
@@ -110,102 +109,98 @@ export default function ArticleArchive({
   const { footerMenu } = useContext(NavigationContext);
 
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation page={page} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={page} />
-            <SearchPageContent
-              page={page}
-              className="articlesArchive"
-              noResults={!isLoading && articles?.length === 0}
-              items={articles}
-              tags={categories}
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              onSearch={(freeSearch, tags) => {
-                // TODO: Instead of doing this through yet another state, could the query just be updated?
-                setSearchTerm(freeSearch);
-                // NOTE: For some reason the CMS needs database ids here instead of ids or slugs.
-                setSearchCategories(
-                  tags
-                    .filter(skipFalsyType)
-                    .map((tag) => tag?.databaseId.toString())
-                );
-              }}
-              onLoadMore={() => {
-                fetchMoreArticles();
-              }}
-              largeFirstItem={showFirstItemLarge}
-              createLargeCard={(item) => {
-                const cardItem = item as ArticleType;
-                const itemCategories = cardItem?.categories;
-                return (
-                  <LargeCard
-                    key={`lg-card-${item?.id}`}
-                    {...cmsHelper.getArticlePageCardProps(
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation page={page} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={page} />
+          <SearchPageContent
+            page={page}
+            className="articlesArchive"
+            noResults={!isLoading && articles?.length === 0}
+            items={articles}
+            tags={categories}
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            onSearch={(freeSearch, tags) => {
+              // TODO: Instead of doing this through yet another state, could the query just be updated?
+              setSearchTerm(freeSearch);
+              // NOTE: For some reason the CMS needs database ids here instead of ids or slugs.
+              setSearchCategories(
+                tags
+                  .filter(skipFalsyType)
+                  .map((tag) => tag?.databaseId.toString())
+              );
+            }}
+            onLoadMore={() => {
+              fetchMoreArticles();
+            }}
+            largeFirstItem={showFirstItemLarge}
+            createLargeCard={(item) => {
+              const cardItem = item as ArticleType;
+              const itemCategories = cardItem?.categories;
+              return (
+                <LargeCard
+                  key={`lg-card-${item?.id}`}
+                  {...cmsHelper.getArticlePageCardProps(
+                    item as ArticleType,
+                    getRoutedInternalHref
+                  )}
+                  // todo: fix any type
+                  customContent={
+                    <ArticleDetails
+                      keywords={
+                        itemCategories?.edges
+                          ?.filter((category: any) => category?.node?.name)
+                          .map((category: any) => category?.node?.name || '') ||
+                        []
+                      }
+                    />
+                  }
+                />
+              );
+            }}
+            createCard={(item) => {
+              const cardItem = item as ArticleType;
+              const itemCategories = cardItem?.categories;
+              return (
+                <Card
+                  key={`sm-card-${item?.id}`}
+                  {...{
+                    ...cmsHelper.getArticlePageCardProps(
                       item as ArticleType,
                       getRoutedInternalHref
-                    )}
-                    // todo: fix any type
-                    customContent={
-                      <ArticleDetails
-                        keywords={
-                          itemCategories?.edges
-                            ?.filter((category: any) => category?.node?.name)
-                            .map(
-                              (category: any) => category?.node?.name || ''
-                            ) || []
-                        }
-                      />
-                    }
-                  />
-                );
-              }}
-              createCard={(item) => {
-                const cardItem = item as ArticleType;
-                const itemCategories = cardItem?.categories;
-                return (
-                  <Card
-                    key={`sm-card-${item?.id}`}
-                    {...{
-                      ...cmsHelper.getArticlePageCardProps(
-                        item as ArticleType,
-                        getRoutedInternalHref
-                      ),
+                    ),
 
-                      text: '', // A design decision: The text is not wanted in the small cards
-                    }}
-                    // todo: fix any type
-                    customContent={
-                      <ArticleDetails
-                        keywords={
-                          itemCategories?.edges
-                            ?.filter((category: any) => category?.node?.name)
-                            .map(
-                              (category: any) => category?.node?.name || ''
-                            ) || []
-                        }
-                      />
-                    }
-                  />
-                );
-              }}
-              hasMore={hasMoreToLoad}
-              isLoading={isLoading || isLoadingMore}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={commonT('appEvents:appName')}
-            feedbackWithPadding
+                    text: '', // A design decision: The text is not wanted in the small cards
+                  }}
+                  // todo: fix any type
+                  customContent={
+                    <ArticleDetails
+                      keywords={
+                        itemCategories?.edges
+                          ?.filter((category: any) => category?.node?.name)
+                          .map((category: any) => category?.node?.name || '') ||
+                        []
+                      }
+                    />
+                  }
+                />
+              );
+            }}
+            hasMore={hasMoreToLoad}
+            isLoading={isLoading || isLoadingMore}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={commonT('appEvents:appName')}
+          feedbackWithPadding
+        />
+      }
+    />
   );
 }
 

--- a/apps/events-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/events-helsinki/src/pages/cookie-consent/index.tsx
@@ -12,8 +12,7 @@ import {
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as HCRCApolloPage } from 'react-helsinki-headless-cms/apollo';
-import { ROUTES } from '../../constants';
+import { Page as HCRCPage } from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getEventsStaticProps from '../../domain/app/getEventsStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
@@ -42,8 +41,7 @@ export default function CookieConsent() {
 
   return (
     <MatomoWrapper>
-      <HCRCApolloPage
-        uri={ROUTES.COOKIE_CONSENT}
+      <HCRCPage
         className="pageLayout"
         navigation={<Navigation />}
         content={

--- a/apps/events-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/events-helsinki/src/pages/cookie-consent/index.tsx
@@ -11,7 +11,7 @@ import {
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as HCRCPage } from 'react-helsinki-headless-cms';
+import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getEventsStaticProps from '../../domain/app/getEventsStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
@@ -39,7 +39,7 @@ export default function CookieConsent() {
   usePageScrollRestoration();
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/apps/events-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/events-helsinki/src/pages/cookie-consent/index.tsx
@@ -1,7 +1,6 @@
 import {
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
@@ -40,31 +39,29 @@ export default function CookieConsent() {
   usePageScrollRestoration();
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <ConsentPageContent>
-              <EventsCookieConsent
-                appName={t('appEvents:appName')}
-                isModal={false}
-                onConsentGiven={handleRedirect}
-              />
-            </ConsentPageContent>
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appEvents:appName')}
-            hasFeedBack={false}
-          />
-        }
-      />
-    </MatomoWrapper>
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <ConsentPageContent>
+            <EventsCookieConsent
+              appName={t('appEvents:appName')}
+              isModal={false}
+              onConsentGiven={handleRedirect}
+            />
+          </ConsentPageContent>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appEvents:appName')}
+          hasFeedBack={false}
+        />
+      }
+    />
   );
 }
 

--- a/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
+++ b/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
@@ -3,9 +3,9 @@ import {
   NavigationContext,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
   getLanguageOrDefault,
   FooterSection,
+  useAppEventsTranslation,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -25,7 +25,7 @@ const Event: NextPage<{
   loading: boolean;
 }> = ({ event, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t } = useAppEventsTranslation();
   return (
     <MatomoWrapper>
       <RHHCPage

--- a/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
+++ b/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
@@ -2,7 +2,6 @@ import {
   EventDetailsDocument,
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   getLanguageOrDefault,
   FooterSection,
   useAppEventsTranslation,
@@ -27,22 +26,20 @@ const Event: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useAppEventsTranslation();
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <EventPageContainer
-            event={event}
-            loading={loading}
-            showSimilarEvents={AppConfig.showSimilarEvents}
-          />
-        }
-        footer={
-          <FooterSection menu={footerMenu} appName={t('appEvents:appName')} />
-        }
-      />
-    </MatomoWrapper>
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <EventPageContainer
+          event={event}
+          loading={loading}
+          showSimilarEvents={AppConfig.showSimilarEvents}
+        />
+      }
+      footer={
+        <FooterSection menu={footerMenu} appName={t('appEvents:appName')} />
+      }
+    />
   );
 };
 export default Event;

--- a/apps/events-helsinki/src/pages/index.tsx
+++ b/apps/events-helsinki/src/pages/index.tsx
@@ -14,8 +14,8 @@ import React, { useContext } from 'react';
 import type { PageType, ArticleType } from 'react-helsinki-headless-cms';
 import {
   useConfig,
-  PageContent as HCRCPageContent,
-  Page as HCRCPage,
+  PageContent as RHHCPageContent,
+  Page as RHHCPage,
   TemplateEnum,
 } from 'react-helsinki-headless-cms';
 import type {
@@ -40,13 +40,13 @@ const HomePage: NextPage<{
   const { t } = useAppEventsTranslation();
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={
         <>
           <RouteMeta origin={AppConfig.origin} />
-          <HCRCPageContent
+          <RHHCPageContent
             page={page}
             PageContentLayoutComponent={LandingPageContentLayout}
             collections={(page: PageType | ArticleType) =>

--- a/apps/events-helsinki/src/pages/index.tsx
+++ b/apps/events-helsinki/src/pages/index.tsx
@@ -3,7 +3,6 @@ import {
   getQlLanguage,
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   useAppEventsTranslation,
   getLanguageOrDefault,
   FooterSection,
@@ -41,32 +40,30 @@ const HomePage: NextPage<{
   const { t } = useAppEventsTranslation();
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <HCRCPageContent
-              page={page}
-              PageContentLayoutComponent={LandingPageContentLayout}
-              collections={(page: PageType | ArticleType) =>
-                cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
-              }
-              language={getQlLanguage(locale)}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appEvents:appName')}
-            hasFeedBack={false}
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <HCRCPageContent
+            page={page}
+            PageContentLayoutComponent={LandingPageContentLayout}
+            collections={(page: PageType | ArticleType) =>
+              cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
+            }
+            language={getQlLanguage(locale)}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appEvents:appName')}
+          hasFeedBack={false}
+        />
+      }
+    />
   );
 };
 

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -6,7 +6,6 @@ import {
   Navigation,
   NavigationContext,
   getAllPages,
-  MatomoWrapper,
   useAppEventsTranslation,
   getLanguageOrDefault,
   FooterSection,
@@ -56,31 +55,29 @@ const NextCmsPage: NextPage<{
   if (!page) return null;
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="page"
-        navigation={<Navigation page={page} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={page} />
-            <HCRCPageContent
-              page={page}
-              collections={
-                collections
-                  ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
-                  : []
-              }
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={appTranslation('appEvents:appName')}
+    <HCRCPage
+      className="page"
+      navigation={<Navigation page={page} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={page} />
+          <HCRCPageContent
+            page={page}
+            collections={
+              collections
+                ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
+                : []
+            }
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={appTranslation('appEvents:appName')}
+        />
+      }
+    />
   );
 };
 

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -25,8 +25,8 @@ import type {
 } from 'react-helsinki-headless-cms';
 import {
   getCollections,
-  PageContent as HCRCPageContent,
-  Page as HCRCPage,
+  PageContent as RHHCPageContent,
+  Page as RHHCPage,
   useConfig,
 } from 'react-helsinki-headless-cms';
 import type {
@@ -55,13 +55,13 @@ const NextCmsPage: NextPage<{
   if (!page) return null;
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="page"
       navigation={<Navigation page={page} />}
       content={
         <>
           <RouteMeta origin={AppConfig.origin} page={page} />
-          <HCRCPageContent
+          <RHHCPageContent
             page={page}
             collections={
               collections

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -13,14 +13,12 @@ import type { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
+import { Page as HCRCPage } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
 } from 'react-helsinki-headless-cms/apollo';
-import {
-  Page as HCRCApolloPage,
-  PageDocument,
-} from 'react-helsinki-headless-cms/apollo';
+import { PageDocument } from 'react-helsinki-headless-cms/apollo';
 import { ROUTES } from '../../constants';
 import AppConfig from '../../domain/app/AppConfig';
 import getEventsStaticProps from '../../domain/app/getEventsStaticProps';
@@ -58,8 +56,7 @@ const Search: NextPage<{
 
   return (
     <MatomoWrapper>
-      <HCRCApolloPage
-        uri={ROUTES.SEARCH}
+      <HCRCPage
         className="pageLayout"
         navigation={<Navigation />}
         content={
@@ -96,7 +93,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     >({
       query: PageDocument,
       variables: {
-        id: `/${language}/search/`,
+        id: `/${language}${ROUTES.SEARCH}/`,
       },
       fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
     });

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -12,7 +12,7 @@ import type { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { Page as HCRCPage } from 'react-helsinki-headless-cms';
+import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -54,7 +54,7 @@ const Search: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -2,7 +2,6 @@ import {
   NavigationContext,
   useAppEventsTranslation,
   Navigation,
-  MatomoWrapper,
   getLanguageOrDefault,
   FooterSection,
   RouteMeta,
@@ -55,29 +54,27 @@ const Search: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <PageMeta {...page?.seo} />
-            <SearchPage
-              SearchComponent={AdvancedSearch}
-              pageTitle={tAppEvents('appEvents:search.pageTitle')}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={tAppEvents('appEvents:appName')}
-            feedbackWithPadding
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <PageMeta {...page?.seo} />
+          <SearchPage
+            SearchComponent={AdvancedSearch}
+            pageTitle={tAppEvents('appEvents:search.pageTitle')}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={tAppEvents('appEvents:appName')}
+          feedbackWithPadding
+        />
+      }
+    />
   );
 };
 

--- a/apps/hobbies-helsinki/src/hooks/useHobbiesRHHCConfig.tsx
+++ b/apps/hobbies-helsinki/src/hooks/useHobbiesRHHCConfig.tsx
@@ -10,6 +10,7 @@ import {
   useCommonCmsConfig,
   HelsinkiCityOwnedIcon,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_PREFIXES,
+  useAppHobbiesTranslation,
 } from '@events-helsinki/components';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -41,6 +42,7 @@ export default function useHobbiesRHHCConfig(args: {
 }) {
   const { apolloClient } = args;
   const { t: commonTranslation } = useCommonTranslation();
+  const { t: appTranslation } = useAppHobbiesTranslation();
   const { t: eventTranslation } = useEventTranslation();
   const locale = useLocale();
   const commonConfig = useCommonCmsConfig();
@@ -85,7 +87,7 @@ export default function useHobbiesRHHCConfig(args: {
           <HelsinkiCityOwnedIcon {...props} />
         ),
       },
-      siteName: commonTranslation('appHobbies:appName'),
+      siteName: appTranslation('appHobbies:appName'),
       currentLanguageCode: locale.toUpperCase(),
       apolloClient,
       eventsApolloClient: apolloClient,
@@ -127,5 +129,12 @@ export default function useHobbiesRHHCConfig(args: {
       },
       internalHrefOrigins,
     } as unknown as Config;
-  }, [commonConfig, commonTranslation, eventTranslation, locale, apolloClient]);
+  }, [
+    commonConfig,
+    appTranslation,
+    commonTranslation,
+    eventTranslation,
+    locale,
+    apolloClient,
+  ]);
 }

--- a/apps/hobbies-helsinki/src/pages/_app.tsx
+++ b/apps/hobbies-helsinki/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import type { NavigationProviderProps } from '@events-helsinki/components';
 import {
   useLocale,
   BaseApp,
-  useCommonTranslation,
+  useAppHobbiesTranslation,
 } from '@events-helsinki/components';
 import { FallbackComponent } from '@events-helsinki/components/app/BaseApp';
 import { useRouter } from 'next/router';
@@ -38,7 +38,7 @@ export type AppProps<P = any> = {
 export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
-  const { t } = useCommonTranslation();
+  const { t } = useAppHobbiesTranslation();
   const locale = useLocale();
   const { asPath, pathname } = useRouter();
   const appName = t('appHobbies:appName');

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -5,7 +5,6 @@ import {
   getAllArticles,
   Navigation,
   useCommonTranslation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   useAppHobbiesTranslation,
@@ -59,40 +58,38 @@ const NextCmsArticle: NextPage<{
   if (!article) return null;
 
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="article-page"
-        navigation={<Navigation page={article} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={article} />
-            <RHHCPageContent
-              page={article}
-              breadcrumbs={
-                breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
-              }
-              shareLinks={
-                <ShareLinks title={commonTranslation('common:share.article')} />
-              }
-              collections={
-                collections
-                  ? cmsHelper.getDefaultCollections(
-                      article,
-                      getRoutedInternalHref
-                    )
-                  : []
-              }
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={appTranslation('appHobbies:appName')}
+    <RHHCPage
+      className="article-page"
+      navigation={<Navigation page={article} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={article} />
+          <RHHCPageContent
+            page={article}
+            breadcrumbs={
+              breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
+            }
+            shareLinks={
+              <ShareLinks title={commonTranslation('common:share.article')} />
+            }
+            collections={
+              collections
+                ? cmsHelper.getDefaultCollections(
+                    article,
+                    getRoutedInternalHref
+                  )
+                : []
+            }
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={appTranslation('appHobbies:appName')}
+        />
+      }
+    />
   );
 };
 

--- a/apps/hobbies-helsinki/src/pages/articles/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/index.tsx
@@ -152,7 +152,7 @@ export default function ArticleArchive({
                       keywords={
                         itemCategories?.edges
                           ?.filter((category: any) => category?.node?.name)
-                          .map((category: any) => category?.node?.name || '') ||
+                          .map((category: any) => category?.node?.name || '') ??
                         []
                       }
                     />
@@ -180,7 +180,7 @@ export default function ArticleArchive({
                       keywords={
                         itemCategories?.edges
                           ?.filter((category: any) => category?.node?.name)
-                          .map((category: any) => category?.node?.name || '') ||
+                          .map((category: any) => category?.node?.name || '') ??
                         []
                       }
                     />

--- a/apps/hobbies-helsinki/src/pages/articles/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/index.tsx
@@ -7,10 +7,10 @@ import {
   useDebounce,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
+  useAppHobbiesTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
 import React, { useContext } from 'react';
@@ -50,7 +50,7 @@ const SEARCH_DEBOUNCE_TIME = 500;
 export default function ArticleArchive({
   page,
 }: HobbiesGlobalPageProps & { page: PageType }) {
-  const { t: commonT } = useCommonTranslation();
+  const { t } = useAppHobbiesTranslation();
   const [searchTerm, setSearchTerm] = React.useState('');
   const [searchCategories, setSearchCategories] = React.useState<string[]>([]);
   const debouncedSearchTerm = useDebounce(searchTerm, SEARCH_DEBOUNCE_TIME);
@@ -200,7 +200,7 @@ export default function ArticleArchive({
         footer={
           <FooterSection
             menu={footerMenu}
-            appName={commonT('appHobbies:appName')}
+            appName={t('appHobbies:appName')}
             feedbackWithPadding
           />
         }

--- a/apps/hobbies-helsinki/src/pages/articles/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/index.tsx
@@ -6,7 +6,6 @@ import {
   skipFalsyType,
   useDebounce,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
@@ -110,102 +109,98 @@ export default function ArticleArchive({
   const { footerMenu } = useContext(NavigationContext);
 
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation page={page} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={page} />
-            <SearchPageContent
-              page={page}
-              className="articlesArchive"
-              noResults={!isLoading && articles?.length === 0}
-              items={articles}
-              tags={categories}
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              onSearch={(freeSearch, tags) => {
-                // TODO: Instead of doing this through yet another state, could the query just be updated?
-                setSearchTerm(freeSearch);
-                // NOTE: For some reason the CMS needs database ids here instead of ids or slugs.
-                setSearchCategories(
-                  tags
-                    .filter(skipFalsyType)
-                    .map((tag) => tag?.databaseId.toString())
-                );
-              }}
-              onLoadMore={() => {
-                fetchMoreArticles();
-              }}
-              largeFirstItem={showFirstItemLarge}
-              createLargeCard={(item) => {
-                const cardItem = item as ArticleType;
-                const itemCategories = cardItem?.categories;
-                return (
-                  <LargeCard
-                    key={`lg-card-${item?.id}`}
-                    {...cmsHelper.getArticlePageCardProps(
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation page={page} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={page} />
+          <SearchPageContent
+            page={page}
+            className="articlesArchive"
+            noResults={!isLoading && articles?.length === 0}
+            items={articles}
+            tags={categories}
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            onSearch={(freeSearch, tags) => {
+              // TODO: Instead of doing this through yet another state, could the query just be updated?
+              setSearchTerm(freeSearch);
+              // NOTE: For some reason the CMS needs database ids here instead of ids or slugs.
+              setSearchCategories(
+                tags
+                  .filter(skipFalsyType)
+                  .map((tag) => tag?.databaseId.toString())
+              );
+            }}
+            onLoadMore={() => {
+              fetchMoreArticles();
+            }}
+            largeFirstItem={showFirstItemLarge}
+            createLargeCard={(item) => {
+              const cardItem = item as ArticleType;
+              const itemCategories = cardItem?.categories;
+              return (
+                <LargeCard
+                  key={`lg-card-${item?.id}`}
+                  {...cmsHelper.getArticlePageCardProps(
+                    item as ArticleType,
+                    getRoutedInternalHref
+                  )}
+                  // todo: fix any type
+                  customContent={
+                    <ArticleDetails
+                      keywords={
+                        itemCategories?.edges
+                          ?.filter((category: any) => category?.node?.name)
+                          .map((category: any) => category?.node?.name || '') ||
+                        []
+                      }
+                    />
+                  }
+                />
+              );
+            }}
+            createCard={(item) => {
+              const cardItem = item as ArticleType;
+              const itemCategories = cardItem?.categories;
+              return (
+                <Card
+                  key={`sm-card-${item?.id}`}
+                  {...{
+                    ...cmsHelper.getArticlePageCardProps(
                       item as ArticleType,
                       getRoutedInternalHref
-                    )}
-                    // todo: fix any type
-                    customContent={
-                      <ArticleDetails
-                        keywords={
-                          itemCategories?.edges
-                            ?.filter((category: any) => category?.node?.name)
-                            .map(
-                              (category: any) => category?.node?.name || ''
-                            ) || []
-                        }
-                      />
-                    }
-                  />
-                );
-              }}
-              createCard={(item) => {
-                const cardItem = item as ArticleType;
-                const itemCategories = cardItem?.categories;
-                return (
-                  <Card
-                    key={`sm-card-${item?.id}`}
-                    {...{
-                      ...cmsHelper.getArticlePageCardProps(
-                        item as ArticleType,
-                        getRoutedInternalHref
-                      ),
+                    ),
 
-                      text: '', // A design decision: The text is not wanted in the small cards
-                    }}
-                    // todo: fix any type
-                    customContent={
-                      <ArticleDetails
-                        keywords={
-                          itemCategories?.edges
-                            ?.filter((category: any) => category?.node?.name)
-                            .map(
-                              (category: any) => category?.node?.name || ''
-                            ) || []
-                        }
-                      />
-                    }
-                  />
-                );
-              }}
-              hasMore={hasMoreToLoad}
-              isLoading={isLoading || isLoadingMore}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appHobbies:appName')}
-            feedbackWithPadding
+                    text: '', // A design decision: The text is not wanted in the small cards
+                  }}
+                  // todo: fix any type
+                  customContent={
+                    <ArticleDetails
+                      keywords={
+                        itemCategories?.edges
+                          ?.filter((category: any) => category?.node?.name)
+                          .map((category: any) => category?.node?.name || '') ||
+                        []
+                      }
+                    />
+                  }
+                />
+              );
+            }}
+            hasMore={hasMoreToLoad}
+            isLoading={isLoading || isLoadingMore}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appHobbies:appName')}
+          feedbackWithPadding
+        />
+      }
+    />
   );
 }
 

--- a/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
@@ -11,7 +11,7 @@ import {
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as HCRCPage } from 'react-helsinki-headless-cms';
+import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
@@ -39,7 +39,7 @@ export default function CookieConsent() {
   usePageScrollRestoration();
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
@@ -12,8 +12,7 @@ import {
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as HCRCApolloPage } from 'react-helsinki-headless-cms/apollo';
-import { ROUTES } from '../../constants';
+import { Page as HCRCPage } from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
@@ -42,8 +41,7 @@ export default function CookieConsent() {
 
   return (
     <MatomoWrapper>
-      <HCRCApolloPage
-        uri={ROUTES.COOKIE_CONSENT}
+      <HCRCPage
         className="pageLayout"
         navigation={<Navigation />}
         content={

--- a/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
@@ -1,7 +1,6 @@
 import {
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
@@ -40,31 +39,29 @@ export default function CookieConsent() {
   usePageScrollRestoration();
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <ConsentPageContent>
-              <EventsCookieConsent
-                appName={t('appHobbies:appName')}
-                isModal={false}
-                onConsentGiven={handleRedirect}
-              />
-            </ConsentPageContent>
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appHobbies:appName')}
-            hasFeedBack={false}
-          />
-        }
-      />
-    </MatomoWrapper>
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <ConsentPageContent>
+            <EventsCookieConsent
+              appName={t('appHobbies:appName')}
+              isModal={false}
+              onConsentGiven={handleRedirect}
+            />
+          </ConsentPageContent>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appHobbies:appName')}
+          hasFeedBack={false}
+        />
+      }
+    />
   );
 }
 

--- a/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -3,9 +3,9 @@ import {
   NavigationContext,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
+  useAppHobbiesTranslation,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -25,7 +25,7 @@ const Event: NextPage<{
   loading: boolean;
 }> = ({ event, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t } = useAppHobbiesTranslation();
   return (
     <MatomoWrapper>
       <RHHCPage

--- a/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -2,7 +2,6 @@ import {
   EventDetailsDocument,
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   useAppHobbiesTranslation,
@@ -27,22 +26,20 @@ const Event: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useAppHobbiesTranslation();
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <EventPageContainer
-            event={event}
-            loading={loading}
-            showSimilarEvents={AppConfig.showSimilarEvents}
-          />
-        }
-        footer={
-          <FooterSection menu={footerMenu} appName={t('appHobbies:appName')} />
-        }
-      />
-    </MatomoWrapper>
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <EventPageContainer
+          event={event}
+          loading={loading}
+          showSimilarEvents={AppConfig.showSimilarEvents}
+        />
+      }
+      footer={
+        <FooterSection menu={footerMenu} appName={t('appHobbies:appName')} />
+      }
+    />
   );
 };
 export default Event;

--- a/apps/hobbies-helsinki/src/pages/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/index.tsx
@@ -3,7 +3,6 @@ import {
   getQlLanguage,
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
@@ -40,32 +39,30 @@ const HomePage: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useAppHobbiesTranslation();
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <HCRCPageContent
-              page={page}
-              PageContentLayoutComponent={LandingPageContentLayout}
-              collections={(page: PageType | ArticleType) =>
-                cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
-              }
-              language={getQlLanguage(locale)}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appHobbies:appName')}
-            hasFeedBack={false}
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <HCRCPageContent
+            page={page}
+            PageContentLayoutComponent={LandingPageContentLayout}
+            collections={(page: PageType | ArticleType) =>
+              cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
+            }
+            language={getQlLanguage(locale)}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appHobbies:appName')}
+          hasFeedBack={false}
+        />
+      }
+    />
   );
 };
 

--- a/apps/hobbies-helsinki/src/pages/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/index.tsx
@@ -4,10 +4,10 @@ import {
   NavigationContext,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
+  useAppHobbiesTranslation,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
 import type { GetStaticPropsContext, NextPage } from 'next';
@@ -38,7 +38,7 @@ const HomePage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t } = useAppHobbiesTranslation();
   return (
     <MatomoWrapper>
       <HCRCPage

--- a/apps/hobbies-helsinki/src/pages/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/index.tsx
@@ -14,8 +14,8 @@ import React, { useContext } from 'react';
 import type { PageType, ArticleType } from 'react-helsinki-headless-cms';
 import {
   useConfig,
-  PageContent as HCRCPageContent,
-  Page as HCRCPage,
+  PageContent as RHHCPageContent,
+  Page as RHHCPage,
   TemplateEnum,
 } from 'react-helsinki-headless-cms';
 import type {
@@ -39,13 +39,13 @@ const HomePage: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useAppHobbiesTranslation();
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={
         <>
           <RouteMeta origin={AppConfig.origin} />
-          <HCRCPageContent
+          <RHHCPageContent
             page={page}
             PageContentLayoutComponent={LandingPageContentLayout}
             collections={(page: PageType | ArticleType) =>

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -5,7 +5,6 @@ import type { AppLanguage } from '@events-helsinki/components';
 import {
   NavigationContext,
   getAllPages,
-  MatomoWrapper,
   useAppHobbiesTranslation,
   FooterSection,
   getLanguageOrDefault,
@@ -56,31 +55,29 @@ const NextCmsPage: NextPage<{
   if (!page) return null;
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="page"
-        navigation={<Navigation page={page} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={page} />
-            <HCRCPageContent
-              page={page}
-              collections={
-                collections
-                  ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
-                  : []
-              }
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={appTranslation('appHobbies:appName')}
+    <HCRCPage
+      className="page"
+      navigation={<Navigation page={page} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={page} />
+          <HCRCPageContent
+            page={page}
+            collections={
+              collections
+                ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
+                : []
+            }
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={appTranslation('appHobbies:appName')}
+        />
+      }
+    />
   );
 };
 

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -24,8 +24,8 @@ import type {
 } from 'react-helsinki-headless-cms';
 import {
   getCollections,
-  PageContent as HCRCPageContent,
-  Page as HCRCPage,
+  PageContent as RHHCPageContent,
+  Page as RHHCPage,
   useConfig,
 } from 'react-helsinki-headless-cms';
 import type {
@@ -55,13 +55,13 @@ const NextCmsPage: NextPage<{
   if (!page) return null;
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="page"
       navigation={<Navigation page={page} />}
       content={
         <>
           <RouteMeta origin={AppConfig.origin} page={page} />
-          <HCRCPageContent
+          <RHHCPageContent
             page={page}
             collections={
               collections

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -2,7 +2,6 @@ import {
   NavigationContext,
   useAppHobbiesTranslation,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
@@ -54,29 +53,27 @@ const Search: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <PageMeta {...page?.seo} />
-            <SearchPage
-              SearchComponent={AdvancedSearch}
-              pageTitle={tAppHobbies('appHobbies:search.pageTitle')}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={tAppHobbies('appHobbies:appName')}
-            feedbackWithPadding
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <PageMeta {...page?.seo} />
+          <SearchPage
+            SearchComponent={AdvancedSearch}
+            pageTitle={tAppHobbies('appHobbies:search.pageTitle')}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={tAppHobbies('appHobbies:appName')}
+          feedbackWithPadding
+        />
+      }
+    />
   );
 };
 

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -13,14 +13,12 @@ import type { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
+import { Page as HCRCPage } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
 } from 'react-helsinki-headless-cms/apollo';
-import {
-  Page as HCRCApolloPage,
-  PageDocument,
-} from 'react-helsinki-headless-cms/apollo';
+import { PageDocument } from 'react-helsinki-headless-cms/apollo';
 import { ROUTES } from '../../constants';
 import AppConfig from '../../domain/app/AppConfig';
 import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
@@ -57,8 +55,7 @@ const Search: NextPage<{
 
   return (
     <MatomoWrapper>
-      <HCRCApolloPage
-        uri={ROUTES.SEARCH}
+      <HCRCPage
         className="pageLayout"
         navigation={<Navigation />}
         content={
@@ -95,7 +92,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     >({
       query: PageDocument,
       variables: {
-        id: `/${language}/search/`,
+        id: `/${language}${ROUTES.SEARCH}/`,
       },
       fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
     });

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -12,7 +12,7 @@ import type { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { Page as HCRCPage } from 'react-helsinki-headless-cms';
+import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -53,7 +53,7 @@ const Search: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/apps/sports-helsinki/src/hooks/useSportsRHHCConfig.tsx
+++ b/apps/sports-helsinki/src/hooks/useSportsRHHCConfig.tsx
@@ -10,6 +10,7 @@ import {
   useCommonCmsConfig,
   HelsinkiCityOwnedIcon,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_PREFIXES,
+  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -41,6 +42,7 @@ export default function useSportsRHHCConfig(args: {
 }) {
   const { apolloClient } = args;
   const { t: commonTranslation } = useCommonTranslation();
+  const { t: appTranslation } = useAppSportsTranslation();
   const { t: eventTranslation } = useEventTranslation();
   const locale = useLocale();
   const commonConfig = useCommonCmsConfig();
@@ -85,7 +87,7 @@ export default function useSportsRHHCConfig(args: {
           <HelsinkiCityOwnedIcon {...props} />
         ),
       },
-      siteName: commonTranslation('appSports:appName'),
+      siteName: appTranslation('appSports:appName'),
       currentLanguageCode: locale.toUpperCase(),
       apolloClient,
       eventsApolloClient: apolloClient,
@@ -127,5 +129,12 @@ export default function useSportsRHHCConfig(args: {
       },
       internalHrefOrigins,
     } as unknown as Config;
-  }, [commonConfig, commonTranslation, eventTranslation, locale, apolloClient]);
+  }, [
+    commonConfig,
+    appTranslation,
+    commonTranslation,
+    eventTranslation,
+    locale,
+    apolloClient,
+  ]);
 }

--- a/apps/sports-helsinki/src/pages/_app.tsx
+++ b/apps/sports-helsinki/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import type { NavigationProviderProps } from '@events-helsinki/components';
 import {
   useLocale,
   BaseApp,
-  useCommonTranslation,
+  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import { FallbackComponent } from '@events-helsinki/components/app/BaseApp';
 import type { AppProps as NextAppProps } from 'next/app';
@@ -38,7 +38,7 @@ export type AppProps<P = any> = {
 export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
-  const { t } = useCommonTranslation();
+  const { t } = useAppSportsTranslation();
   const locale = useLocale();
   const { asPath, pathname } = useRouter();
   const appName = t('appSports:appName');

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -4,7 +4,6 @@ import {
   ShareLinks,
   getAllArticles,
   Navigation,
-  MatomoWrapper,
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
@@ -59,40 +58,38 @@ const NextCmsArticle: NextPage<{
   if (!article) return null;
 
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="article-page"
-        navigation={<Navigation page={article} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={article} />
-            <RHHCPageContent
-              page={article}
-              breadcrumbs={
-                breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
-              }
-              shareLinks={
-                <ShareLinks title={commonTranslation('common:share.article')} />
-              }
-              collections={
-                collections
-                  ? cmsHelper.getDefaultCollections(
-                      article,
-                      getRoutedInternalHref
-                    )
-                  : []
-              }
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={appTranslation('appSports:appName')}
+    <RHHCPage
+      className="article-page"
+      navigation={<Navigation page={article} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={article} />
+          <RHHCPageContent
+            page={article}
+            breadcrumbs={
+              breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
+            }
+            shareLinks={
+              <ShareLinks title={commonTranslation('common:share.article')} />
+            }
+            collections={
+              collections
+                ? cmsHelper.getDefaultCollections(
+                    article,
+                    getRoutedInternalHref
+                  )
+                : []
+            }
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={appTranslation('appSports:appName')}
+        />
+      }
+    />
   );
 };
 

--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -153,7 +153,7 @@ export default function ArticleArchive({
                       keywords={
                         itemCategories?.edges
                           ?.filter((category: any) => category?.node?.name)
-                          .map((category: any) => category?.node?.name || '') ||
+                          .map((category: any) => category?.node?.name || '') ??
                         []
                       }
                     />
@@ -181,7 +181,7 @@ export default function ArticleArchive({
                       keywords={
                         itemCategories?.edges
                           ?.filter((category: any) => category?.node?.name)
-                          .map((category: any) => category?.node?.name || '') ||
+                          .map((category: any) => category?.node?.name || '') ??
                         []
                       }
                     />

--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -6,7 +6,6 @@ import {
   skipFalsyType,
   useDebounce,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
@@ -111,102 +110,98 @@ export default function ArticleArchive({
   const { footerMenu } = useContext(NavigationContext);
 
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation page={page} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={page} />
-            <SearchPageContent
-              page={page}
-              className="articlesArchive"
-              noResults={!isLoading && articles?.length === 0}
-              items={articles}
-              tags={categories}
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              onSearch={(freeSearch, tags) => {
-                // TODO: Instead of doing this through yet another state, could the query just be updated?
-                setSearchTerm(freeSearch);
-                // NOTE: For some reason the CMS needs database ids here instead of ids or slugs.
-                setSearchCategories(
-                  tags
-                    .filter(skipFalsyType)
-                    .map((tag) => tag?.databaseId.toString())
-                );
-              }}
-              onLoadMore={() => {
-                fetchMoreArticles();
-              }}
-              largeFirstItem={showFirstItemLarge}
-              createLargeCard={(item) => {
-                const cardItem = item as ArticleType;
-                const itemCategories = cardItem?.categories;
-                return (
-                  <LargeCard
-                    key={`lg-card-${item?.id}`}
-                    {...cmsHelper.getArticlePageCardProps(
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation page={page} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={page} />
+          <SearchPageContent
+            page={page}
+            className="articlesArchive"
+            noResults={!isLoading && articles?.length === 0}
+            items={articles}
+            tags={categories}
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            onSearch={(freeSearch, tags) => {
+              // TODO: Instead of doing this through yet another state, could the query just be updated?
+              setSearchTerm(freeSearch);
+              // NOTE: For some reason the CMS needs database ids here instead of ids or slugs.
+              setSearchCategories(
+                tags
+                  .filter(skipFalsyType)
+                  .map((tag) => tag?.databaseId.toString())
+              );
+            }}
+            onLoadMore={() => {
+              fetchMoreArticles();
+            }}
+            largeFirstItem={showFirstItemLarge}
+            createLargeCard={(item) => {
+              const cardItem = item as ArticleType;
+              const itemCategories = cardItem?.categories;
+              return (
+                <LargeCard
+                  key={`lg-card-${item?.id}`}
+                  {...cmsHelper.getArticlePageCardProps(
+                    item as ArticleType,
+                    getRoutedInternalHref
+                  )}
+                  // todo: fix any type
+                  customContent={
+                    <ArticleDetails
+                      keywords={
+                        itemCategories?.edges
+                          ?.filter((category: any) => category?.node?.name)
+                          .map((category: any) => category?.node?.name || '') ||
+                        []
+                      }
+                    />
+                  }
+                />
+              );
+            }}
+            createCard={(item) => {
+              const cardItem = item as ArticleType;
+              const itemCategories = cardItem?.categories;
+              return (
+                <Card
+                  key={`sm-card-${item?.id}`}
+                  {...{
+                    ...cmsHelper.getArticlePageCardProps(
                       item as ArticleType,
                       getRoutedInternalHref
-                    )}
-                    // todo: fix any type
-                    customContent={
-                      <ArticleDetails
-                        keywords={
-                          itemCategories?.edges
-                            ?.filter((category: any) => category?.node?.name)
-                            .map(
-                              (category: any) => category?.node?.name || ''
-                            ) || []
-                        }
-                      />
-                    }
-                  />
-                );
-              }}
-              createCard={(item) => {
-                const cardItem = item as ArticleType;
-                const itemCategories = cardItem?.categories;
-                return (
-                  <Card
-                    key={`sm-card-${item?.id}`}
-                    {...{
-                      ...cmsHelper.getArticlePageCardProps(
-                        item as ArticleType,
-                        getRoutedInternalHref
-                      ),
+                    ),
 
-                      text: '', // A design decision: The text is not wanted in the small cards
-                    }}
-                    // todo: fix any type
-                    customContent={
-                      <ArticleDetails
-                        keywords={
-                          itemCategories?.edges
-                            ?.filter((category: any) => category?.node?.name)
-                            .map(
-                              (category: any) => category?.node?.name || ''
-                            ) || []
-                        }
-                      />
-                    }
-                  />
-                );
-              }}
-              hasMore={hasMoreToLoad}
-              isLoading={isLoading || isLoadingMore}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appSports:appName')}
-            feedbackWithPadding
+                    text: '', // A design decision: The text is not wanted in the small cards
+                  }}
+                  // todo: fix any type
+                  customContent={
+                    <ArticleDetails
+                      keywords={
+                        itemCategories?.edges
+                          ?.filter((category: any) => category?.node?.name)
+                          .map((category: any) => category?.node?.name || '') ||
+                        []
+                      }
+                    />
+                  }
+                />
+              );
+            }}
+            hasMore={hasMoreToLoad}
+            isLoading={isLoading || isLoadingMore}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appSports:appName')}
+          feedbackWithPadding
+        />
+      }
+    />
   );
 }
 

--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -6,11 +6,11 @@ import {
   skipFalsyType,
   useDebounce,
   Navigation,
-  useCommonTranslation,
   MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
+  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
 import React, { useContext } from 'react';
@@ -50,7 +50,7 @@ const SEARCH_DEBOUNCE_TIME = 500;
 export default function ArticleArchive({
   page,
 }: SportsGlobalPageProps & { page: PageType }) {
-  const { t: commonT } = useCommonTranslation();
+  const { t } = useAppSportsTranslation();
   const [searchTerm, setSearchTerm] = React.useState('');
   const [searchCategories, setSearchCategories] = React.useState<string[]>([]);
   const debouncedSearchTerm = useDebounce(searchTerm, SEARCH_DEBOUNCE_TIME);
@@ -201,7 +201,7 @@ export default function ArticleArchive({
         footer={
           <FooterSection
             menu={footerMenu}
-            appName={commonT('appSports:appName')}
+            appName={t('appSports:appName')}
             feedbackWithPadding
           />
         }

--- a/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
@@ -11,7 +11,7 @@ import {
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as HCRCPage } from 'react-helsinki-headless-cms';
+import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getSportsStaticProps from '../../domain/app/getSportsStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
@@ -39,7 +39,7 @@ export default function CookieConsent() {
   usePageScrollRestoration();
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
@@ -1,7 +1,6 @@
 import {
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
@@ -40,31 +39,29 @@ export default function CookieConsent() {
   usePageScrollRestoration();
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <ConsentPageContent>
-              <EventsCookieConsent
-                appName={t('appSports:appName')}
-                isModal={false}
-                onConsentGiven={handleRedirect}
-              />
-            </ConsentPageContent>
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appSports:appName')}
-            hasFeedBack={false}
-          />
-        }
-      />
-    </MatomoWrapper>
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <ConsentPageContent>
+            <EventsCookieConsent
+              appName={t('appSports:appName')}
+              isModal={false}
+              onConsentGiven={handleRedirect}
+            />
+          </ConsentPageContent>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appSports:appName')}
+          hasFeedBack={false}
+        />
+      }
+    />
   );
 }
 

--- a/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
@@ -12,8 +12,7 @@ import {
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as HCRCApolloPage } from 'react-helsinki-headless-cms/apollo';
-import { ROUTES } from '../../constants';
+import { Page as HCRCPage } from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getSportsStaticProps from '../../domain/app/getSportsStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
@@ -42,8 +41,7 @@ export default function CookieConsent() {
 
   return (
     <MatomoWrapper>
-      <HCRCApolloPage
-        uri={ROUTES.COOKIE_CONSENT}
+      <HCRCPage
         className="pageLayout"
         navigation={<Navigation />}
         content={

--- a/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -3,9 +3,9 @@ import {
   NavigationContext,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
+  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -26,7 +26,7 @@ const EventPage: NextPage<{
   loading: boolean;
 }> = ({ event, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t } = useAppSportsTranslation();
   return (
     <MatomoWrapper>
       <RHHCPage

--- a/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -2,7 +2,6 @@ import {
   EventDetailsDocument,
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   useAppSportsTranslation,
@@ -28,22 +27,20 @@ const EventPage: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
   const { t } = useAppSportsTranslation();
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <EventPageContainer
-            event={event}
-            loading={loading}
-            showSimilarEvents={AppConfig.showSimilarEvents}
-          />
-        }
-        footer={
-          <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
-        }
-      />
-    </MatomoWrapper>
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <EventPageContainer
+          event={event}
+          loading={loading}
+          showSimilarEvents={AppConfig.showSimilarEvents}
+        />
+      }
+      footer={
+        <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
+      }
+    />
   );
 };
 export default EventPage;

--- a/apps/sports-helsinki/src/pages/index.tsx
+++ b/apps/sports-helsinki/src/pages/index.tsx
@@ -3,7 +3,6 @@ import {
   getQlLanguage,
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   useAppSportsTranslation,
   FooterSection,
   getLanguageOrDefault,
@@ -42,32 +41,30 @@ const HomePage: NextPage<{
   const { t } = useAppSportsTranslation();
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <HCRCPageContent
-              page={page}
-              PageContentLayoutComponent={LandingPageContentLayout}
-              collections={(page: PageType | ArticleType) =>
-                cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
-              }
-              language={getQlLanguage(locale)}
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appSports:appName')}
-            hasFeedBack={false}
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <HCRCPageContent
+            page={page}
+            PageContentLayoutComponent={LandingPageContentLayout}
+            collections={(page: PageType | ArticleType) =>
+              cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
+            }
+            language={getQlLanguage(locale)}
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appSports:appName')}
+          hasFeedBack={false}
+        />
+      }
+    />
   );
 };
 

--- a/apps/sports-helsinki/src/pages/index.tsx
+++ b/apps/sports-helsinki/src/pages/index.tsx
@@ -14,8 +14,8 @@ import React, { useContext } from 'react';
 import type { PageType, ArticleType } from 'react-helsinki-headless-cms';
 import {
   useConfig,
-  PageContent as HCRCPageContent,
-  Page as HCRCPage,
+  PageContent as RHHCPageContent,
+  Page as RHHCPage,
   TemplateEnum,
 } from 'react-helsinki-headless-cms';
 import type {
@@ -41,13 +41,13 @@ const HomePage: NextPage<{
   const { t } = useAppSportsTranslation();
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={
         <>
           <RouteMeta origin={AppConfig.origin} />
-          <HCRCPageContent
+          <RHHCPageContent
             page={page}
             PageContentLayoutComponent={LandingPageContentLayout}
             collections={(page: PageType | ArticleType) =>

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -6,7 +6,6 @@ import {
   NavigationContext,
   getAllPages,
   Navigation,
-  MatomoWrapper,
   useAppSportsTranslation,
   FooterSection,
   getLanguageOrDefault,
@@ -56,31 +55,29 @@ const NextCmsPage: NextPage<{
   if (!page) return null;
 
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="page"
-        navigation={<Navigation page={page} />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} page={page} />
-            <HCRCPageContent
-              page={page}
-              collections={
-                collections
-                  ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
-                  : []
-              }
-            />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={appTranslation('appSports:appName')}
+    <HCRCPage
+      className="page"
+      navigation={<Navigation page={page} />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} page={page} />
+          <HCRCPageContent
+            page={page}
+            collections={
+              collections
+                ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
+                : []
+            }
           />
-        }
-      />
-    </MatomoWrapper>
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={appTranslation('appSports:appName')}
+        />
+      }
+    />
   );
 };
 

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -25,8 +25,8 @@ import type {
 } from 'react-helsinki-headless-cms';
 import {
   getCollections,
-  PageContent as HCRCPageContent,
-  Page as HCRCPage,
+  PageContent as RHHCPageContent,
+  Page as RHHCPage,
   useConfig,
 } from 'react-helsinki-headless-cms';
 import type {
@@ -55,13 +55,13 @@ const NextCmsPage: NextPage<{
   if (!page) return null;
 
   return (
-    <HCRCPage
+    <RHHCPage
       className="page"
       navigation={<Navigation page={page} />}
       content={
         <>
           <RouteMeta origin={AppConfig.origin} page={page} />
-          <HCRCPageContent
+          <RHHCPageContent
             page={page}
             collections={
               collections

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -2,12 +2,12 @@ import {
   NavigationContext,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
   RouteMeta,
   PageMeta,
+  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React, { useContext } from 'react';
@@ -31,7 +31,7 @@ const Search: NextPage<{
   page: PageType;
 }> = ({ page }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t } = useAppSportsTranslation();
   usePageScrollRestoration();
   return (
     <MatomoWrapper>

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -1,7 +1,6 @@
 import {
   NavigationContext,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
@@ -32,26 +31,24 @@ const Search: NextPage<{
   const { t } = useAppSportsTranslation();
   usePageScrollRestoration();
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <PageMeta {...page?.seo} />
-            <CombinedSearchPage defaultTab="Venue" />
-          </>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={t('appSports:appName')}
-            feedbackWithPadding
-          />
-        }
-      />
-    </MatomoWrapper>
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <PageMeta {...page?.seo} />
+          <CombinedSearchPage defaultTab="Venue" />
+        </>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={t('appSports:appName')}
+          feedbackWithPadding
+        />
+      }
+    />
   );
 };
 

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -12,14 +12,12 @@ import {
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React, { useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
+import { Page as HCRCPage } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
 } from 'react-helsinki-headless-cms/apollo';
-import {
-  Page as HCRCApolloPage,
-  PageDocument,
-} from 'react-helsinki-headless-cms/apollo';
+import { PageDocument } from 'react-helsinki-headless-cms/apollo';
 import { ROUTES } from '../../constants';
 import AppConfig from '../../domain/app/AppConfig';
 import getSportsStaticProps from '../../domain/app/getSportsStaticProps';
@@ -35,8 +33,7 @@ const Search: NextPage<{
   usePageScrollRestoration();
   return (
     <MatomoWrapper>
-      <HCRCApolloPage
-        uri={ROUTES.SEARCH}
+      <HCRCPage
         className="pageLayout"
         navigation={<Navigation />}
         content={
@@ -69,8 +66,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     >({
       query: PageDocument,
       variables: {
-        // does not work
-        id: `/${language}/search/`,
+        id: `/${language}${ROUTES.SEARCH}/`,
       },
       fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
     });

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -11,7 +11,7 @@ import {
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React, { useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { Page as HCRCPage } from 'react-helsinki-headless-cms';
+import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -31,7 +31,7 @@ const Search: NextPage<{
   const { t } = useAppSportsTranslation();
   usePageScrollRestoration();
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/apps/sports-helsinki/src/pages/search/map.tsx
+++ b/apps/sports-helsinki/src/pages/search/map.tsx
@@ -14,7 +14,7 @@ import { useRouter } from 'next/router';
 import queryString from 'query-string';
 import React from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { PageSection, Page as HCRCPage } from 'react-helsinki-headless-cms';
+import { PageSection, Page as RHHCPage } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -133,7 +133,7 @@ export function MapSearchPageContent() {
 
 export default function MapSearch({ page }: { page: PageType }) {
   return (
-    <HCRCPage
+    <RHHCPage
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/apps/sports-helsinki/src/pages/search/map.tsx
+++ b/apps/sports-helsinki/src/pages/search/map.tsx
@@ -3,7 +3,6 @@ import {
   useLocale,
   getURLSearchParamsFromAsPath,
   Navigation,
-  MatomoWrapper,
   getLanguageOrDefault,
   RouteMeta,
   PageMeta,
@@ -134,22 +133,20 @@ export function MapSearchPageContent() {
 
 export default function MapSearch({ page }: { page: PageType }) {
   return (
-    <MatomoWrapper>
-      <HCRCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <>
-            <RouteMeta origin={AppConfig.origin} />
-            <PageMeta {...page?.seo} />
-            <CombinedSearchProvider>
-              <MapSearchPageContent />
-            </CombinedSearchProvider>
-          </>
-        }
-        footer={null}
-      />
-    </MatomoWrapper>
+    <HCRCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <>
+          <RouteMeta origin={AppConfig.origin} />
+          <PageMeta {...page?.seo} />
+          <CombinedSearchProvider>
+            <MapSearchPageContent />
+          </CombinedSearchProvider>
+        </>
+      }
+      footer={null}
+    />
   );
 }
 

--- a/apps/sports-helsinki/src/pages/search/map.tsx
+++ b/apps/sports-helsinki/src/pages/search/map.tsx
@@ -5,6 +5,8 @@ import {
   Navigation,
   MatomoWrapper,
   getLanguageOrDefault,
+  RouteMeta,
+  PageMeta,
 } from '@events-helsinki/components';
 import { LoadingSpinner } from 'hds-react';
 import type { GetStaticPropsContext } from 'next';
@@ -12,11 +14,18 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
 import React from 'react';
-import { PageSection } from 'react-helsinki-headless-cms';
-import { Page as HCRCApolloPage } from 'react-helsinki-headless-cms/apollo';
+import type { PageType } from 'react-helsinki-headless-cms';
+import { PageSection, Page as HCRCPage } from 'react-helsinki-headless-cms';
+import type {
+  PageQuery,
+  PageQueryVariables,
+} from 'react-helsinki-headless-cms/apollo';
+import { PageDocument } from 'react-helsinki-headless-cms/apollo';
 import { ROUTES } from '../../constants';
+import AppConfig from '../../domain/app/AppConfig';
 import getSportsStaticProps from '../../domain/app/getSportsStaticProps';
 import routerHelper from '../../domain/app/routerHelper';
+import { sportsApolloClient } from '../../domain/clients/sportsApolloClient';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 import { CombinedSearchProvider } from '../../domain/search/combinedSearch/adapters/CombinedSearchProvider';
 import SearchHeader from '../../domain/search/searchHeader/SearchHeader';
@@ -123,17 +132,20 @@ export function MapSearchPageContent() {
   );
 }
 
-export default function MapSearch() {
+export default function MapSearch({ page }: { page: PageType }) {
   return (
     <MatomoWrapper>
-      <HCRCApolloPage
-        uri={ROUTES.MAPSEARCH}
+      <HCRCPage
         className="pageLayout"
         navigation={<Navigation />}
         content={
-          <CombinedSearchProvider>
-            <MapSearchPageContent />
-          </CombinedSearchProvider>
+          <>
+            <RouteMeta origin={AppConfig.origin} />
+            <PageMeta {...page?.seo} />
+            <CombinedSearchProvider>
+              <MapSearchPageContent />
+            </CombinedSearchProvider>
+          </>
         }
         footer={null}
       />
@@ -144,8 +156,19 @@ export default function MapSearch() {
 export async function getStaticProps(context: GetStaticPropsContext) {
   return getSportsStaticProps(context, async () => {
     const language = getLanguageOrDefault(context.locale);
+    const { data: pageData } = await sportsApolloClient.query<
+      PageQuery,
+      PageQueryVariables
+    >({
+      query: PageDocument,
+      variables: {
+        id: `/${language}${ROUTES.SEARCH}/`,
+      },
+      fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
+    });
     return {
       props: {
+        page: pageData.page,
         ...(await serverSideTranslationsWithCommon(language, ['search'])),
       },
     };

--- a/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
@@ -2,7 +2,6 @@ import {
   NavigationContext,
   VenueDocument,
   Navigation,
-  MatomoWrapper,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
@@ -29,23 +28,21 @@ const VenuePage: NextPage<{
   const { t } = useAppSportsTranslation();
   usePageScrollRestoration();
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation />}
-        content={
-          <VenuePageContainer
-            venue={venue}
-            loading={loading}
-            showSimilarVenues={AppConfig.showSimilarVenues}
-            showUpcomingEvents={AppConfig.showVenuesUpcomingEvents}
-          />
-        }
-        footer={
-          <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
-        }
-      />
-    </MatomoWrapper>
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <VenuePageContainer
+          venue={venue}
+          loading={loading}
+          showSimilarVenues={AppConfig.showSimilarVenues}
+          showUpcomingEvents={AppConfig.showVenuesUpcomingEvents}
+        />
+      }
+      footer={
+        <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
+      }
+    />
   );
 };
 export default VenuePage;

--- a/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
@@ -3,10 +3,10 @@ import {
   VenueDocument,
   Navigation,
   MatomoWrapper,
-  useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
+  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import type {
   Venue,
@@ -26,7 +26,7 @@ const VenuePage: NextPage<{
   loading: boolean;
 }> = ({ venue, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useCommonTranslation();
+  const { t } = useAppSportsTranslation();
   usePageScrollRestoration();
   return (
     <MatomoWrapper>

--- a/packages/components/src/app/BaseApp.tsx
+++ b/packages/components/src/app/BaseApp.tsx
@@ -10,6 +10,7 @@ import { injectStyle } from 'react-toastify/dist/inject-style';
 import '../styles/globals.scss';
 import '../styles/askem.scss';
 import { CmsHelperProvider } from '../cmsHelperProvider';
+import { MatomoWrapper } from '../components';
 import type { createAskemInstance } from '../components/askem';
 import useAskemContext from '../components/askem/useAskemContext';
 
@@ -132,17 +133,19 @@ function BaseApp({
                     footerMenu={footerMenu}
                     languages={languages}
                   >
-                    <GeolocationErrorNotification />
-                    <ResetFocus />
-                    {children}
-                    {withConsent && (
-                      <EventsCookieConsent
-                        onConsentGiven={handleConsentGiven}
-                        allowLanguageSwitch={false}
-                        appName={appName}
-                      />
-                    )}
-                    <DynamicToastContainer />
+                    <MatomoWrapper>
+                      <GeolocationErrorNotification />
+                      <ResetFocus />
+                      {children}
+                      {withConsent && (
+                        <EventsCookieConsent
+                          onConsentGiven={handleConsentGiven}
+                          allowLanguageSwitch={false}
+                          appName={appName}
+                        />
+                      )}
+                      <DynamicToastContainer />
+                    </MatomoWrapper>
                   </NavigationProvider>
                 </GeolocationProvider>
               </AskemProvider>

--- a/packages/components/src/components/errorPages/ErrorPage.tsx
+++ b/packages/components/src/components/errorPages/ErrorPage.tsx
@@ -7,7 +7,6 @@ import useErrorsTranslation from '../../hooks/useErrorsTranslation';
 import useLocale from '../../hooks/useLocale';
 import NavigationContext from '../../navigationProvider/NavigationContext';
 import FooterSection from '../footer/Footer';
-import MatomoWrapper from '../matomoWrapper/MatomoWrapper';
 import Navigation from '../navigation/Navigation';
 import styles from './errorPage.module.scss';
 
@@ -32,33 +31,31 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
   };
 
   return (
-    <MatomoWrapper>
-      <RHHCPage
-        className="pageLayout"
-        navigation={<Navigation languages={HARDCODED_LANGUAGES} />}
-        content={
-          <div className={styles.errorPageWrapper}>
-            <main id={MAIN_CONTENT_ID}>
-              <div className={styles.errorPageHero}>
-                <IconCrossCircle size="xl" />
-                <h1>{headerText}</h1>
-                <p>{descriptionText}</p>
-                <Button onClick={moveToHomePage} variant="success">
-                  {t(`errors:moveToHomePageButton`)}
-                </Button>
-              </div>
-            </main>
-          </div>
-        }
-        footer={
-          <FooterSection
-            menu={footerMenu}
-            appName={appName}
-            hasFeedBack={false}
-          />
-        }
-      />
-    </MatomoWrapper>
+    <RHHCPage
+      className="pageLayout"
+      navigation={<Navigation languages={HARDCODED_LANGUAGES} />}
+      content={
+        <div className={styles.errorPageWrapper}>
+          <main id={MAIN_CONTENT_ID}>
+            <div className={styles.errorPageHero}>
+              <IconCrossCircle size="xl" />
+              <h1>{headerText}</h1>
+              <p>{descriptionText}</p>
+              <Button onClick={moveToHomePage} variant="success">
+                {t(`errors:moveToHomePageButton`)}
+              </Button>
+            </div>
+          </main>
+        </div>
+      }
+      footer={
+        <FooterSection
+          menu={footerMenu}
+          appName={appName}
+          hasFeedBack={false}
+        />
+      }
+    />
   );
 };
 export default ErrorPage;

--- a/packages/components/src/translations/common.config.ts
+++ b/packages/components/src/translations/common.config.ts
@@ -1,12 +1,10 @@
 import type { I18nActiveNamespaces } from '@/lib/i18n';
 
 export type CommonConfig = {
-  i18nNamespaces: I18nActiveNamespaces<
-    'common' | 'appHobbies' | 'appEvents' | 'appSports'
-  >;
+  i18nNamespaces: I18nActiveNamespaces<'common'>;
 };
 
 export const commonConfig: CommonConfig = {
   /** Namespaces that should be loaded for this page */
-  i18nNamespaces: ['common', 'appHobbies', 'appEvents', 'appSports'],
+  i18nNamespaces: ['common'],
 };


### PR DESCRIPTION
HH-342.

- Use app specific translations instead of Common. Remove the app specific translations from the common scope.
- Cookie-consent page should not fetch any page document
- Search page should not use HCRC Apollo Page to prevent duplicate dta fetching
- MatomoWrappers moved from NextPages to the BaseApp component
- Use more consistent naming when using HCRC Page component