### PR TITLE
Fix some broken styles

### DIFF
--- a/apps/events-helsinki/src/styles/globals.scss
+++ b/apps/events-helsinki/src/styles/globals.scss
@@ -70,3 +70,11 @@ button {
     font-size: var(--fontsize-heading-xl-mobile) !important;
   }
 }
+
+/* LIIKUNTA-612 fix: the order of the CSS files can vary */
+button[class^='FooterBase-module_backToTopButton'] {
+  font-size: 20px !important;
+  font-weight: 700 !important;
+  line-height: 30px !important;
+  margin-left: auto !important;
+}

--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -68,3 +68,11 @@ button {
     font-size: var(--fontsize-heading-xl-mobile) !important;
   }
 }
+
+/* LIIKUNTA-612 fix: the order of the CSS files can vary */
+button[class^='FooterBase-module_backToTopButton'] {
+  font-size: 20px !important;
+  font-weight: 700 !important;
+  line-height: 30px !important;
+  margin-left: auto !important;
+}

--- a/apps/sports-helsinki/src/domain/search/searchHeader/searchHeader.module.scss
+++ b/apps/sports-helsinki/src/domain/search/searchHeader/searchHeader.module.scss
@@ -76,7 +76,7 @@
     button {
       width: 50%;
       border: none;
-      margin-left: auto;
+      margin-left: auto !important;
       background-color: white;
 
       &:focus {
@@ -98,7 +98,7 @@
 
     @include breakpoints.respond-above(m) {
       button:last-child {
-        margin-left: 0;
+        margin-left: 0 !important;
       }
     }
   }

--- a/apps/sports-helsinki/src/styles/globals.scss
+++ b/apps/sports-helsinki/src/styles/globals.scss
@@ -69,3 +69,11 @@ button {
     font-size: var(--fontsize-heading-xl-mobile) !important;
   }
 }
+
+/* LIIKUNTA-612 fix: the order of the CSS files can vary */
+button[class^='FooterBase-module_backToTopButton'] {
+  font-size: 20px !important;
+  font-weight: 700 !important;
+  line-height: 30px !important;
+  margin-left: auto !important;
+}


### PR DESCRIPTION
LIIKUNTA-612 (HH-311 HH-335).

There is a bug in NextJS related to the CSS ordering and it could be the issue here too:
1. https://github.com/vercel/next.js/issues/16630
2. https://github.com/vercel/next.js/issues/51030

Some of our styles are now misordered after the changes done in https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/615.

*This PR aims to fix the most obvious ones.*

NOTE: We could also just revert the changes https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/630.

### Fixes affects to these

#### The footer buttons are not aligned to right

Before:
![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/9ba8eb3a-db19-4e0d-a7e0-8a6d299d144d)

After:
<img width="1134" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/ccbb9d02-9e3a-43e9-b9cc-d03b302652c8">


#### The map search buttons on header are not aligned to right

Before:
![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/c98e6d2a-fa16-494f-9ad6-c3a0317b803b)

After:
<img width="1129" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/e8655d58-c789-41e6-8e6e-9f40578791d1">



