### PR TITLE
LIIKUNTA-619, HH-348 | fix: sports appName case, add yso:p2739 to hobbies visual arts keywords

### DIFF
--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -181,11 +181,12 @@ export const ARTS_AND_CULTURE_COURSES_KEYWORDS = [
 ];
 
 export const VISUAL_ARTS_COURSES_KEYWORDS = [
-  'kulke:81',
-  'yso:p1148',
-  'yso:p38773',
-  'yso:p8883',
-  'yso:p695',
+  'kulke:81', // Sarjakuva
+  'yso:p1148', // sarjakuvat / comics
+  'yso:p2739', // kuvataide / fine arts
+  'yso:p38773', // sarjakuvataide / comic art
+  'yso:p8883', // maalaustaide / painting (visual arts)
+  'yso:p695', // piirtäminen (taide) / drawing (artistic creation)
 ];
 
 export const HANDICRAFTS_COURSES_KEYWORDS = [

--- a/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
+++ b/packages/components/src/utils/resilientTranslation/getResilientTranslation.ts
@@ -22,7 +22,7 @@ const RESILIENT_TRANSLATIONS = {
   },
   'appSports:appName': {
     en: 'Sports and recreation',
-    fi: 'Helsinki Liikkuu',
+    fi: 'Helsinki liikkuu',
     sv: 'Idrott och motion',
   },
   'errors:feedbackFormLink': {


### PR DESCRIPTION
## Description

### fix: sports appName case, add yso:p2739 to hobbies visual arts keywords

refs LIIKUNTA-619 (sports appName "Helsinki Liikkuu"→"Helsinki liikkuu")
refs HH-348 (yso:p2739 i.e. "fine arts" to hobbies visual arts keywords)

## Issues

### Closes

[LIIKUNTA-619](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-619)
[HH-348](https://helsinkisolutionoffice.atlassian.net/browse/HH-348)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-619]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HH-348]: https://helsinkisolutionoffice.atlassian.net/browse/HH-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ