### PR TITLE
Replace the location phone and email from event info with provider contact info

### DIFF
--- a/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
@@ -276,13 +276,14 @@ const OtherInfo: React.FC<{
         ) => {
           return (
             !!externalLink.link &&
+            !!externalLink.name &&
             externalLink.link !== registrationUrl && (
               <SecondaryLink
                 className={styles.link}
-                key={index}
+                key={`externalLink-${index}`}
                 href={externalLink.link}
               >
-                {translateValue('info.', externalLink.name as string, t)}
+                {translateValue('info.', externalLink.name, t)}
               </SecondaryLink>
             )
           );

--- a/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
@@ -14,7 +14,7 @@ import type { EventAttributes } from 'ics';
 import { createEvent } from 'ics';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import { Link, SecondaryLink } from 'react-helsinki-headless-cms';
+import { SecondaryLink } from 'react-helsinki-headless-cms';
 
 import IconDirections from '../../../../assets/icons/IconDirections';
 import InfoWithIcon from '../../../../components/infoWithIcon/InfoWithIcon';
@@ -249,7 +249,7 @@ const OtherInfo: React.FC<{
   const { t } = useTranslation('event');
   const locale = useLocale();
 
-  const { email, externalLinks, infoUrl, telephone, registrationUrl } =
+  const { externalLinks, infoUrl, registrationUrl, providerContactInfo } =
     getEventFields(event, locale);
 
   return (
@@ -257,20 +257,7 @@ const OtherInfo: React.FC<{
       icon={<IconInfoCircle aria-hidden />}
       title={t('info.labelOtherInfo')}
     >
-      {email && (
-        <div key={email}>
-          <Link className={styles.link} size="L" href={`mailto:${email}`}>
-            {email}
-          </Link>
-        </div>
-      )}
-      {telephone && (
-        <div key={telephone}>
-          <Link className={styles.link} size="L" href={`tel:${telephone}`}>
-            {telephone}
-          </Link>
-        </div>
-      )}
+      {providerContactInfo && <div>{providerContactInfo}</div>}
 
       {infoUrl && (
         <SecondaryLink

--- a/packages/components/src/components/domain/event/query.ts
+++ b/packages/components/src/components/domain/event/query.ts
@@ -72,6 +72,9 @@ export const QUERY_EVENT_DETAILS = gql`
     provider {
       ...localizedFields
     }
+    providerContactInfo {
+      ...localizedFields
+    }
     infoUrl {
       ...localizedFields
     }

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -2907,7 +2907,7 @@ export type EventDetails = {
   name: LocalizedObject;
   offers: Array<Offer>;
   provider?: Maybe<LocalizedObject>;
-  providerContactInfo?: Maybe<Scalars['String']['output']>;
+  providerContactInfo?: Maybe<LocalizedObject>;
   publisher?: Maybe<Scalars['ID']['output']>;
   remainingAttendeeCapacity?: Maybe<Scalars['Int']['output']>;
   shortDescription?: Maybe<LocalizedObject>;
@@ -12625,6 +12625,12 @@ export type EventFieldsFragment = {
     fi?: string | null;
     sv?: string | null;
   } | null;
+  providerContactInfo?: {
+    __typename?: 'LocalizedObject';
+    en?: string | null;
+    fi?: string | null;
+    sv?: string | null;
+  } | null;
   infoUrl?: {
     __typename?: 'LocalizedObject';
     en?: string | null;
@@ -12807,6 +12813,12 @@ export type EventDetailsQuery = {
       sv?: string | null;
     } | null;
     provider?: {
+      __typename?: 'LocalizedObject';
+      en?: string | null;
+      fi?: string | null;
+      sv?: string | null;
+    } | null;
+    providerContactInfo?: {
       __typename?: 'LocalizedObject';
       en?: string | null;
       fi?: string | null;
@@ -13079,6 +13091,12 @@ export type EventListQuery = {
         fi?: string | null;
         sv?: string | null;
       } | null;
+      providerContactInfo?: {
+        __typename?: 'LocalizedObject';
+        en?: string | null;
+        fi?: string | null;
+        sv?: string | null;
+      } | null;
       infoUrl?: {
         __typename?: 'LocalizedObject';
         en?: string | null;
@@ -13273,6 +13291,12 @@ export type EventsByIdsQuery = {
         sv?: string | null;
       } | null;
       provider?: {
+        __typename?: 'LocalizedObject';
+        en?: string | null;
+        fi?: string | null;
+        sv?: string | null;
+      } | null;
+      providerContactInfo?: {
         __typename?: 'LocalizedObject';
         en?: string | null;
         fi?: string | null;
@@ -14249,6 +14273,9 @@ export const EventFieldsFragmentDoc = gql`
     startTime
     publisher
     provider {
+      ...localizedFields
+    }
+    providerContactInfo {
       ...localizedFields
     }
     infoUrl {

--- a/packages/components/src/utils/eventUtils.ts
+++ b/packages/components/src/utils/eventUtils.ts
@@ -363,6 +363,7 @@ export const getEventFields = (event: EventFields, locale: AppLanguage) => {
     remainingAttendeeCapacity: event.remainingAttendeeCapacity,
     enrolmentStartTime: event.enrolmentStartTime,
     enrolmentEndTime: event.enrolmentEndTime,
+    providerContactInfo: getLocalizedString(event.providerContactInfo, locale),
   };
 };
 


### PR DESCRIPTION
HH-337
1. add localized providerContactInfo field to event details
2. replace the location phone and email from event info with provider contact info
3. trivial refactoring for an old implementation

NOTE: Relates to https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/617 and https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/618 . Needs those to be merged first.

<img width="906" alt="Screenshot 2024-01-15 at 15 37 41" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/0b75331e-2637-4248-b43e-b4b0c46065fd">
<img width="322" alt="Screenshot 2024-01-15 at 15 37 54" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/5ced36b1-390e-4813-9cd3-616705acff77">
