### PR TITLE
fix: internal links handling when the link changes the locale

### DIFF
--- a/apps/sports-helsinki/src/middleware.ts
+++ b/apps/sports-helsinki/src/middleware.ts
@@ -35,6 +35,23 @@ function isPathnameMissingLocale(pathname: string) {
       pathname !== '/'
   );
 }
+
+type DefaultMatchesType = {
+  firstLocale?: string;
+  secondLocale?: string;
+};
+
+function getLocaleMatchesFromPathname(pathname: string): DefaultMatchesType {
+  const doubleLocalePrefix =
+    /^\/(?<firstLocale>fi|en|sv)\/(?<secondLocale>fi|en|sv)\//;
+  return (
+    pathname.match(doubleLocalePrefix)?.groups || {
+      firstLocale: undefined,
+      secondLocale: undefined,
+    }
+  );
+}
+
 /**
  * Enforce prefix for default locale 'fi'
  * https://github.com/vercel/next.js/discussions/18419
@@ -76,6 +93,21 @@ const prefixDefaultLocale = async (req: NextRequest) => {
     return NextResponse.redirect(
       new URL(`/${DEFAULT_LANGUAGE}${pathname}${search}`, req.url)
     );
+  }
+
+  const { firstLocale, secondLocale } = getLocaleMatchesFromPathname(pathname);
+
+  // Remove the double locale prefix which might occur
+  // when CMS content has an internal link to another locale context.
+  // NOTE: The locale will be automatically added as a prefix to
+  // the next URL by the NextJS (under the hood).
+  // The request's locale attribute should be used for that.
+  if (firstLocale && secondLocale && firstLocale !== secondLocale) {
+    const nextPathname = pathname
+      .replace(new RegExp(`^/${firstLocale}`), '')
+      .replace(new RegExp(`^/${secondLocale}`), '');
+    const nextUrl = new URL(`${nextPathname}${search}`, req.url);
+    return NextResponse.redirect(nextUrl.href);
   }
 };
 


### PR DESCRIPTION
LIIKUNTA-613.

There was an issue in the internal links handling,
when the link was had a new locale (in the start of the pathname).

1. The internal links for another language should not change the UI
language, since the user does not know how to navigate on new locale.

2. The middeware that is handling the locales should never allow
multiple locales in the beginning of the URL.

The changeset now tries to handle the locale change so that
it trusts in the NextJS locale handling and removes all the locales
from the URL, if the locale is changed with a link URL
(not by Link-component's locale-attribute).

As an example, before the changes were applied,
if the user was in `/fi/pages/saavutettavuusseloste`
and there was a link `/en/pages/accessibility-statement` in the CMS page content,
the user was redirected to `/fi/en/pages/accessibility-statement`,
which does not exist, because there was a double locale set in the URL.
The "fi" locale was added by the NextJS, because it was the locale of the request.
Now after the changes are applied, the user is taken to 
`/fi/pages/accessibility-statement`, so the content of the page is in English,
but the UI language is still Finnish.