### PR TITLE
Remove the closed events from the search list

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_EVENT_SORT_OPTION,
   isEventSortOption,
   EventList,
+  useClearClosedEventsFromApolloCache,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -73,6 +74,9 @@ const SearchPage: React.FC<{
     variables: eventFilters,
   });
   const eventsList = eventsData?.eventList;
+
+  // Clear the cache from the events of the past
+  useClearClosedEventsFromApolloCache(eventsData);
 
   const handleLoadMore = async () => {
     const page = eventsData?.eventList.meta

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -11,6 +11,7 @@ import {
   MAIN_CONTENT_ID,
   EVENT_SORT_OPTIONS,
   EventList,
+  useClearClosedEventsFromApolloCache,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -68,6 +69,9 @@ const SearchPage: React.FC<{
   });
 
   const eventsList = eventsData?.eventList;
+
+  // Clear the cache from the events of the past
+  useClearClosedEventsFromApolloCache(eventsData);
 
   const handleLoadMore = async () => {
     const page = eventsData?.eventList.meta

--- a/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
@@ -4,6 +4,7 @@ import {
   useIsSmallScreen,
   useEventListQuery,
   getLargeEventCardId,
+  useClearClosedEventsFromApolloCache,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -46,6 +47,9 @@ function useEventSearchPageQuery(eventType: EventTypeId) {
     }
     setIsFetchingMore(false);
   };
+
+  // Clear the cache from the events of the past
+  useClearClosedEventsFromApolloCache(data);
 
   return {
     data,

--- a/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/hooks/useSearchPage.tsx
@@ -107,7 +107,7 @@ function useSearchPage({ eventType }: { eventType: EventTypeId }): SearchPage {
     }
   };
 
-  const count = (eventsData?.eventList?.meta.count as number) ?? 0;
+  const count = eventsData?.eventList?.meta.count ?? 0;
   const hasNext = !!eventsData?.eventList?.meta.next;
 
   return {

--- a/packages/components/src/components/eventCard/EventCard.tsx
+++ b/packages/components/src/components/eventCard/EventCard.tsx
@@ -15,7 +15,6 @@ import {
   getEventCardId,
   getEventFields,
   getEventPrice,
-  isEventClosed,
 } from '../../utils';
 import EventKeywords from '../eventKeywords/EventKeywords';
 import EventName from '../eventName/EventName';
@@ -34,7 +33,6 @@ const EventCard: React.FC<EventCardProps> = ({ event, eventUrl }) => {
     locale
   );
 
-  const eventClosed = isEventClosed(event);
   const eventPriceText = getEventPrice(event, locale, t('eventCard.isFree'));
 
   const goToEventPage = () => {
@@ -53,11 +51,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, eventUrl }) => {
         data-testid={event.id}
         href={eventUrl}
       >
-        <div
-          className={classNames(styles.eventCard, {
-            [styles.eventClosed]: eventClosed,
-          })}
-        >
+        <div className={classNames(styles.eventCard)}>
           {/* INFO WRAPPER. Re-order info wrapper and text wrapper on css */}
           <div className={styles.infoWrapper}>
             <div className={styles.textWrapper}>

--- a/packages/components/src/components/eventCard/EventCard.tsx
+++ b/packages/components/src/components/eventCard/EventCard.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -51,7 +50,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, eventUrl }) => {
         data-testid={event.id}
         href={eventUrl}
       >
-        <div className={classNames(styles.eventCard)}>
+        <div className={styles.eventCard}>
           {/* INFO WRAPPER. Re-order info wrapper and text wrapper on css */}
           <div className={styles.infoWrapper}>
             <div className={styles.textWrapper}>

--- a/packages/components/src/components/eventCard/LargeEventCard.tsx
+++ b/packages/components/src/components/eventCard/LargeEventCard.tsx
@@ -66,7 +66,7 @@ const LargeEventCard: React.FC<LargeEventCardProps> = ({
         data-testid={event.id}
         href={eventUrl}
       >
-        <div className={classNames(styles.eventCard)}>
+        <div className={styles.eventCard}>
           {/* INFO WRAPPER. Re-order info wrapper and text wrapper on css */}
           <div className={styles.infoWrapper}>
             <div className={styles.eventName}>

--- a/packages/components/src/components/eventCard/LargeEventCard.tsx
+++ b/packages/components/src/components/eventCard/LargeEventCard.tsx
@@ -22,7 +22,6 @@ import {
   getEventFields,
   getEventPrice,
   getLargeEventCardId,
-  isEventClosed,
 } from '../../utils';
 import EventKeywords from '../eventKeywords/EventKeywords';
 import EventName from '../eventName/EventName';
@@ -50,8 +49,6 @@ const LargeEventCard: React.FC<LargeEventCardProps> = ({
 
   const audienceAge = getAudienceAgeText(t, audienceMinAge, audienceMaxAge);
 
-  const eventClosed = isEventClosed(event);
-
   const { status: eventEnrolmentStatus } = useEventEnrolmentStatus(event);
 
   const { clickCaptureRef, clicked } = useClickCapture(1000);
@@ -69,11 +66,7 @@ const LargeEventCard: React.FC<LargeEventCardProps> = ({
         data-testid={event.id}
         href={eventUrl}
       >
-        <div
-          className={classNames(styles.eventCard, {
-            [styles.eventClosed]: eventClosed,
-          })}
-        >
+        <div className={classNames(styles.eventCard)}>
           {/* INFO WRAPPER. Re-order info wrapper and text wrapper on css */}
           <div className={styles.infoWrapper}>
             <div className={styles.eventName}>

--- a/packages/components/src/components/eventCard/eventCard.module.scss
+++ b/packages/components/src/components/eventCard/eventCard.module.scss
@@ -125,10 +125,4 @@
       }
     }
   }
-
-  &.eventClosed {
-    .imageWrapper {
-      opacity: 0.5;
-    }
-  }
 }

--- a/packages/components/src/components/eventCard/largeEventCard.module.scss
+++ b/packages/components/src/components/eventCard/largeEventCard.module.scss
@@ -167,10 +167,4 @@
       }
     }
   }
-
-  &.eventClosed {
-    .imageWrapper {
-      opacity: 0.5;
-    }
-  }
 }

--- a/packages/components/src/components/eventList/EventList.tsx
+++ b/packages/components/src/components/eventList/EventList.tsx
@@ -19,7 +19,7 @@ const eventCardsMap = {
 
 type EventListProps = {
   buttonCentered?: boolean;
-  cardSize?: 'default' | 'large';
+  cardSize?: keyof typeof eventCardsMap;
   events: EventFields[];
   count: number;
   loading: boolean;
@@ -46,7 +46,7 @@ const EventList: React.FC<EventListProps> = ({
   const eventsLeft = count - events.length;
   const EventCardComponent = eventCardsMap[cardSize];
 
-  const eventCards = (events as EventFields[]).map((event) => {
+  const eventCards = events.map((event) => {
     const eventUrl = getEventUrl(event, router, locale);
     return (
       <EventCardComponent

--- a/packages/components/src/components/matomoWrapper/MatomoWrapper.tsx
+++ b/packages/components/src/components/matomoWrapper/MatomoWrapper.tsx
@@ -2,7 +2,7 @@ import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import { useCookies } from 'hds-react';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useCookieConfigurationContext } from '../../cookieConfigurationProvider';
 
 interface Props {

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -26,3 +26,4 @@ export { default as useClickCapture } from './useClickCapture';
 export { default as usePageScrollRestoration } from './usePageScrollRestoration';
 export { default as useSuperEventLazyLoad } from './useSuperEventLazyLoad';
 export { default as useGeolocation } from './useGeolocation';
+export { default as useClearClosedEventsFromApolloCache } from './useClearClosedEventsFromApolloCache';

--- a/packages/components/src/hooks/useClearClosedEventsFromApolloCache.ts
+++ b/packages/components/src/hooks/useClearClosedEventsFromApolloCache.ts
@@ -23,6 +23,7 @@ export default function useClearClosedEventsFromApolloCache(
       cache.gc();
       // eslint-disable-next-line no-console
       console.info(
+        // eslint-disable-next-line no-console
         'Removed the past events from the Apollo cache by carbage collecting them',
         eventsOfPastIds
       );

--- a/packages/components/src/hooks/useClearClosedEventsFromApolloCache.ts
+++ b/packages/components/src/hooks/useClearClosedEventsFromApolloCache.ts
@@ -11,11 +11,9 @@ export default function useClearClosedEventsFromApolloCache(
 ) {
   const { cache } = useApolloClient();
   useEffect(() => {
-    const eventsOfPastIds = data?.eventList.data.reduce<string[]>(
-      (pastEventIds, event) =>
-        isEventClosed(event) ? [...pastEventIds, event.id] : pastEventIds,
-      []
-    );
+    const eventsOfPastIds = data?.eventList.data
+      .filter(isEventClosed)
+      .map((event) => event.id);
     if (eventsOfPastIds?.length) {
       eventsOfPastIds?.forEach((eventId) =>
         cache.evict({ id: `EventDetails:${eventId}` })
@@ -23,7 +21,6 @@ export default function useClearClosedEventsFromApolloCache(
       cache.gc();
       // eslint-disable-next-line no-console
       console.info(
-        // eslint-disable-next-line no-console
         'Removed the past events from the Apollo cache by carbage collecting them',
         eventsOfPastIds
       );

--- a/packages/components/src/hooks/useClearClosedEventsFromApolloCache.ts
+++ b/packages/components/src/hooks/useClearClosedEventsFromApolloCache.ts
@@ -1,0 +1,31 @@
+import { useApolloClient } from '@apollo/client';
+import { useEffect } from 'react';
+import type { EventListQuery } from '../types/generated/graphql';
+import { isEventClosed } from '../utils/eventUtils';
+
+/**
+ * Clear the Apollo cache from the events of the past
+ */
+export default function useClearClosedEventsFromApolloCache(
+  data?: EventListQuery
+) {
+  const { cache } = useApolloClient();
+  useEffect(() => {
+    const eventsOfPastIds = data?.eventList.data.reduce<string[]>(
+      (pastEventIds, event) =>
+        isEventClosed(event) ? [...pastEventIds, event.id] : pastEventIds,
+      []
+    );
+    if (eventsOfPastIds?.length) {
+      eventsOfPastIds?.forEach((eventId) =>
+        cache.evict({ id: `EventDetails:${eventId}` })
+      );
+      cache.gc();
+      // eslint-disable-next-line no-console
+      console.info(
+        'Removed the past events from the Apollo cache by carbage collecting them',
+        eventsOfPastIds
+      );
+    }
+  }, [cache, data?.eventList.data]);
+}


### PR DESCRIPTION
TH-1317.

Evict the closed events from the Apollo cache, that is used in the search page for the event listing. Clear the "carbage" to clean the cache from evicted items. A common hook is added so all the 3 apps can use the same code.

There is no need for the closed event styles anymore, since the closed events are removed from the events listing.

Apollo client cache garbage collection documentation: https://www.apollographql.com/docs/react/caching/garbage-collection/#cacheevict

----

To test, use the [apollo dev tools](https://github.com/apollographql/apollo-client-devtools/) to see the Apollo client's cached content. Note that the built version of the NextJS application is needed to be ran, so build the nextjs application with `yarn build-fast` and run it with `yarn start`. Then see the cached content with the dev-tool.

*NOTE: it is not that easy to get closed events in the event list!!* You can add a specific id or something in the new hook by editing the eventsOfPastIds constant 
```
    const eventsOfPastIds = data?.eventList.data.reduce<string[]>(
      (pastEventIds, event) =>
        isEventClosed(event) ? [...pastEventIds, event.id] : pastEventIds,
      []
    );
```