### PR TITLE
chore: upgrade hds-design-tokens to v3.5.0

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "fast-deep-equal": "3.1.3",
     "file-saver": "^2.0.5",
     "graphql": "16.7.1",
-    "hds-design-tokens": "^3.3.0",
+    "hds-design-tokens": "^3.5.0",
     "hds-react": "^3.5.0",
     "https": "1.0.0",
     "i18next": "23.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,7 +3295,7 @@ __metadata:
     file-saver: "npm:^2.0.5"
     graphql: "npm:16.7.1"
     happy-dom: "npm:9.20.3"
-    hds-design-tokens: "npm:^3.3.0"
+    hds-design-tokens: "npm:^3.5.0"
     hds-react: "npm:^3.5.0"
     html-react-parser: "npm:4.0.0"
     https: "npm:1.0.0"
@@ -15678,7 +15678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hds-design-tokens@npm:^3.3.0, hds-design-tokens@npm:^3.5.0":
+"hds-design-tokens@npm:^3.5.0":
   version: 3.5.0
   resolution: "hds-design-tokens@npm:3.5.0"
   checksum: e29b167b82858d198f138f5a4868d0278881486975bacc3c39404fccb8c3e45ae7835559044372b9031f1e2a92b95115fdb15d4f073498f69c1d62a0e516c950


### PR DESCRIPTION
## Description

### chore: upgrade hds-design-tokens to v3.5.0

RHHC v1.0.0-alpha255 already uses hds-design-tokens v3.5.0,
so it's better to use the same version here also if there is no
particular reason for using v3.3.0.

refs LIIKUNTA-614 (upgraded hds-react to v3.5.0)

## Issues

### Closes

[LIIKUNTA-614](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-614)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-614]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ