### PR TITLE
LIIKUNTA-620 | fix: remove page margin using !important in all globals.scss files

### DIFF
--- a/apps/events-helsinki/src/styles/globals.scss
+++ b/apps/events-helsinki/src/styles/globals.scss
@@ -6,6 +6,7 @@ html,
 body,
 #__next,
 main {
+  margin: 0 !important;
   height: 100%;
   color: var(--color-primary-black);
 }

--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -5,6 +5,7 @@ html,
 body,
 #__next,
 main {
+  margin: 0 !important;
   height: 100%;
   color: var(--color-black-90);
 }

--- a/apps/sports-helsinki/src/styles/globals.scss
+++ b/apps/sports-helsinki/src/styles/globals.scss
@@ -5,7 +5,7 @@ html,
 body,
 #__next,
 main {
-  margin: 0;
+  margin: 0 !important;
   height: 100%;
   color: var(--color-black-90);
 }

--- a/packages/components/src/styles/globals.scss
+++ b/packages/components/src/styles/globals.scss
@@ -3,6 +3,7 @@
 html,
 #__next,
 main {
+  margin: 0 !important;
   height: 100%;
 }
 


### PR DESCRIPTION
## Description

### fix: remove page margin using !important in all globals.scss files

refs LIIKUNTA-620 ("margin: 0" wasn't enough -> "margin: 0 !important")

## Issues

### Closes

[LIIKUNTA-620](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-620)

### Related

## Testing

### Automated tests

### Manual testing

Tested locally using "yarn dev" & "yarn build && yarn start" using sports-helsinki and both worked.

## Screenshots

## Additional notes


[LIIKUNTA-620]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ