### PR TITLE
fix(apps): do not show empty other info on event details

### DIFF
--- a/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
@@ -56,17 +56,16 @@ const EventInfo: React.FC<EventInfoProps> = ({ event, superEvent }) => {
     className: styles.focusVisible,
   });
   const {
-    email,
     externalLinks,
     infoUrl,
     languages,
-    telephone,
+    providerContactInfo,
     audience,
     audienceMinAge,
     audienceMaxAge,
   } = getEventFields(event, locale);
   const showOtherInfo = Boolean(
-    email || externalLinks.length || infoUrl || telephone
+    providerContactInfo || externalLinks.length || infoUrl
   );
   /*
   Middle level events are all the events that have super event and subEvents


### PR DESCRIPTION
HH-337

Before:
<img width="236" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/f4ff73a2-59f7-45f4-94bf-55aefed6a0f6">

After:
<img width="327" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/dfc1eca1-8a24-4417-999a-0eea424b64e2">
