### PR TITLE
fix: remove home-translations from the common list for optimization

### DIFF
--- a/apps/events-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
+++ b/apps/events-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
@@ -11,7 +11,6 @@ const COMMON_TRANSLATIONS = [
   'footer',
   'geolocationProvider',
   'notFound',
-  'home',
 ];
 
 export default async function serverSideTranslationsWithCommon(

--- a/apps/events-helsinki/src/pages/index.tsx
+++ b/apps/events-helsinki/src/pages/index.tsx
@@ -99,6 +99,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       return {
         props: {
           ...(await serverSideTranslationsWithCommon(language, [
+            'home',
             'search',
             'event',
           ])),
@@ -114,6 +115,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       return {
         props: {
           ...(await serverSideTranslationsWithCommon(DEFAULT_LANGUAGE, [
+            'home',
             'search',
             'event',
           ])),

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -101,6 +101,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         ...(await serverSideTranslationsWithCommon(language, [
           'event',
           'search',
+          'home',
         ])),
       },
     };

--- a/apps/hobbies-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
+++ b/apps/hobbies-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
@@ -11,7 +11,6 @@ const COMMON_TRANSLATIONS = [
   'footer',
   'geolocationProvider',
   'notFound',
-  'home',
 ];
 
 export default async function serverSideTranslationsWithCommon(

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -100,6 +100,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         ...(await serverSideTranslationsWithCommon(language, [
           'event',
           'search',
+          'home',
         ])),
       },
     };

--- a/apps/sports-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
+++ b/apps/sports-helsinki/src/domain/i18n/serverSideTranslationsWithCommon.ts
@@ -11,7 +11,6 @@ const COMMON_TRANSLATIONS = [
   'footer',
   'geolocationProvider',
   'notFound',
-  'home',
 ];
 
 export default async function serverSideTranslationsWithCommon(

--- a/apps/sports-helsinki/src/pages/index.tsx
+++ b/apps/sports-helsinki/src/pages/index.tsx
@@ -100,6 +100,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       return {
         props: {
           ...(await serverSideTranslationsWithCommon(language, [
+            'home',
             'search',
             'event',
           ])),
@@ -115,7 +116,9 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       return {
         props: {
           ...(await serverSideTranslationsWithCommon(DEFAULT_LANGUAGE, [
+            'home',
             'search',
+            'event',
           ])),
           page: null,
         },

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -75,6 +75,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
           'event',
           'search',
           'venue',
+          'home',
         ])),
       },
     };

--- a/apps/sports-helsinki/src/pages/search/map.tsx
+++ b/apps/sports-helsinki/src/pages/search/map.tsx
@@ -165,8 +165,10 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     });
     return {
       props: {
-        page: pageData.page,
-        ...(await serverSideTranslationsWithCommon(language, ['search'])),
+        ...(await serverSideTranslationsWithCommon(language, [
+          'search',
+          'home',
+        ])),
       },
     };
   });


### PR DESCRIPTION
HH-336 HH-311.

Remove the home-translations from the common list to
optimise and reduce the size of (SSG) generated pages.
