### PR TITLE
LIIKUNTA-606 | Fix unknown error page's translations

### DIFF
--- a/apps/events-helsinki/src/hooks/useEventsRHHCConfig.tsx
+++ b/apps/events-helsinki/src/hooks/useEventsRHHCConfig.tsx
@@ -1,6 +1,7 @@
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import type { EventFieldsFragment } from '@events-helsinki/components';
 import {
+  useResilientTranslation,
   getLanguageCode,
   getLinkArrowLabel,
   useLocale,
@@ -10,7 +11,6 @@ import {
   useCommonCmsConfig,
   HelsinkiCityOwnedIcon,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_PREFIXES,
-  useAppEventsTranslation,
 } from '@events-helsinki/components';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -42,8 +42,8 @@ export default function useEventsRHHCConfig(args: {
 }): Config {
   const { apolloClient } = args;
   const { t: commonTranslation } = useCommonTranslation();
-  const { t: appTranslation } = useAppEventsTranslation();
   const { t: eventTranslation } = useEventTranslation();
+  const { resilientT } = useResilientTranslation();
   const locale = useLocale();
   const commonConfig = useCommonCmsConfig();
   return React.useMemo(() => {
@@ -86,7 +86,7 @@ export default function useEventsRHHCConfig(args: {
           <HelsinkiCityOwnedIcon {...props} />
         ),
       },
-      siteName: appTranslation('appEvents:appName'),
+      siteName: resilientT('appEvents:appName'),
       currentLanguageCode: getLanguageCode(locale),
       apolloClient,
       eventsApolloClient: apolloClient,
@@ -134,9 +134,9 @@ export default function useEventsRHHCConfig(args: {
     };
   }, [
     commonConfig,
-    appTranslation,
     commonTranslation,
     eventTranslation,
+    resilientT,
     locale,
     apolloClient,
   ]);

--- a/apps/events-helsinki/src/pages/404.tsx
+++ b/apps/events-helsinki/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   NotFound,
-  useAppEventsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getEventsStaticProps from '../domain/app/getEventsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const FourOhFour: NextPage = () => {
-  const { t } = useAppEventsTranslation();
-  return <NotFound appName={t('appEvents:appName')} />;
+  const { resilientT } = useResilientTranslation();
+  return <NotFound appName={resilientT('appEvents:appName')} />;
 };
 export default FourOhFour;
 

--- a/apps/events-helsinki/src/pages/500.tsx
+++ b/apps/events-helsinki/src/pages/500.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   UnknownError,
-  useAppEventsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next/types';
 import React from 'react';
@@ -9,8 +9,8 @@ import getEventsStaticProps from '../domain/app/getEventsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const NextErrorPage = () => {
-  const { t } = useAppEventsTranslation();
-  return <UnknownError appName={t('appEvents:appName')} />;
+  const { resilientT } = useResilientTranslation();
+  return <UnknownError appName={resilientT('appEvents:appName')} />;
 };
 
 export async function getStaticProps(context: GetStaticPropsContext) {

--- a/apps/events-helsinki/src/pages/_app.tsx
+++ b/apps/events-helsinki/src/pages/_app.tsx
@@ -1,8 +1,8 @@
 import type { NavigationProviderProps } from '@events-helsinki/components';
 import {
+  useResilientTranslation,
   useLocale,
   BaseApp,
-  useAppEventsTranslation,
 } from '@events-helsinki/components';
 import { FallbackComponent } from '@events-helsinki/components/app/BaseApp';
 import type { AppProps as NextAppProps } from 'next/app';
@@ -37,10 +37,10 @@ export type AppProps<P = any> = {
 export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
-  const { t } = useAppEventsTranslation();
+  const { resilientT } = useResilientTranslation();
   const locale = useLocale();
   const { asPath, pathname } = useRouter();
-  const appName = t('appEvents:appName');
+  const appName = resilientT('appEvents:appName');
   return (
     <ErrorBoundary
       FallbackComponent={({ error }) => (

--- a/apps/events-helsinki/src/pages/_error.tsx
+++ b/apps/events-helsinki/src/pages/_error.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   UnknownError,
-  useAppEventsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next/types';
 import React from 'react';
@@ -9,8 +9,8 @@ import getEventsStaticProps from '../domain/app/getEventsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const NextErrorPage = () => {
-  const { t } = useAppEventsTranslation();
-  return <UnknownError appName={t('appEvents:appName')} />;
+  const { resilientT } = useResilientTranslation();
+  return <UnknownError appName={resilientT('appEvents:appName')} />;
 };
 
 export async function getStaticProps(context: GetStaticPropsContext) {

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -7,9 +7,9 @@ import {
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
-  useAppEventsTranslation,
   RouteMeta,
   getLanguageCodeFilter,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { AppLanguage } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
@@ -60,7 +60,7 @@ const NextCmsArticle: NextPage<{
   } = useConfig();
 
   const { t: commonTranslation } = useCommonTranslation();
-  const { t: appTranslation } = useAppEventsTranslation();
+  const { resilientT } = useResilientTranslation();
 
   const { footerMenu } = useContext(NavigationContext);
 
@@ -121,7 +121,7 @@ const NextCmsArticle: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={appTranslation('appEvents:appName')}
+          appName={resilientT('appEvents:appName')}
         />
       }
     />

--- a/apps/events-helsinki/src/pages/articles/index.tsx
+++ b/apps/events-helsinki/src/pages/articles/index.tsx
@@ -6,11 +6,11 @@ import {
   NavigationContext,
   skipFalsyType,
   Navigation,
-  useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
   getLanguageCodeFilter,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
@@ -53,7 +53,7 @@ export default function ArticleArchive({
   page,
 }: EventsGlobalPageProps & { page: PageType }) {
   const router = useRouter();
-  const { t: commonT } = useCommonTranslation();
+  const { resilientT } = useResilientTranslation();
 
   const getArticlesSearchQuery = (
     text: string,
@@ -240,7 +240,7 @@ export default function ArticleArchive({
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={commonT('appEvents:appName')}
+          appName={resilientT('appEvents:appName')}
           feedbackWithPadding
         />
       }

--- a/apps/events-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/events-helsinki/src/pages/cookie-consent/index.tsx
@@ -6,7 +6,7 @@ import {
   usePageScrollRestoration,
   EventsCookieConsent,
   RouteMeta,
-  useAppEventsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
@@ -19,7 +19,7 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 export default function CookieConsent() {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppEventsTranslation();
+  const { resilientT } = useResilientTranslation();
   const router = useRouter();
   /*
   // bug or feature: query is empty in handleRedirect
@@ -47,7 +47,7 @@ export default function CookieConsent() {
           <RouteMeta origin={AppConfig.origin} />
           <ConsentPageContent>
             <EventsCookieConsent
-              appName={t('appEvents:appName')}
+              appName={resilientT('appEvents:appName')}
               isModal={false}
               onConsentGiven={handleRedirect}
             />
@@ -57,7 +57,7 @@ export default function CookieConsent() {
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appEvents:appName')}
+          appName={resilientT('appEvents:appName')}
           hasFeedBack={false}
         />
       }

--- a/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
+++ b/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
@@ -4,7 +4,7 @@ import {
   Navigation,
   getLanguageOrDefault,
   FooterSection,
-  useAppEventsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -24,7 +24,7 @@ const Event: NextPage<{
   loading: boolean;
 }> = ({ event, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppEventsTranslation();
+  const { resilientT } = useResilientTranslation();
   return (
     <RHHCPage
       className="pageLayout"
@@ -37,7 +37,10 @@ const Event: NextPage<{
         />
       }
       footer={
-        <FooterSection menu={footerMenu} appName={t('appEvents:appName')} />
+        <FooterSection
+          menu={footerMenu}
+          appName={resilientT('appEvents:appName')}
+        />
       }
     />
   );

--- a/apps/events-helsinki/src/pages/index.tsx
+++ b/apps/events-helsinki/src/pages/index.tsx
@@ -3,10 +3,10 @@ import {
   getQlLanguage,
   NavigationContext,
   Navigation,
-  useAppEventsTranslation,
   getLanguageOrDefault,
   FooterSection,
   RouteMeta,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
 import type { GetStaticPropsContext, NextPage } from 'next';
@@ -37,7 +37,7 @@ const HomePage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppEventsTranslation();
+  const { resilientT } = useResilientTranslation();
 
   return (
     <RHHCPage
@@ -59,7 +59,7 @@ const HomePage: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appEvents:appName')}
+          appName={resilientT('appEvents:appName')}
           hasFeedBack={false}
         />
       }

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -3,10 +3,10 @@
 import type { NormalizedCacheObject } from '@apollo/client';
 import type { AppLanguage } from '@events-helsinki/components';
 import {
+  useResilientTranslation,
   Navigation,
   NavigationContext,
   getAllPages,
-  useAppEventsTranslation,
   getLanguageOrDefault,
   FooterSection,
   RouteMeta,
@@ -48,7 +48,7 @@ const NextCmsPage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t: appTranslation } = useAppEventsTranslation();
+  const { resilientT } = useResilientTranslation();
 
   // FIXME: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
@@ -74,7 +74,7 @@ const NextCmsPage: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={appTranslation('appEvents:appName')}
+          appName={resilientT('appEvents:appName')}
         />
       }
     />

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -6,6 +6,7 @@ import {
   FooterSection,
   RouteMeta,
   PageMeta,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import { usePageScrollRestoration } from '@events-helsinki/components/src/hooks';
 import type { GetStaticPropsContext, NextPage } from 'next';
@@ -33,6 +34,7 @@ const Search: NextPage<{
   const scrollTo = router.query?.scrollTo;
   const listRef = useRef<HTMLUListElement | null>(null);
   const { t: tAppEvents } = useAppEventsTranslation();
+  const { resilientT } = useResilientTranslation();
   usePageScrollRestoration();
 
   useEffect(() => {
@@ -70,7 +72,7 @@ const Search: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={tAppEvents('appEvents:appName')}
+          appName={resilientT('appEvents:appName')}
           feedbackWithPadding
         />
       }

--- a/apps/hobbies-helsinki/src/hooks/useHobbiesRHHCConfig.tsx
+++ b/apps/hobbies-helsinki/src/hooks/useHobbiesRHHCConfig.tsx
@@ -1,6 +1,7 @@
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import type { EventFieldsFragment } from '@events-helsinki/components';
 import {
+  useResilientTranslation,
   getLanguageCode,
   getLinkArrowLabel,
   useLocale,
@@ -10,7 +11,6 @@ import {
   useCommonCmsConfig,
   HelsinkiCityOwnedIcon,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_PREFIXES,
-  useAppHobbiesTranslation,
 } from '@events-helsinki/components';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -42,8 +42,8 @@ export default function useHobbiesRHHCConfig(args: {
 }): Config {
   const { apolloClient } = args;
   const { t: commonTranslation } = useCommonTranslation();
-  const { t: appTranslation } = useAppHobbiesTranslation();
   const { t: eventTranslation } = useEventTranslation();
+  const { resilientT } = useResilientTranslation();
   const locale = useLocale();
   const commonConfig = useCommonCmsConfig();
 
@@ -87,7 +87,7 @@ export default function useHobbiesRHHCConfig(args: {
           <HelsinkiCityOwnedIcon {...props} />
         ),
       },
-      siteName: appTranslation('appHobbies:appName'),
+      siteName: resilientT('appHobbies:appName'),
       currentLanguageCode: getLanguageCode(locale),
       apolloClient,
       eventsApolloClient: apolloClient,
@@ -135,9 +135,9 @@ export default function useHobbiesRHHCConfig(args: {
     };
   }, [
     commonConfig,
-    appTranslation,
     commonTranslation,
     eventTranslation,
+    resilientT,
     locale,
     apolloClient,
   ]);

--- a/apps/hobbies-helsinki/src/pages/404.tsx
+++ b/apps/hobbies-helsinki/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   NotFound,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getHobbiesStaticProps from '../domain/app/getHobbiesStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const FourOhFour: NextPage = () => {
-  const { t } = useAppHobbiesTranslation();
-  return <NotFound appName={t('appHobbies:appName')} />;
+  const { resilientT } = useResilientTranslation();
+  return <NotFound appName={resilientT('appHobbies:appName')} />;
 };
 export default FourOhFour;
 

--- a/apps/hobbies-helsinki/src/pages/500.tsx
+++ b/apps/hobbies-helsinki/src/pages/500.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   UnknownError,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getHobbiesStaticProps from '../domain/app/getHobbiesStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const NextErrorPage: NextPage = () => {
-  const { t } = useAppHobbiesTranslation();
-  return <UnknownError appName={t(`appHobbies:appName`)} />;
+  const { resilientT } = useResilientTranslation();
+  return <UnknownError appName={resilientT('appHobbies:appName')} />;
 };
 
 export async function getStaticProps(context: GetStaticPropsContext) {

--- a/apps/hobbies-helsinki/src/pages/_app.tsx
+++ b/apps/hobbies-helsinki/src/pages/_app.tsx
@@ -1,8 +1,8 @@
 import type { NavigationProviderProps } from '@events-helsinki/components';
 import {
+  useResilientTranslation,
   useLocale,
   BaseApp,
-  useAppHobbiesTranslation,
 } from '@events-helsinki/components';
 import { FallbackComponent } from '@events-helsinki/components/app/BaseApp';
 import { useRouter } from 'next/router';
@@ -37,10 +37,10 @@ export type AppProps<P = any> = {
 export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
-  const { t } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
   const locale = useLocale();
   const { asPath, pathname } = useRouter();
-  const appName = t('appHobbies:appName');
+  const appName = resilientT('appHobbies:appName');
   return (
     <ErrorBoundary
       FallbackComponent={({ error }) => (

--- a/apps/hobbies-helsinki/src/pages/_error.tsx
+++ b/apps/hobbies-helsinki/src/pages/_error.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   UnknownError,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getHobbiesStaticProps from '../domain/app/getHobbiesStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const NextErrorPage: NextPage = () => {
-  const { t } = useAppHobbiesTranslation();
-  return <UnknownError appName={t(`appHobbies:appName`)} />;
+  const { resilientT } = useResilientTranslation();
+  return <UnknownError appName={resilientT('appHobbies:appName')} />;
 };
 
 export async function getStaticProps(context: GetStaticPropsContext) {

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -7,7 +7,7 @@ import {
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
   RouteMeta,
   getLanguageCodeFilter,
 } from '@events-helsinki/components';
@@ -60,7 +60,7 @@ const NextCmsArticle: NextPage<{
   } = useConfig();
 
   const { t: commonTranslation } = useCommonTranslation();
-  const { t: appTranslation } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
   const { footerMenu } = useContext(NavigationContext);
 
   const { data: categoriesData, loading: loadingCategories } =
@@ -120,7 +120,7 @@ const NextCmsArticle: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={appTranslation('appHobbies:appName')}
+          appName={resilientT('appHobbies:appName')}
         />
       }
     />

--- a/apps/hobbies-helsinki/src/pages/articles/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/index.tsx
@@ -9,7 +9,7 @@ import {
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
   getLanguageCodeFilter,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
@@ -53,7 +53,7 @@ export default function ArticleArchive({
   page,
 }: HobbiesGlobalPageProps & { page: PageType }) {
   const router = useRouter();
-  const { t } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
 
   const getArticlesSearchQuery = (
     text: string,
@@ -240,7 +240,7 @@ export default function ArticleArchive({
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appHobbies:appName')}
+          appName={resilientT('appHobbies:appName')}
           feedbackWithPadding
         />
       }

--- a/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
@@ -6,7 +6,7 @@ import {
   usePageScrollRestoration,
   EventsCookieConsent,
   RouteMeta,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
@@ -19,7 +19,7 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 export default function CookieConsent() {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
   const router = useRouter();
   /*
   // bug or feature: query is empty in handleRedirect
@@ -47,7 +47,7 @@ export default function CookieConsent() {
           <RouteMeta origin={AppConfig.origin} />
           <ConsentPageContent>
             <EventsCookieConsent
-              appName={t('appHobbies:appName')}
+              appName={resilientT('appHobbies:appName')}
               isModal={false}
               onConsentGiven={handleRedirect}
             />
@@ -57,7 +57,7 @@ export default function CookieConsent() {
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appHobbies:appName')}
+          appName={resilientT('appHobbies:appName')}
           hasFeedBack={false}
         />
       }

--- a/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -4,7 +4,7 @@ import {
   Navigation,
   FooterSection,
   getLanguageOrDefault,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -24,7 +24,7 @@ const Event: NextPage<{
   loading: boolean;
 }> = ({ event, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
   return (
     <RHHCPage
       className="pageLayout"
@@ -37,7 +37,10 @@ const Event: NextPage<{
         />
       }
       footer={
-        <FooterSection menu={footerMenu} appName={t('appHobbies:appName')} />
+        <FooterSection
+          menu={footerMenu}
+          appName={resilientT('appHobbies:appName')}
+        />
       }
     />
   );

--- a/apps/hobbies-helsinki/src/pages/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/index.tsx
@@ -6,7 +6,7 @@ import {
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
 import type { GetStaticPropsContext, NextPage } from 'next';
@@ -37,7 +37,7 @@ const HomePage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
   return (
     <RHHCPage
       className="pageLayout"
@@ -58,7 +58,7 @@ const HomePage: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appHobbies:appName')}
+          appName={resilientT('appHobbies:appName')}
           hasFeedBack={false}
         />
       }

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -5,7 +5,7 @@ import type { AppLanguage } from '@events-helsinki/components';
 import {
   NavigationContext,
   getAllPages,
-  useAppHobbiesTranslation,
+  useResilientTranslation,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
@@ -48,7 +48,7 @@ const NextCmsPage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t: appTranslation } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
 
   // FIXME: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
@@ -74,7 +74,7 @@ const NextCmsPage: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={appTranslation('appHobbies:appName')}
+          appName={resilientT('appHobbies:appName')}
         />
       }
     />

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -7,6 +7,7 @@ import {
   usePageScrollRestoration,
   RouteMeta,
   PageMeta,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
@@ -30,6 +31,7 @@ const Search: NextPage<{
   page: PageType;
 }> = ({ page }) => {
   const { t: tAppHobbies } = useAppHobbiesTranslation();
+  const { resilientT } = useResilientTranslation();
   const router = useRouter();
   const scrollTo = router.query?.scrollTo;
   const listRef = useRef<HTMLUListElement | null>(null);
@@ -69,7 +71,7 @@ const Search: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={tAppHobbies('appHobbies:appName')}
+          appName={resilientT('appHobbies:appName')}
           feedbackWithPadding
         />
       }

--- a/apps/sports-helsinki/src/hooks/useSportsRHHCConfig.tsx
+++ b/apps/sports-helsinki/src/hooks/useSportsRHHCConfig.tsx
@@ -1,6 +1,7 @@
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import type { EventFieldsFragment } from '@events-helsinki/components';
 import {
+  useResilientTranslation,
   getLanguageCode,
   getLinkArrowLabel,
   useLocale,
@@ -10,7 +11,6 @@ import {
   useCommonCmsConfig,
   HelsinkiCityOwnedIcon,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_PREFIXES,
-  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -42,8 +42,8 @@ export default function useSportsRHHCConfig(args: {
 }): Config {
   const { apolloClient } = args;
   const { t: commonTranslation } = useCommonTranslation();
-  const { t: appTranslation } = useAppSportsTranslation();
   const { t: eventTranslation } = useEventTranslation();
+  const { resilientT } = useResilientTranslation();
   const locale = useLocale();
   const commonConfig = useCommonCmsConfig();
 
@@ -87,7 +87,7 @@ export default function useSportsRHHCConfig(args: {
           <HelsinkiCityOwnedIcon {...props} />
         ),
       },
-      siteName: appTranslation('appSports:appName'),
+      siteName: resilientT('appSports:appName'),
       currentLanguageCode: getLanguageCode(locale),
       apolloClient,
       eventsApolloClient: apolloClient,
@@ -135,9 +135,9 @@ export default function useSportsRHHCConfig(args: {
     };
   }, [
     commonConfig,
-    appTranslation,
     commonTranslation,
     eventTranslation,
+    resilientT,
     locale,
     apolloClient,
   ]);

--- a/apps/sports-helsinki/src/pages/404.tsx
+++ b/apps/sports-helsinki/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   NotFound,
-  useAppSportsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getSportsStaticProps from '../domain/app/getSportsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const FourOhFour: NextPage = () => {
-  const { t } = useAppSportsTranslation();
-  return <NotFound appName={t('appSports:appName')} />;
+  const { resilientT } = useResilientTranslation();
+  return <NotFound appName={resilientT('appSports:appName')} />;
 };
 export default FourOhFour;
 

--- a/apps/sports-helsinki/src/pages/500.tsx
+++ b/apps/sports-helsinki/src/pages/500.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   UnknownError,
-  useAppSportsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getSportsStaticProps from '../domain/app/getSportsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const NextErrorPage: NextPage = () => {
-  const { t } = useAppSportsTranslation();
-  return <UnknownError appName={t(`appSports:appName`)} />;
+  const { resilientT } = useResilientTranslation();
+  return <UnknownError appName={resilientT('appSports:appName')} />;
 };
 
 export async function getStaticProps(context: GetStaticPropsContext) {

--- a/apps/sports-helsinki/src/pages/_app.tsx
+++ b/apps/sports-helsinki/src/pages/_app.tsx
@@ -1,8 +1,8 @@
 import type { NavigationProviderProps } from '@events-helsinki/components';
 import {
+  useResilientTranslation,
   useLocale,
   BaseApp,
-  useAppSportsTranslation,
 } from '@events-helsinki/components';
 import { FallbackComponent } from '@events-helsinki/components/app/BaseApp';
 import type { AppProps as NextAppProps } from 'next/app';
@@ -37,10 +37,10 @@ export type AppProps<P = any> = {
 export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
-  const { t } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
   const locale = useLocale();
   const { asPath, pathname } = useRouter();
-  const appName = t('appSports:appName');
+  const appName = resilientT('appSports:appName');
   return (
     <ErrorBoundary
       FallbackComponent={({ error }) => (

--- a/apps/sports-helsinki/src/pages/_error.tsx
+++ b/apps/sports-helsinki/src/pages/_error.tsx
@@ -1,7 +1,7 @@
 import {
   getLanguageOrDefault,
   UnknownError,
-  useAppSportsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React from 'react';
@@ -9,8 +9,8 @@ import getSportsStaticProps from '../domain/app/getSportsStaticProps';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 
 const NextErrorPage: NextPage = () => {
-  const { t } = useAppSportsTranslation();
-  return <UnknownError appName={t(`appSports:appName`)} />;
+  const { resilientT } = useResilientTranslation();
+  return <UnknownError appName={resilientT('appSports:appName')} />;
 };
 
 export async function getStaticProps(context: GetStaticPropsContext) {

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -7,7 +7,7 @@ import {
   useCommonTranslation,
   FooterSection,
   getLanguageOrDefault,
-  useAppSportsTranslation,
+  useResilientTranslation,
   RouteMeta,
   getLanguageCodeFilter,
 } from '@events-helsinki/components';
@@ -60,7 +60,7 @@ const NextCmsArticle: NextPage<{
   } = useConfig();
 
   const { t: commonTranslation } = useCommonTranslation();
-  const { t: appTranslation } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
   const { footerMenu } = useContext(NavigationContext);
 
   const { data: categoriesData, loading: loadingCategories } =
@@ -120,7 +120,7 @@ const NextCmsArticle: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={appTranslation('appSports:appName')}
+          appName={resilientT('appSports:appName')}
         />
       }
     />

--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -9,7 +9,7 @@ import {
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
-  useAppSportsTranslation,
+  useResilientTranslation,
   getLanguageCodeFilter,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
@@ -53,7 +53,7 @@ export default function ArticleArchive({
   page,
 }: SportsGlobalPageProps & { page: PageType }) {
   const router = useRouter();
-  const { t } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
 
   const getArticlesSearchQuery = (
     text: string,
@@ -240,7 +240,7 @@ export default function ArticleArchive({
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appSports:appName')}
+          appName={resilientT('appSports:appName')}
           feedbackWithPadding
         />
       }

--- a/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
@@ -6,7 +6,7 @@ import {
   usePageScrollRestoration,
   EventsCookieConsent,
   RouteMeta,
-  useAppSportsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
@@ -19,7 +19,7 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 export default function CookieConsent() {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
   const router = useRouter();
   /*
   // bug or feature: query is empty in handleRedirect
@@ -47,7 +47,7 @@ export default function CookieConsent() {
           <RouteMeta origin={AppConfig.origin} />
           <ConsentPageContent>
             <EventsCookieConsent
-              appName={t('appSports:appName')}
+              appName={resilientT('appSports:appName')}
               isModal={false}
               onConsentGiven={handleRedirect}
             />
@@ -57,7 +57,7 @@ export default function CookieConsent() {
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appSports:appName')}
+          appName={resilientT('appSports:appName')}
           hasFeedBack={false}
         />
       }

--- a/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -4,7 +4,7 @@ import {
   Navigation,
   FooterSection,
   getLanguageOrDefault,
-  useAppSportsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -25,7 +25,7 @@ const EventPage: NextPage<{
   loading: boolean;
 }> = ({ event, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
   return (
     <RHHCPage
       className="pageLayout"
@@ -38,7 +38,10 @@ const EventPage: NextPage<{
         />
       }
       footer={
-        <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
+        <FooterSection
+          menu={footerMenu}
+          appName={resilientT('appSports:appName')}
+        />
       }
     />
   );

--- a/apps/sports-helsinki/src/pages/index.tsx
+++ b/apps/sports-helsinki/src/pages/index.tsx
@@ -3,7 +3,7 @@ import {
   getQlLanguage,
   NavigationContext,
   Navigation,
-  useAppSportsTranslation,
+  useResilientTranslation,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
@@ -38,7 +38,7 @@ const HomePage: NextPage<{
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
 
-  const { t } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
 
   return (
     <RHHCPage
@@ -60,7 +60,7 @@ const HomePage: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appSports:appName')}
+          appName={resilientT('appSports:appName')}
           hasFeedBack={false}
         />
       }

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -6,7 +6,7 @@ import {
   NavigationContext,
   getAllPages,
   Navigation,
-  useAppSportsTranslation,
+  useResilientTranslation,
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
@@ -48,7 +48,7 @@ const NextCmsPage: NextPage<{
     utils: { getRoutedInternalHref },
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
-  const { t: appTranslation } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
 
   // FIXME: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
@@ -74,7 +74,7 @@ const NextCmsPage: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={appTranslation('appSports:appName')}
+          appName={resilientT('appSports:appName')}
         />
       }
     />

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -6,7 +6,7 @@ import {
   usePageScrollRestoration,
   RouteMeta,
   PageMeta,
-  useAppSportsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React, { useContext } from 'react';
@@ -28,7 +28,7 @@ const Search: NextPage<{
   page: PageType;
 }> = ({ page }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
   usePageScrollRestoration();
   return (
     <RHHCPage
@@ -44,7 +44,7 @@ const Search: NextPage<{
       footer={
         <FooterSection
           menu={footerMenu}
-          appName={t('appSports:appName')}
+          appName={resilientT('appSports:appName')}
           feedbackWithPadding
         />
       }

--- a/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/venues/[venueId]/index.tsx
@@ -5,7 +5,7 @@ import {
   FooterSection,
   getLanguageOrDefault,
   usePageScrollRestoration,
-  useAppSportsTranslation,
+  useResilientTranslation,
 } from '@events-helsinki/components';
 import type {
   Venue,
@@ -25,7 +25,7 @@ const VenuePage: NextPage<{
   loading: boolean;
 }> = ({ venue, loading }) => {
   const { footerMenu } = useContext(NavigationContext);
-  const { t } = useAppSportsTranslation();
+  const { resilientT } = useResilientTranslation();
   usePageScrollRestoration();
   return (
     <RHHCPage
@@ -40,7 +40,10 @@ const VenuePage: NextPage<{
         />
       }
       footer={
-        <FooterSection menu={footerMenu} appName={t('appSports:appName')} />
+        <FooterSection
+          menu={footerMenu}
+          appName={resilientT('appSports:appName')}
+        />
       }
     />
   );

--- a/packages/common-i18n/src/locales/en/appEvents.json
+++ b/packages/common-i18n/src/locales/en/appEvents.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Events",
   "footer": {
     "titleEventsCategories": "Popular events categories"
   },

--- a/packages/common-i18n/src/locales/en/appHobbies.json
+++ b/packages/common-i18n/src/locales/en/appHobbies.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Hobbies",
   "home": {
     "search": {
       "title": "Find hobbies"

--- a/packages/common-i18n/src/locales/en/appSports.json
+++ b/packages/common-i18n/src/locales/en/appSports.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Sports and recreation",
   "footer": {
     "titleSportsCategories": "Popular sports categories"
   },

--- a/packages/common-i18n/src/locales/en/errors.json
+++ b/packages/common-i18n/src/locales/en/errors.json
@@ -3,15 +3,8 @@
     "title": "Whoops, the page you were looking for cannot be found",
     "description": "The link can be outdated or the page has been deleted."
   },
-  "unknownError": {
-    "title": "An error was detected!",
-    "description": "Try again later. If the situation recurs, tell us about it via our <2>feedback form</2>",
-    "feedbackFormLink": "https://www.hel.fi/helsinki/en/administration/participate/feedback/"
-  },
   "apolloError": {
     "title": "A connection problem was detected on the site!",
-    "description": "Some of the site's functions are unavailable. Try again later. If the problem persists, please let us know using the <2>feedback form</2>",
-    "feedbackFormLink": "https://www.hel.fi/helsinki/en/administration/participate/feedback/"
-  },
-  "moveToHomePageButton": " Go to the front page"
+    "description": "Some of the site's functions are unavailable. Try again later. If the problem persists, please let us know using the <2>feedback form</2>"
+  }
 }

--- a/packages/common-i18n/src/locales/en/footer.json
+++ b/packages/common-i18n/src/locales/en/footer.json
@@ -1,10 +1,1 @@
-{
-  "linkAbout": "About the service",
-  "linkAccessibility": "Accessibility Statement",
-  "linkFeedback": "Give feedback",
-  "linkFeedbackUrl": "https://www.hel.fi/helsinki/en/administration/participate/feedback/",
-  "searchCollections": "We recommend",
-  "backToTop": "Back to top",
-  "copyright": "Copyright",
-  "allRightsReserved": "All rights reserved"
-}
+{}

--- a/packages/common-i18n/src/locales/fi/appEvents.json
+++ b/packages/common-i18n/src/locales/fi/appEvents.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Tapahtumat",
   "footer": {
     "titleEventsCategories": "Suositut tapahtumien kategoriat"
   },

--- a/packages/common-i18n/src/locales/fi/appHobbies.json
+++ b/packages/common-i18n/src/locales/fi/appHobbies.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Harrastukset",
   "home": {
     "search": {
       "title": "Löydä harrastuksia"

--- a/packages/common-i18n/src/locales/fi/appSports.json
+++ b/packages/common-i18n/src/locales/fi/appSports.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Helsinki Liikkuu",
   "footer": {
     "titleSportsCategories": "Suositut liikuntakategoriat"
   },

--- a/packages/common-i18n/src/locales/fi/errors.json
+++ b/packages/common-i18n/src/locales/fi/errors.json
@@ -3,15 +3,8 @@
     "title": "Hups, hakemaasi sivua ei löydy!",
     "description": "Linkki voi olla vanhentunut, tai sivu on ehditty poistaa."
   },
-  "unknownError": {
-    "title": "Sivustolla havaittiin virhe!",
-    "description": "Koita myöhemmin uudestaan. Jos tilanne toistuu, kerro siitä meille <2>palautelomakkeella</2>",
-    "feedbackFormLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta"
-  },
   "apolloError": {
     "title": "Sivustolla havaittiin yhteysongelma!",
-    "description": "Osa sivuston toiminnoista ei ole käytettävissä. Koita myöhemmin uudestaan. Jos ongelma toistuu, kerro siitä meille <2>palautelomakkeella</2>",
-    "feedbackFormLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta"
-  },
-  "moveToHomePageButton": "Siirry etusivulle"
+    "description": "Osa sivuston toiminnoista ei ole käytettävissä. Koita myöhemmin uudestaan. Jos ongelma toistuu, kerro siitä meille <2>palautelomakkeella</2>"
+  }
 }

--- a/packages/common-i18n/src/locales/fi/footer.json
+++ b/packages/common-i18n/src/locales/fi/footer.json
@@ -1,10 +1,1 @@
-{
-  "linkAbout": "Tietoa palvelusta",
-  "linkAccessibility": "Saavutettavuus­seloste",
-  "linkFeedback": "Anna palautetta",
-  "linkFeedbackUrl": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta",
-  "searchCollections": "Suosittelemme",
-  "backToTop": "Takaisin alkuun",
-  "copyright": "Copyright",
-  "allRightsReserved": "Kaikki oikeudet pidätetään"
-}
+{}

--- a/packages/common-i18n/src/locales/sv/appEvents.json
+++ b/packages/common-i18n/src/locales/sv/appEvents.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Evenemang",
   "footer": {
     "titleEventsCategories": "Populära evenemangskategorier"
   },

--- a/packages/common-i18n/src/locales/sv/appHobbies.json
+++ b/packages/common-i18n/src/locales/sv/appHobbies.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Hobbyer",
   "home": {
     "search": {
       "title": "Hitta hobbyer"

--- a/packages/common-i18n/src/locales/sv/appSports.json
+++ b/packages/common-i18n/src/locales/sv/appSports.json
@@ -1,5 +1,4 @@
 {
-  "appName": "Idrott och motion",
   "footer": {
     "titleSportsCategories": "Populära kategorier"
   },

--- a/packages/common-i18n/src/locales/sv/errors.json
+++ b/packages/common-i18n/src/locales/sv/errors.json
@@ -3,15 +3,8 @@
     "title": "Hoppsan! Sidan du söker finns inte!",
     "description": "Länken kan vara föråldrad eller sidan har tagits bort."
   },
-  "unknownError": {
-    "title": "Ett fel upptäcktes på webbplatsen!",
-    "description": "Försök igen om en stund. Om situationen återkommer, berätta om det för oss med <2>responsblanketten</2>",
-    "feedbackFormLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback/"
-  },
   "apolloError": {
     "title": "Anslutningsproblem upptäcktes på webbplatsen!",
-    "description": "Vissa funktioner på webbplatsen fungerar inte korrekt Försök igen om en stund. Om situationen återkommer, berätta om det för oss med <2>responsblanketten</2>",
-    "feedbackFormLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback/"
-  },
-  "moveToHomePageButton": "Gå till startsidan."
+    "description": "Vissa funktioner på webbplatsen fungerar inte korrekt Försök igen om en stund. Om situationen återkommer, berätta om det för oss med <2>responsblanketten</2>"
+  }
 }

--- a/packages/common-i18n/src/locales/sv/footer.json
+++ b/packages/common-i18n/src/locales/sv/footer.json
@@ -1,10 +1,1 @@
-{
-  "linkAbout": "Om tjänsten",
-  "linkAccessibility": "Tillgänglighets­utlåtande",
-  "linkFeedback": "Ge respons",
-  "linkFeedbackUrl": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback/",
-  "searchCollections": "Vi rekommenderar",
-  "backToTop": "Tillbaka upp",
-  "copyright": "Copyright",
-  "allRightsReserved": "Alla rättigheter förbehållna"
-}
+{}

--- a/packages/components/src/components/apolloErrorNotification/ApolloErrorNotification.tsx
+++ b/packages/components/src/components/apolloErrorNotification/ApolloErrorNotification.tsx
@@ -1,6 +1,7 @@
 import type { NotificationProps } from 'hds-react';
 import { Notification } from 'hds-react';
 import { Trans } from 'next-i18next';
+import { useResilientTranslation } from '../../hooks';
 import useCommonTranslation from '../../hooks/useCommonTranslation';
 import useErrorsTranslation from '../../hooks/useErrorsTranslation';
 
@@ -14,6 +15,9 @@ export default function ApolloErrorNotification({
 }: ApolloErrorNotificationProps) {
   const { t } = useErrorsTranslation();
   const { t: commonTranslation } = useCommonTranslation();
+  const { resilientT } = useResilientTranslation();
+  const feedbackUrl = resilientT('errors:feedbackFormLink');
+
   return (
     <Notification
       {...hdsProps}
@@ -28,11 +32,7 @@ export default function ApolloErrorNotification({
       <Trans t={t} i18nKey="errors:apolloError.description">
         Osa sivuston toiminnoista ei ole käytettävissä. Koita myöhemmin
         uudestaan. Jos ongelma toistuu, kerro siitä meille{' '}
-        <a
-          href={t(`errors:apolloError.feedbackFormLink`)}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href={feedbackUrl} target="_blank" rel="noopener noreferrer">
           palautelomakkeella
         </a>
       </Trans>

--- a/packages/components/src/components/errorPages/ErrorPage.tsx
+++ b/packages/components/src/components/errorPages/ErrorPage.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import React, { useContext } from 'react';
 import { Page as RHHCPage } from 'react-helsinki-headless-cms';
 import { HARDCODED_LANGUAGES, MAIN_CONTENT_ID } from '../../constants';
-import useErrorsTranslation from '../../hooks/useErrorsTranslation';
+import { useResilientTranslation } from '../../hooks';
 import useLocale from '../../hooks/useLocale';
 import NavigationContext from '../../navigationProvider/NavigationContext';
 import FooterSection from '../footer/Footer';
@@ -21,7 +21,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
   descriptionText,
   appName,
 }) => {
-  const { t } = useErrorsTranslation();
+  const { resilientT } = useResilientTranslation();
   const router = useRouter();
   const locale = useLocale();
   const { footerMenu } = useContext(NavigationContext);
@@ -42,7 +42,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
               <h1>{headerText}</h1>
               <p>{descriptionText}</p>
               <Button onClick={moveToHomePage} className={styles.backButton}>
-                {t(`errors:moveToHomePageButton`)}
+                {resilientT('errors:moveToHomePageButton')}
               </Button>
             </div>
           </main>

--- a/packages/components/src/components/errorPages/UnknownError.tsx
+++ b/packages/components/src/components/errorPages/UnknownError.tsx
@@ -1,6 +1,5 @@
-import { Trans } from 'next-i18next';
 import React from 'react';
-import useErrorsTranslation from '../../hooks/useErrorsTranslation';
+import { useResilientTranslation } from '../../hooks';
 import ErrorPage from './ErrorPage';
 import type { ErrorPageProps } from './ErrorPage';
 
@@ -8,21 +7,21 @@ type Props = {
   appName: ErrorPageProps['appName'];
 };
 const UnknownError: React.FC<Props> = ({ appName }) => {
-  const { t } = useErrorsTranslation();
+  const { resilientT } = useResilientTranslation();
   return (
     <ErrorPage
-      headerText={t(`errors:unknownError.title`)}
+      headerText={resilientT('errors:unknownError.title')}
       descriptionText={
-        <Trans t={t} i18nKey="errors:unknownError.description">
-          Koita myöhemmin uudestaan. Jos tilanne toistuu, kerro siitä meille{' '}
+        <p>
+          {resilientT('errors:unknownError.descriptionPrefix')}{' '}
           <a
-            href={t(`errors:unknownError.feedbackFormLink`)}
+            href={resilientT('errors:feedbackFormLink')}
             target="_blank"
             rel="noopener noreferrer"
           >
-            palautelomakkeella
+            {resilientT('errors:unknownError.descriptionSuffixLinkText')}
           </a>
-        </Trans>
+        </p>
       }
       appName={appName}
     />

--- a/packages/components/src/components/errorPages/errorPage.module.scss
+++ b/packages/components/src/components/errorPages/errorPage.module.scss
@@ -22,8 +22,8 @@
 
   h1 {
     max-width: 700px;
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
 
   p {

--- a/packages/components/src/components/footer/Footer.tsx
+++ b/packages/components/src/components/footer/Footer.tsx
@@ -4,8 +4,7 @@ import type { FunctionComponent } from 'react';
 import type { Menu } from 'react-helsinki-headless-cms';
 import { useMenuQuery } from 'react-helsinki-headless-cms/apollo';
 import { DEFAULT_FOOTER_MENU_NAME } from '../../constants';
-import { useCommonTranslation } from '../../hooks';
-import useFooterTranslation from '../../hooks/useFooterTranslation';
+import { useCommonTranslation, useResilientTranslation } from '../../hooks';
 import useLocale from '../../hooks/useLocale';
 
 import { resetFocusId } from '../resetFocus/ResetFocus';
@@ -33,8 +32,8 @@ const FooterSection: FunctionComponent<FooterSectionProps> = ({
   feedbackWithPadding = false,
   consentUrl = '/cookie-consent',
 }: FooterSectionProps) => {
-  const { t } = useFooterTranslation();
   const { t: commonT } = useCommonTranslation();
+  const { resilientT } = useResilientTranslation();
   const locale = useLocale();
 
   const { data: footerMenuData } = useMenuQuery({
@@ -62,8 +61,8 @@ const FooterSection: FunctionComponent<FooterSectionProps> = ({
       )}
       <Footer title={appName} className={styles.footer}>
         <Footer.Base
-          copyrightHolder={t('footer:copyright')}
-          copyrightText={t('footer:allRightsReserved')}
+          copyrightHolder={resilientT('footer:copyright')}
+          copyrightText={resilientT('footer:allRightsReserved')}
           logo={
             <Logo
               src={locale === 'sv' ? logoSv : logoFi}
@@ -71,7 +70,7 @@ const FooterSection: FunctionComponent<FooterSectionProps> = ({
               alt={commonT('common:cityOfHelsinki')}
             />
           }
-          backToTopLabel={t('footer:backToTop')}
+          backToTopLabel={resilientT('footer:backToTop')}
           onBackToTopClick={handleBackToTop}
         >
           {footerMenu?.menuItems?.nodes?.map((navigationItem) => (

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -14,6 +14,7 @@ export { default as useErrorsTranslation } from './useErrorsTranslation';
 export { default as useHomeTranslation } from './useHomeTranslation';
 export { default as useFooterTranslation } from './useFooterTranslation';
 export { default as useNotFoundTranslation } from './useNotFoundTranslation';
+export { default as useResilientTranslation } from './useResilientTranslation';
 export { default as useSearchTranslation } from './useSearchTranslation';
 export { default as useSetSortQueryParamToOptionValue } from './useSetSortQueryParamToOptionValue';
 export { default as useEventTranslation } from './useEventTranslation';

--- a/packages/components/src/hooks/useResilientTranslation.ts
+++ b/packages/components/src/hooks/useResilientTranslation.ts
@@ -1,0 +1,23 @@
+import type { ResilientTranslationKey } from '../utils';
+import { getResilientTranslation } from '../utils';
+import useLocale from './useLocale';
+
+/**
+ * Use resilient translation which works also when an error occurs during an error.
+ *
+ * @returns {object} Object containing translation function for the current language in
+ * property resilientT.
+ * @example Used for making sure application name is translated on UnknownError page
+ * even when next-i18next's translation fails.
+ * @see https://github.com/i18next/next-i18next/issues/1020
+ */
+export default function useResilientTranslation(): {
+  resilientT: (translationKey: ResilientTranslationKey) => string;
+} {
+  const currentLocale = useLocale();
+
+  const resilientTranslation = (translationKey: ResilientTranslationKey) =>
+    getResilientTranslation(translationKey, currentLocale);
+
+  return { resilientT: resilientTranslation };
+}

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -4,6 +4,7 @@ export { default as buildQueryFromObject } from './buildQueryFromObject';
 export * from './dateUtils';
 export * from './arrayUtils';
 export * from './eventUtils';
+export * from './resilientTranslation';
 export { default as getDateArray } from './getDateArray';
 export { default as getDateRangeStr } from './getDateRangeStr';
 export { default as getDomain } from './getDomain';

--- a/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
+++ b/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
@@ -25,6 +25,46 @@ const RESILIENT_TRANSLATIONS = {
     fi: 'Helsinki Liikkuu',
     sv: 'Idrott och motion',
   },
+  'errors:feedbackFormLink': {
+    en: 'https://palautteet.hel.fi/en/',
+    fi: 'https://palautteet.hel.fi/fi/',
+    sv: 'https://palautteet.hel.fi/sv/',
+  },
+  'errors:moveToHomePageButton': {
+    en: 'Go to the front page',
+    fi: 'Siirry etusivulle',
+    sv: 'Gå till startsidan',
+  },
+  'errors:unknownError.descriptionPrefix': {
+    en: 'Try again later. If the situation recurs, tell us about it via our',
+    fi: 'Koita myöhemmin uudestaan. Jos tilanne toistuu, kerro siitä meille',
+    sv: 'Försök igen om en stund. Om situationen återkommer, berätta om det för oss med',
+  },
+  'errors:unknownError.descriptionSuffixLinkText': {
+    en: 'feedback form',
+    fi: 'responsblanketten',
+    sv: 'palautelomakkeella',
+  },
+  'errors:unknownError.title': {
+    en: 'An error was detected!',
+    fi: 'Sivustolla havaittiin virhe!',
+    sv: 'Ett fel upptäcktes på webbplatsen!',
+  },
+  'footer:allRightsReserved': {
+    en: 'All rights reserved',
+    fi: 'Kaikki oikeudet pidätetään',
+    sv: 'Alla rättigheter förbehållna',
+  },
+  'footer:backToTop': {
+    en: 'Back to top',
+    fi: 'Takaisin alkuun',
+    sv: 'Tillbaka upp',
+  },
+  'footer:copyright': {
+    en: 'Copyright',
+    fi: 'Copyright',
+    sv: 'Copyright',
+  },
 } as const satisfies ResilientTranslations;
 
 /**

--- a/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
+++ b/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
@@ -1,0 +1,40 @@
+import type { AppLanguage } from '../../types';
+import type { ResilientTranslationKey, ResilientTranslations } from './types';
+
+/**
+ * Resilient translations that should be used only for cases where next-i18next's
+ * translation may fail.
+ *
+ * @warning DO NOT USE FOR NORMAL TRANSLATIONS, USE ONLY IF YOU NEED TO BE EXTRA SURE
+ * THAT TRANSLATIONS WORK EVEN ON ERROR PAGES
+ * @see https://github.com/i18next/next-i18next/issues/1020
+ */
+const RESILIENT_TRANSLATIONS = {
+  'appEvents:appName': {
+    en: 'Events',
+    fi: 'Tapahtumat',
+    sv: 'Evenemang',
+  },
+  'appHobbies:appName': {
+    en: 'Hobbies',
+    fi: 'Harrastukset',
+    sv: 'Hobbyer',
+  },
+  'appSports:appName': {
+    en: 'Sports and recreation',
+    fi: 'Helsinki Liikkuu',
+    sv: 'Idrott och motion',
+  },
+} as const satisfies ResilientTranslations;
+
+/**
+ * Translate resiliently i.e. so that it works even if next-i18next's translation fails,
+ * which it does e.g. when an error occurs during an error.
+ * @see https://github.com/i18next/next-i18next/issues/1020
+ */
+const getResilientTranslation = (
+  translationKey: ResilientTranslationKey,
+  language: AppLanguage
+) => RESILIENT_TRANSLATIONS[translationKey][language];
+
+export default getResilientTranslation;

--- a/packages/components/src/utils/resilientTranslation/index.ts
+++ b/packages/components/src/utils/resilientTranslation/index.ts
@@ -1,0 +1,2 @@
+export { default as getResilientTranslation } from './getResilientTranslation';
+export * from './types';

--- a/packages/components/src/utils/resilientTranslation/types.ts
+++ b/packages/components/src/utils/resilientTranslation/types.ts
@@ -1,0 +1,13 @@
+import type { AppLanguage } from '../../types';
+
+export type ResilientTranslationKey =
+  | 'appEvents:appName'
+  | 'appHobbies:appName'
+  | 'appSports:appName';
+
+export type ResilientTranslation = Record<AppLanguage, string>;
+
+export type ResilientTranslations = Record<
+  ResilientTranslationKey,
+  ResilientTranslation
+>;

--- a/packages/components/src/utils/resilientTranslation/types.ts
+++ b/packages/components/src/utils/resilientTranslation/types.ts
@@ -3,7 +3,15 @@ import type { AppLanguage } from '../../types';
 export type ResilientTranslationKey =
   | 'appEvents:appName'
   | 'appHobbies:appName'
-  | 'appSports:appName';
+  | 'appSports:appName'
+  | 'errors:feedbackFormLink'
+  | 'errors:moveToHomePageButton'
+  | 'errors:unknownError.descriptionPrefix'
+  | 'errors:unknownError.descriptionSuffixLinkText'
+  | 'errors:unknownError.title'
+  | 'footer:allRightsReserved'
+  | 'footer:backToTop'
+  | 'footer:copyright';
 
 export type ResilientTranslation = Record<AppLanguage, string>;
 


### PR DESCRIPTION
## Description

### feat: add resilient translation, use it for appName, works on error page

next-i18next's translation fails on UnknownError page, e.g. when an
error occurs during an error, see
https://github.com/i18next/next-i18next/issues/1020

to fix translations on unknown error page, we need to use a different
means of translation, which is what this commit does for appName only.

TODO:
 - Translate rest of the translatable strings used on UnknownError page

refs LIIKUNTA-606

### fix: fix UnknownError page's translations including header & footer

using resilient translation the header, footer and UnknownError page
contents are translated even when next-i18next's translation would fail:
https://github.com/i18next/next-i18next/issues/1020

also:
 - fix horizontal centering of the UnknownError page's title
 - remove unused translations from footer.json leaving it empty

refs LIIKUNTA-606

## Issues

### Closes

[LIIKUNTA-606](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-606)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

### Finnish
![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/4069a1fe-a1cc-42a3-8a5c-d140ff347056)

### Swedish
![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/356a40a9-a67a-432d-9d3b-af02dfa08317)

### English
![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/f43f8cd1-387d-4e8e-9109-c977ac1a0b27)

## Additional notes


[LIIKUNTA-606]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ