### PR TITLE
Improve the Azure DevOps pipeline triggers

### DIFF
--- a/azure-pipelines-events-graphql-proxy-release.yml
+++ b/azure-pipelines-events-graphql-proxy-release.yml
@@ -8,9 +8,6 @@ trigger:
   tags:
     include:
       - events-graphql-proxy-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-events-graphql-proxy-review.yml
+++ b/azure-pipelines-events-graphql-proxy-review.yml
@@ -24,7 +24,8 @@ pr:
   paths:
     include:
       - 'proxies/events-graphql-proxy/**'
-      - 'packages/**'
+      - 'packages/graphql-proxy-server/**'
+      - 'packages/eslint-config-bases/**'
       - 'package.json'
       - 'yarn.lock'
       - '.yarnrc.yml'
@@ -34,9 +35,11 @@ pr:
       - 'azure-pipelines-events-graphql-proxy-review.yml'
       - 'Dockerfile'
       - '*.Dockerfile'
-      - 'docker-compose.yml'
-      - 'docker-compose.*.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-events-graphql-proxy-test.yml
+++ b/azure-pipelines-events-graphql-proxy-test.yml
@@ -10,8 +10,16 @@ trigger:
     include:
       - main
   paths:
-    exclude:
-      - README.md
+    include:
+      - 'proxies/events-graphql-proxy/**'
+      - 'packages/graphql-proxy-server/**'
+      - 'packages/eslint-config-bases/**'
+      - 'azure-pipelines-events-graphql-proxy-test.yml'
+      - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-harrastukset-federation-router-release.yml
+++ b/azure-pipelines-harrastukset-federation-router-release.yml
@@ -9,9 +9,6 @@ trigger:
   tags:
     include:
       - federation-router-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-harrastukset-federation-router-review.yml
+++ b/azure-pipelines-harrastukset-federation-router-review.yml
@@ -25,6 +25,10 @@ pr:
       - 'proxies/events-graphql-federation/**'
       - 'azure-pipelines-harrastukset-federation-router-review.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-harrastukset-federation-router-test.yml
+++ b/azure-pipelines-harrastukset-federation-router-test.yml
@@ -14,6 +14,10 @@ trigger:
       - 'proxies/events-graphql-federation/**'
       - 'azure-pipelines-harrastukset-federation-router-test.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-harrastukset-release.yml
+++ b/azure-pipelines-harrastukset-release.yml
@@ -8,9 +8,6 @@ trigger:
   tags:
     include:
       - hobbies-helsinki-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-harrastukset-review.yml
+++ b/azure-pipelines-harrastukset-review.yml
@@ -25,6 +25,7 @@ pr:
     include:
       - 'apps/hobbies-helsinki/**'
       - 'packages/**'
+      - '!packages/graphql-proxy-server/**'
       - 'package.json'
       - 'yarn.lock'
       - '.yarnrc.yml'
@@ -34,9 +35,11 @@ pr:
       - 'azure-pipelines-harrastukset-review.yml'
       - 'Dockerfile'
       - '*.Dockerfile'
-      - 'docker-compose.yml'
-      - 'docker-compose.*.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-harrastukset-test.yml
+++ b/azure-pipelines-harrastukset-test.yml
@@ -10,8 +10,14 @@ trigger:
     include:
       - main
   paths:
+    # Note that we want to run the checks for the apps when we merge new changes
+    # related to the proxies and federation router.
     exclude:
-      - README.md
+      - '**/README.md'
+      - '**/CHANGELOG.md'
+      - '**/LICENSE'
+      - '**/.env*'
+      - '**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-liikunta-federation-router-release.yml
+++ b/azure-pipelines-liikunta-federation-router-release.yml
@@ -9,9 +9,6 @@ trigger:
   tags:
     include:
       - federation-router-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-liikunta-federation-router-review.yml
+++ b/azure-pipelines-liikunta-federation-router-review.yml
@@ -25,6 +25,10 @@ pr:
       - 'proxies/events-graphql-federation/**'
       - 'azure-pipelines-liikunta-federation-router-review.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-liikunta-federation-router-test.yml
+++ b/azure-pipelines-liikunta-federation-router-test.yml
@@ -14,6 +14,10 @@ trigger:
       - 'proxies/events-graphql-federation/**'
       - 'azure-pipelines-liikunta-federation-router-test.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-liikunta-release.yml
+++ b/azure-pipelines-liikunta-release.yml
@@ -8,9 +8,6 @@ trigger:
   tags:
     include:
       - sports-helsinki-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-liikunta-review.yml
+++ b/azure-pipelines-liikunta-review.yml
@@ -25,6 +25,7 @@ pr:
     include:
       - 'apps/sports-helsinki/**'
       - 'packages/**'
+      - '!packages/graphql-proxy-server/**'
       - 'package.json'
       - 'yarn.lock'
       - '.yarnrc.yml'
@@ -34,9 +35,11 @@ pr:
       - 'azure-pipelines-liikunta-review.yml'
       - 'Dockerfile'
       - '*.Dockerfile'
-      - 'docker-compose.yml'
-      - 'docker-compose.*.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-liikunta-test.yml
+++ b/azure-pipelines-liikunta-test.yml
@@ -10,8 +10,14 @@ trigger:
     include:
       - main
   paths:
+    # Note that we want to run the checks for the apps when we merge new changes
+    # related to the proxies and federation router.
     exclude:
-      - README.md
+      - '**/README.md'
+      - '**/CHANGELOG.md'
+      - '**/LICENSE'
+      - '**/.env*'
+      - '**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-tapahtumat-federation-router-release.yml
+++ b/azure-pipelines-tapahtumat-federation-router-release.yml
@@ -9,9 +9,6 @@ trigger:
   tags:
     include:
       - federation-router-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-tapahtumat-federation-router-review.yml
+++ b/azure-pipelines-tapahtumat-federation-router-review.yml
@@ -25,6 +25,10 @@ pr:
       - 'proxies/events-graphql-federation/**'
       - 'azure-pipelines-tapahtumat-federation-router-review.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-tapahtumat-federation-router-test.yml
+++ b/azure-pipelines-tapahtumat-federation-router-test.yml
@@ -14,6 +14,10 @@ trigger:
       - 'proxies/events-graphql-federation/**'
       - 'azure-pipelines-tapahtumat-federation-router-test.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-tapahtumat-release.yml
+++ b/azure-pipelines-tapahtumat-release.yml
@@ -8,9 +8,6 @@ trigger:
   tags:
     include:
       - events-helsinki-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-tapahtumat-review.yml
+++ b/azure-pipelines-tapahtumat-review.yml
@@ -25,6 +25,7 @@ pr:
     include:
       - 'apps/events-helsinki/**'
       - 'packages/**'
+      - '!packages/graphql-proxy-server/**'
       - 'package.json'
       - 'yarn.lock'
       - '.yarnrc.yml'
@@ -34,9 +35,11 @@ pr:
       - 'azure-pipelines-tapahtumat-review.yml'
       - 'Dockerfile'
       - '*.Dockerfile'
-      - 'docker-compose.yml'
-      - 'docker-compose.*.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-tapahtumat-test.yml
+++ b/azure-pipelines-tapahtumat-test.yml
@@ -10,8 +10,14 @@ trigger:
     include:
       - main
   paths:
+    # Note that we want to run the checks for the apps when we merge new changes
+    # related to the proxies and federation router.
     exclude:
-      - README.md
+      - '**/README.md'
+      - '**/CHANGELOG.md'
+      - '**/LICENSE'
+      - '**/.env*'
+      - '**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-venue-graphql-proxy-release.yml
+++ b/azure-pipelines-venue-graphql-proxy-release.yml
@@ -8,9 +8,6 @@ trigger:
   tags:
     include:
       - venue-graphql-proxy-*
-  paths:
-    exclude:
-      - README.md
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to

--- a/azure-pipelines-venue-graphql-proxy-review.yml
+++ b/azure-pipelines-venue-graphql-proxy-review.yml
@@ -24,7 +24,8 @@ pr:
   paths:
     include:
       - 'proxies/venue-graphql-proxy/**'
-      - 'packages/**'
+      - 'packages/graphql-proxy-server/**'
+      - 'packages/eslint-config-bases/**'
       - 'package.json'
       - 'yarn.lock'
       - '.yarnrc.yml'
@@ -34,9 +35,11 @@ pr:
       - 'azure-pipelines-venue-graphql-proxy-review.yml'
       - 'Dockerfile'
       - '*.Dockerfile'
-      - 'docker-compose.yml'
-      - 'docker-compose.*.yml'
       - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-venue-graphql-proxy-test.yml
+++ b/azure-pipelines-venue-graphql-proxy-test.yml
@@ -10,8 +10,16 @@ trigger:
     include:
       - main
   paths:
-    exclude:
-      - README.md
+    include:
+      - 'proxies/venue-graphql-proxy/**'
+      - 'packages/graphql-proxy-server/**'
+      - 'packages/eslint-config-bases/**'
+      - 'azure-pipelines-venue-graphql-proxy-test.yml'
+      - '!**/README.md'
+      - '!**/CHANGELOG.md'
+      - '!**/LICENSE'
+      - '!**/.env*'
+      - '!**/docker-compose*'
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is
 # opened with one of the specified target branches, or when updates are made to


### PR DESCRIPTION
TH-1303.

1. Configure the review and the test environment triggers so that the pipeline is not triggered (or at least not so often) on unrelated changes.
2. Remove the needless paths exclude configuration from the release configurations.
