### PR TITLE
LIIKUNTA-606 | fix: unknown error page's link text translations (fi & sv were swapped)

### DIFF
--- a/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
+++ b/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
@@ -42,8 +42,8 @@ const RESILIENT_TRANSLATIONS = {
   },
   'errors:unknownError.descriptionSuffixLinkText': {
     en: 'feedback form',
-    fi: 'responsblanketten',
-    sv: 'palautelomakkeella',
+    fi: 'palautelomakkeella',
+    sv: 'responsblanketten',
   },
   'errors:unknownError.title': {
     en: 'An error was detected!',


### PR DESCRIPTION
## Description

### fix: unknown error page's link text translations (fi & sv were swapped)

refs LIIKUNTA-606

## Issues

### Closes

### Related

[LIIKUNTA-606](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-606)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-606]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ