### PR TITLE
LIIKUNTA-620 | fix: remove useless page margin

### DIFF
--- a/apps/sports-helsinki/src/styles/globals.scss
+++ b/apps/sports-helsinki/src/styles/globals.scss
@@ -5,6 +5,7 @@ html,
 body,
 #__next,
 main {
+  margin: 0;
   height: 100%;
   color: var(--color-black-90);
 }


### PR DESCRIPTION
## Description

### fix: remove useless page margin

refs LIIKUNTA-620

## Issues

### Closes

[LIIKUNTA-620](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-620)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/a45e5ded-39a8-4a38-b494-49f5cf360fba)

## Additional notes


[LIIKUNTA-620]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ