### PR TITLE
Breadcrumbs: implemenation to the apps 

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -71,7 +71,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha255",
+    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -71,7 +71,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
+    "react-helsinki-headless-cms": "1.0.0-alpha259",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/events-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/events-helsinki/src/domain/event/EventPageContainer.tsx
@@ -10,8 +10,10 @@ import {
   EventPageMeta,
   EventContent,
   RouteMeta,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
 import type { EventFields } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
@@ -37,12 +39,14 @@ export interface EventPageContainerProps {
   loading: boolean;
   event?: EventFields;
   showSimilarEvents?: boolean;
+  breadcrumbs?: BreadcrumbListItem[];
 }
 
 const EventPageContainer: React.FC<EventPageContainerProps> = ({
   event,
   loading,
   showSimilarEvents = true,
+  breadcrumbs,
 }) => {
   const { t } = useTranslation('event');
   const router = useRouter();
@@ -67,6 +71,7 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
   const similarEventsFilters = useSimilarEventsQueryVariables(event!);
   return (
     <div className={styles.eventPageWrapper}>
+      {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
       <main id={MAIN_CONTENT_ID}>
         <LoadingSpinner isLoading={loading}>
           {event ? (

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -10,9 +10,19 @@ import {
   RouteMeta,
   getLanguageCodeFilter,
   useResilientTranslation,
+  getFilteredBreadcrumbs,
+  TemplateEnum,
+  getQlLanguage,
+  defaultArticleArchiveBreadcrumbTitle,
+  PageByTemplateBreadcrumbTitleDocument,
 } from '@events-helsinki/components';
-import type { AppLanguage } from '@events-helsinki/components';
+import type {
+  AppLanguage,
+  PageByTemplateBreadcrumbTitleQuery,
+  PageByTemplateBreadcrumbTitleQueryVariables,
+} from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
+import type { BreadcrumbListItem } from 'hds-react';
 import type {
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -20,16 +30,13 @@ import type {
 } from 'next';
 import { useRouter } from 'next/router';
 import { useContext } from 'react';
-import type {
-  Breadcrumb,
-  CollectionType,
-  ArticleType,
-} from 'react-helsinki-headless-cms';
+import type { CollectionType, ArticleType } from 'react-helsinki-headless-cms';
 import {
   getCollections,
   PageContent as RHHCPageContent,
   Page as RHHCPage,
   useConfig,
+  getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
 import type {
   ArticleQuery,
@@ -50,7 +57,7 @@ const CATEGORIES_AMOUNT = 20;
 
 const NextCmsArticle: NextPage<{
   article: ArticleType;
-  breadcrumbs: Breadcrumb[] | null;
+  breadcrumbs: BreadcrumbListItem[] | null;
   collections: CollectionType[];
 }> = ({ article, breadcrumbs, collections }) => {
   const router = useRouter();
@@ -153,7 +160,7 @@ type ResultProps =
   | {
       initialApolloState: NormalizedCacheObject;
       article: ArticleQuery['post'];
-      breadcrumbs: Breadcrumb[];
+      breadcrumbs?: BreadcrumbListItem[];
       collections: CollectionType[];
     }
   | {
@@ -212,6 +219,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
 }
 
 const getProps = async (context: GetStaticPropsContext) => {
+  const language = getLanguageOrDefault(context.locale);
   const { data: articleData } = await eventsApolloClient.query<
     ArticleQuery,
     ArticleQueryVariables
@@ -227,10 +235,24 @@ const getProps = async (context: GetStaticPropsContext) => {
     fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
+  const { data: articleArchiveTitleData } = await eventsApolloClient.query<
+    PageByTemplateBreadcrumbTitleQuery,
+    PageByTemplateBreadcrumbTitleQueryVariables
+  >({
+    query: PageByTemplateBreadcrumbTitleDocument,
+    variables: {
+      template: TemplateEnum.PostsPage,
+      language: getQlLanguage(language).toLocaleLowerCase(),
+    },
+  });
+
   const currentArticle = articleData.post;
 
-  // TODO: Breadcrumbs are unstyled, so left disabled
-  const breadcrumbs: Breadcrumb[] = []; // await _getBreadcrumbs(apolloClient, currentArticle);
+  const breadcrumbs = cmsHelper.withArticleArchiveBreadcrumb(
+    getFilteredBreadcrumbs(getBreadcrumbsFromPage(currentArticle)),
+    articleArchiveTitleData?.pageByTemplate?.title ??
+      defaultArticleArchiveBreadcrumbTitle[language]
+  );
 
   return { currentArticle, breadcrumbs, apolloClient: eventsApolloClient };
 };
@@ -252,33 +274,5 @@ function _getURIQueryParameter(slugs: string[], locale: AppLanguage) {
   // when it's included in the article URL settings
   return `${AppConfig.cmsArticlesContextPath}${uri}`;
 }
-
-// async function _getBreadcrumbs(
-//   apolloClient: ApolloClient<NormalizedCacheObject>,
-//   currentArticle: ArticleType
-// ) {
-//   // Fetch all parent pages for navigation data
-//   const uriSegments = [ROUTES.ARTICLE_ARCHIVE];
-//   const apolloPageResponses = await Promise.all(
-//     uriSegments.map((uri) => {
-//       return apolloClient.query<PageQuery, PageQueryVariables>({
-//         query: PageDocument,
-//         variables: {
-//           id: uri,
-//         },
-//       });
-//     })
-//   );
-//   const pages = apolloPageResponses.map((res) => res.data.page);
-//   const breadcrumbs = pages
-//     .map((page) => ({
-//       link: page?.link ?? '',
-//       title: page?.title ?? '',
-//     }))
-//     .concat([
-//       { link: currentArticle?.link ?? '', title: currentArticle?.title ?? '' },
-//     ]);
-//   return breadcrumbs;
-// }
 
 export default NextCmsArticle;

--- a/apps/events-helsinki/src/pages/articles/index.tsx
+++ b/apps/events-helsinki/src/pages/articles/index.tsx
@@ -11,7 +11,9 @@ import {
   RouteMeta,
   getLanguageCodeFilter,
   useResilientTranslation,
+  getFilteredBreadcrumbs,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -23,6 +25,7 @@ import {
   SearchPageContent,
   useConfig,
   TemplateEnum,
+  getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
 import type { ArticleType, PageType } from 'react-helsinki-headless-cms';
 import {
@@ -51,7 +54,11 @@ interface ArticleFilters {
 
 export default function ArticleArchive({
   page,
-}: EventsGlobalPageProps & { page: PageType }) {
+  breadcrumbs,
+}: EventsGlobalPageProps & {
+  page: PageType;
+  breadcrumbs?: BreadcrumbListItem[];
+}) {
   const router = useRouter();
   const { resilientT } = useResilientTranslation();
 
@@ -151,6 +158,7 @@ export default function ArticleArchive({
         <>
           <RouteMeta origin={AppConfig.origin} page={page} />
           <SearchPageContent
+            breadcrumbs={breadcrumbs}
             page={page}
             isLoading={isLoading || isLoadingMore}
             className="articlesArchive"
@@ -160,7 +168,6 @@ export default function ArticleArchive({
             currentTags={currentCategories}
             currentText={text ?? ''}
             withQuery
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onSearch={(freeSearch, tags) => {
               const query: ParsedUrlQueryInput = getArticlesSearchQuery(
                 freeSearch,
@@ -219,7 +226,6 @@ export default function ArticleArchive({
 
                     text: '', // A design decision: The text is not wanted in the small cards
                   }}
-                  // todo: fix any type
                   customContent={
                     <ArticleDetails
                       keywords={
@@ -267,9 +273,11 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       };
     }
     const page = pageData.pageByTemplate;
+    const breadcrumbs = getFilteredBreadcrumbs(getBreadcrumbsFromPage(page));
     return {
       props: {
         page,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, ['event'])),
       },
     };

--- a/apps/events-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/events-helsinki/src/pages/cookie-consent/index.tsx
@@ -1,3 +1,11 @@
+import commonTranslationsEn from '@events-helsinki/common-i18n/locales/en/common.json';
+import commonTranslationsFi from '@events-helsinki/common-i18n/locales/fi/common.json';
+import commonTranslationsSv from '@events-helsinki/common-i18n/locales/sv/common.json';
+import type {
+  AppLanguage,
+  PageByTemplateBreadcrumbTitleQuery,
+  PageByTemplateBreadcrumbTitleQueryVariables,
+} from '@events-helsinki/components';
 import {
   NavigationContext,
   Navigation,
@@ -7,17 +15,37 @@ import {
   EventsCookieConsent,
   RouteMeta,
   useResilientTranslation,
+  getQlLanguage,
+  PageByTemplateBreadcrumbTitleDocument,
+  getFilteredBreadcrumbs,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import type { PageType } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  TemplateEnum,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getEventsStaticProps from '../../domain/app/getEventsStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 
-export default function CookieConsent() {
+const cookieConsentBreadcrumbTitle: Record<AppLanguage, string> = {
+  fi: commonTranslationsFi['cookies'] ?? 'Evästeet',
+  en: commonTranslationsEn['cookies'] ?? 'Cookies',
+  sv: commonTranslationsSv['cookies'] ?? 'Cookies',
+};
+
+export default function CookieConsent({
+  breadcrumbs,
+}: {
+  breadcrumbs?: BreadcrumbListItem[];
+}) {
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
   const router = useRouter();
@@ -45,6 +73,7 @@ export default function CookieConsent() {
       content={
         <>
           <RouteMeta origin={AppConfig.origin} />
+          {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
           <ConsentPageContent>
             <EventsCookieConsent
               appName={resilientT('appEvents:appName')}
@@ -66,10 +95,29 @@ export default function CookieConsent() {
 }
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-  return getEventsStaticProps(context, async () => {
+  return getEventsStaticProps(context, async ({ apolloClient }) => {
     const language = getLanguageOrDefault(context.locale);
+    const { data: pageBreadcrumbTitleData } = await apolloClient.query<
+      PageByTemplateBreadcrumbTitleQuery,
+      PageByTemplateBreadcrumbTitleQueryVariables
+    >({
+      query: PageByTemplateBreadcrumbTitleDocument,
+      variables: {
+        template: TemplateEnum.FrontPage,
+        language: getQlLanguage(language).toLocaleLowerCase(),
+      },
+    });
+    const breadcrumbs: BreadcrumbListItem[] = [
+      ...getFilteredBreadcrumbs(
+        getBreadcrumbsFromPage(
+          pageBreadcrumbTitleData.pageByTemplate as PageType
+        )
+      ),
+      { title: cookieConsentBreadcrumbTitle[language], path: null },
+    ];
     return {
       props: {
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language)),
       },
     };

--- a/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
+++ b/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
@@ -5,15 +5,26 @@ import {
   getLanguageOrDefault,
   FooterSection,
   useResilientTranslation,
+  PageBreadcrumbTitleDocument,
+  getFilteredBreadcrumbs,
+  getEventFields,
 } from '@events-helsinki/components';
 import type {
   EventFields,
   EventDetailsQuery,
   EventDetailsQueryVariables,
+  PageBreadcrumbTitleQuery,
+  PageBreadcrumbTitleQueryVariables,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React, { useContext } from 'react';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import type { PageType } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
+import { ROUTES } from '../../../constants';
 import AppConfig from '../../../domain/app/AppConfig';
 import getEventsStaticProps from '../../../domain/app/getEventsStaticProps';
 import EventPageContainer from '../../../domain/event/EventPageContainer';
@@ -22,7 +33,8 @@ import serverSideTranslationsWithCommon from '../../../domain/i18n/serverSideTra
 const Event: NextPage<{
   event: EventFields;
   loading: boolean;
-}> = ({ event, loading }) => {
+  breadcrumbs?: BreadcrumbListItem[];
+}> = ({ event, loading, breadcrumbs }) => {
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
   return (
@@ -31,6 +43,7 @@ const Event: NextPage<{
       navigation={<Navigation />}
       content={
         <EventPageContainer
+          breadcrumbs={breadcrumbs}
           event={event}
           loading={loading}
           showSimilarEvents={AppConfig.showSimilarEvents}
@@ -58,27 +71,46 @@ export async function getStaticPaths() {
 export async function getStaticProps(context: GetStaticPropsContext) {
   return getEventsStaticProps(context, async ({ apolloClient }) => {
     const language = getLanguageOrDefault(context.locale);
+    const id = (context.params?.eventId as string) || '';
     const { data: eventData, loading } = await apolloClient.query<
       EventDetailsQuery,
       EventDetailsQueryVariables
     >({
       query: EventDetailsDocument,
       variables: {
-        id: (context.params?.eventId as string) || '',
+        id,
         include: ['in_language', 'keywords', 'location', 'audience'],
       },
     });
-    if (!eventData) {
+
+    const event = eventData?.eventDetails;
+
+    if (!event) {
       return {
         notFound: true,
       };
     }
-    const event = eventData?.eventDetails;
+
+    const { data: pageBreadcrumbTitleData } = await apolloClient.query<
+      PageBreadcrumbTitleQuery,
+      PageBreadcrumbTitleQueryVariables
+    >({
+      query: PageBreadcrumbTitleDocument,
+      variables: {
+        id: `/${language}${ROUTES.SEARCH}/`,
+      },
+    });
+    const searchPage = pageBreadcrumbTitleData.page;
+    const breadcrumbs: BreadcrumbListItem[] = [
+      ...getFilteredBreadcrumbs(getBreadcrumbsFromPage(searchPage as PageType)),
+      { title: getEventFields(event, language)?.name ?? id, path: null },
+    ];
 
     return {
       props: {
         event,
         loading,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, [
           'search',
           'event',

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -7,13 +7,19 @@ import {
   RouteMeta,
   PageMeta,
   useResilientTranslation,
+  getFilteredBreadcrumbs,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
 import { usePageScrollRestoration } from '@events-helsinki/components/src/hooks';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -29,7 +35,8 @@ import SearchPage from '../../domain/search/eventSearch/SearchPage';
 
 const Search: NextPage<{
   page: PageType;
-}> = ({ page }) => {
+  breadcrumbs?: BreadcrumbListItem[];
+}> = ({ page, breadcrumbs }) => {
   const router = useRouter();
   const scrollTo = router.query?.scrollTo;
   const listRef = useRef<HTMLUListElement | null>(null);
@@ -63,6 +70,7 @@ const Search: NextPage<{
         <>
           <RouteMeta origin={AppConfig.origin} />
           <PageMeta {...page?.seo} />
+          {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
           <SearchPage
             SearchComponent={AdvancedSearch}
             pageTitle={tAppEvents('appEvents:search.pageTitle')}
@@ -96,10 +104,12 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       },
       fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
     });
-
+    const page = pageData.page;
+    const breadcrumbs = getFilteredBreadcrumbs(getBreadcrumbsFromPage(page));
     return {
       props: {
-        page: pageData.page,
+        page,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, [
           'event',
           'search',

--- a/apps/events-helsinki/src/pages/search/search.module.scss
+++ b/apps/events-helsinki/src/pages/search/search.module.scss
@@ -1,8 +1,0 @@
-@import 'variables';
-
-.koros {
-  fill: $color-silver-light;
-  margin-top: -1rem;
-  margin-bottom: -5rem;
-  grid-column: 1 / -1 !important;
-}

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -71,7 +71,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha255",
+    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -71,7 +71,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
+    "react-helsinki-headless-cms": "1.0.0-alpha259",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/EventPageContainer.tsx
@@ -10,8 +10,10 @@ import {
   EventPageMeta,
   EventContent,
   RouteMeta,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
 import type { EventFields } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
@@ -37,12 +39,14 @@ export interface EventPageContainerProps {
   loading: boolean;
   event?: EventFields;
   showSimilarEvents?: boolean;
+  breadcrumbs?: BreadcrumbListItem[];
 }
 
 const EventPageContainer: React.FC<EventPageContainerProps> = ({
   event,
   loading,
   showSimilarEvents = true,
+  breadcrumbs,
 }) => {
   const { t } = useTranslation('event');
   const router = useRouter();
@@ -67,6 +71,7 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
   const similarEventsFilters = useSimilarEventsQueryVariables(event!);
   return (
     <div className={styles.eventPageWrapper}>
+      {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
       <main id={MAIN_CONTENT_ID}>
         <LoadingSpinner isLoading={loading}>
           {event ? (

--- a/apps/hobbies-helsinki/src/pages/articles/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/index.tsx
@@ -11,7 +11,9 @@ import {
   RouteMeta,
   useResilientTranslation,
   getLanguageCodeFilter,
+  getFilteredBreadcrumbs,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -23,6 +25,7 @@ import {
   SearchPageContent,
   useConfig,
   TemplateEnum,
+  getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
 import type { ArticleType, PageType } from 'react-helsinki-headless-cms';
 import {
@@ -51,7 +54,11 @@ interface ArticleFilters {
 
 export default function ArticleArchive({
   page,
-}: HobbiesGlobalPageProps & { page: PageType }) {
+  breadcrumbs,
+}: HobbiesGlobalPageProps & {
+  page: PageType;
+  breadcrumbs?: BreadcrumbListItem[];
+}) {
   const router = useRouter();
   const { resilientT } = useResilientTranslation();
 
@@ -151,6 +158,7 @@ export default function ArticleArchive({
         <>
           <RouteMeta origin={AppConfig.origin} page={page} />
           <SearchPageContent
+            breadcrumbs={breadcrumbs}
             isLoading={isLoading || isLoadingMore}
             page={page}
             className="articlesArchive"
@@ -160,7 +168,6 @@ export default function ArticleArchive({
             currentTags={currentCategories}
             currentText={text ?? ''}
             withQuery
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onSearch={(freeSearch, tags) => {
               const query: ParsedUrlQueryInput = getArticlesSearchQuery(
                 freeSearch,
@@ -219,7 +226,6 @@ export default function ArticleArchive({
 
                     text: '', // A design decision: The text is not wanted in the small cards
                   }}
-                  // todo: fix any type
                   customContent={
                     <ArticleDetails
                       keywords={
@@ -267,9 +273,11 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       };
     }
     const page = pageData.pageByTemplate;
+    const breadcrumbs = getFilteredBreadcrumbs(getBreadcrumbsFromPage(page));
     return {
       props: {
         page,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, ['event'])),
       },
     };

--- a/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/cookie-consent/index.tsx
@@ -1,3 +1,11 @@
+import commonTranslationsEn from '@events-helsinki/common-i18n/locales/en/common.json';
+import commonTranslationsFi from '@events-helsinki/common-i18n/locales/fi/common.json';
+import commonTranslationsSv from '@events-helsinki/common-i18n/locales/sv/common.json';
+import type {
+  AppLanguage,
+  PageByTemplateBreadcrumbTitleQuery,
+  PageByTemplateBreadcrumbTitleQueryVariables,
+} from '@events-helsinki/components';
 import {
   NavigationContext,
   Navigation,
@@ -7,17 +15,37 @@ import {
   EventsCookieConsent,
   RouteMeta,
   useResilientTranslation,
+  getQlLanguage,
+  PageByTemplateBreadcrumbTitleDocument,
+  getFilteredBreadcrumbs,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import type { PageType } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  TemplateEnum,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 
-export default function CookieConsent() {
+const cookieConsentBreadcrumbTitle: Record<AppLanguage, string> = {
+  fi: commonTranslationsFi['cookies'] ?? 'Evästeet',
+  en: commonTranslationsEn['cookies'] ?? 'Cookies',
+  sv: commonTranslationsSv['cookies'] ?? 'Cookies',
+};
+
+export default function CookieConsent({
+  breadcrumbs,
+}: {
+  breadcrumbs?: BreadcrumbListItem[];
+}) {
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
   const router = useRouter();
@@ -45,6 +73,7 @@ export default function CookieConsent() {
       content={
         <>
           <RouteMeta origin={AppConfig.origin} />
+          {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
           <ConsentPageContent>
             <EventsCookieConsent
               appName={resilientT('appHobbies:appName')}
@@ -66,10 +95,29 @@ export default function CookieConsent() {
 }
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-  return getHobbiesStaticProps(context, async () => {
+  return getHobbiesStaticProps(context, async ({ apolloClient }) => {
     const language = getLanguageOrDefault(context.locale);
+    const { data: pageBreadcrumbTitleData } = await apolloClient.query<
+      PageByTemplateBreadcrumbTitleQuery,
+      PageByTemplateBreadcrumbTitleQueryVariables
+    >({
+      query: PageByTemplateBreadcrumbTitleDocument,
+      variables: {
+        template: TemplateEnum.FrontPage,
+        language: getQlLanguage(language).toLocaleLowerCase(),
+      },
+    });
+    const breadcrumbs: BreadcrumbListItem[] = [
+      ...getFilteredBreadcrumbs(
+        getBreadcrumbsFromPage(
+          pageBreadcrumbTitleData.pageByTemplate as PageType
+        )
+      ),
+      { title: cookieConsentBreadcrumbTitle[language], path: null },
+    ];
     return {
       props: {
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language)),
       },
     };

--- a/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -5,15 +5,26 @@ import {
   FooterSection,
   getLanguageOrDefault,
   useResilientTranslation,
+  PageBreadcrumbTitleDocument,
+  getFilteredBreadcrumbs,
+  getEventFields,
 } from '@events-helsinki/components';
 import type {
   EventFields,
   EventDetailsQuery,
   EventDetailsQueryVariables,
+  PageBreadcrumbTitleQuery,
+  PageBreadcrumbTitleQueryVariables,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React, { useContext } from 'react';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import type { PageType } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
+import { ROUTES } from '../../../constants';
 import AppConfig from '../../../domain/app/AppConfig';
 import getHobbiesStaticProps from '../../../domain/app/getHobbiesStaticProps';
 import EventPageContainer from '../../../domain/event/EventPageContainer';
@@ -22,7 +33,8 @@ import serverSideTranslationsWithCommon from '../../../domain/i18n/serverSideTra
 const Event: NextPage<{
   event: EventFields;
   loading: boolean;
-}> = ({ event, loading }) => {
+  breadcrumbs?: BreadcrumbListItem[];
+}> = ({ event, loading, breadcrumbs }) => {
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
   return (
@@ -31,6 +43,7 @@ const Event: NextPage<{
       navigation={<Navigation />}
       content={
         <EventPageContainer
+          breadcrumbs={breadcrumbs}
           event={event}
           loading={loading}
           showSimilarEvents={AppConfig.showSimilarEvents}
@@ -58,27 +71,45 @@ export async function getStaticPaths() {
 export async function getStaticProps(context: GetStaticPropsContext) {
   return getHobbiesStaticProps(context, async ({ apolloClient }) => {
     const language = getLanguageOrDefault(context.locale);
+    const id = (context.params?.eventId as string) || '';
     const { data: eventData, loading } = await apolloClient.query<
       EventDetailsQuery,
       EventDetailsQueryVariables
     >({
       query: EventDetailsDocument,
       variables: {
-        id: (context.params?.eventId as string) || '',
+        id,
         include: ['in_language', 'keywords', 'location', 'audience'],
       },
     });
-    if (!eventData) {
+    const event = eventData?.eventDetails;
+
+    if (!event) {
       return {
         notFound: true,
       };
     }
-    const event = eventData?.eventDetails;
+
+    const { data: pageBreadcrumbTitleData } = await apolloClient.query<
+      PageBreadcrumbTitleQuery,
+      PageBreadcrumbTitleQueryVariables
+    >({
+      query: PageBreadcrumbTitleDocument,
+      variables: {
+        id: `/${language}${ROUTES.SEARCH}/`,
+      },
+    });
+    const searchPage = pageBreadcrumbTitleData.page;
+    const breadcrumbs: BreadcrumbListItem[] = [
+      ...getFilteredBreadcrumbs(getBreadcrumbsFromPage(searchPage as PageType)),
+      { title: getEventFields(event, language)?.name ?? id, path: null },
+    ];
 
     return {
       props: {
         event,
         loading,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, [
           'search',
           'event',

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -9,24 +9,23 @@ import {
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
+  getFilteredBreadcrumbs,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
+import type { BreadcrumbListItem } from 'hds-react';
 import type {
   GetStaticPropsContext,
   GetStaticPropsResult,
   NextPage,
 } from 'next';
 import { useContext } from 'react';
-import type {
-  Breadcrumb,
-  CollectionType,
-  PageType,
-} from 'react-helsinki-headless-cms';
+import type { CollectionType, PageType } from 'react-helsinki-headless-cms';
 import {
   getCollections,
   PageContent as RHHCPageContent,
   Page as RHHCPage,
   useConfig,
+  getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
@@ -42,8 +41,9 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const NextCmsPage: NextPage<{
   page: PageType;
+  breadcrumbs: BreadcrumbListItem[] | null;
   collections: CollectionType[];
-}> = ({ page, collections }) => {
+}> = ({ page, breadcrumbs, collections }) => {
   const {
     utils: { getRoutedInternalHref },
   } = useConfig();
@@ -67,6 +67,9 @@ const NextCmsPage: NextPage<{
               collections
                 ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
                 : []
+            }
+            breadcrumbs={
+              breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
             }
           />
         </>
@@ -109,7 +112,7 @@ type ResultProps =
   | {
       initialApolloState: NormalizedCacheObject;
       page: PageQuery['page'];
-      breadcrumbs: Breadcrumb[];
+      breadcrumbs?: BreadcrumbListItem[];
       collections: CollectionType[];
     }
   | {
@@ -180,13 +183,11 @@ const getProps = async (context: GetStaticPropsContext) => {
   });
 
   const currentPage = pageData.page;
-  // TODO: Breadcrumbs are unstyled, so left disabled
-  // const breadcrumbs = _getBreadcrumbs(
-  //   apolloClient,
-  //   (context.params?.slug ?? []) as string[]
-  // );
+  const breadcrumbs = getFilteredBreadcrumbs(
+    getBreadcrumbsFromPage(currentPage)
+  );
 
-  return { currentPage, breadcrumbs: [], apolloClient: hobbiesApolloClient };
+  return { currentPage, breadcrumbs, apolloClient: hobbiesApolloClient };
 };
 
 /**
@@ -209,32 +210,5 @@ function _getURIQueryParameter(slugs: string[], locale: AppLanguage) {
   // to be subpages for a page with slug 'pages'
   return `${AppConfig.cmsPagesContextPath}${uri}`;
 }
-
-// async function _getBreadcrumbs(
-//   cmsClient: ApolloClient<NormalizedCacheObject>,
-//   slugs: string[]
-// ) {
-//   // Fetch all parent pages for navigation data.
-//   // These breadcrumb uris are used to fetch all the parent pages of the current page
-//   // so that all the childrens of parent page can be figured out and sub page navigations can be formed
-//   // for rendering
-//   const uriSegments = slugsToUriSegments(slugs);
-//   const apolloPageResponses = await Promise.all(
-//     uriSegments.map((uri) => {
-//       return cmsClient.query<PageQuery, PageQueryVariables>({
-//         query: PageDocument,
-//         variables: {
-//           id: uri,
-//         },
-//       });
-//     })
-//   );
-//   const pages = apolloPageResponses.map((res) => res.data.page);
-//   const breadcrumbs = pages.map((page) => ({
-//     link: page?.link ?? '',
-//     title: page?.title ?? '',
-//   }));
-//   return breadcrumbs;
-// }
 
 export default NextCmsPage;

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -8,12 +8,18 @@ import {
   RouteMeta,
   PageMeta,
   useResilientTranslation,
+  getFilteredBreadcrumbs,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -29,7 +35,8 @@ import SearchPage from '../../domain/search/eventSearch/SearchPage';
 
 const Search: NextPage<{
   page: PageType;
-}> = ({ page }) => {
+  breadcrumbs?: BreadcrumbListItem[];
+}> = ({ page, breadcrumbs }) => {
   const { t: tAppHobbies } = useAppHobbiesTranslation();
   const { resilientT } = useResilientTranslation();
   const router = useRouter();
@@ -62,6 +69,7 @@ const Search: NextPage<{
         <>
           <RouteMeta origin={AppConfig.origin} />
           <PageMeta {...page?.seo} />
+          {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
           <SearchPage
             SearchComponent={AdvancedSearch}
             pageTitle={tAppHobbies('appHobbies:search.pageTitle')}
@@ -95,10 +103,12 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       },
       fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
     });
-
+    const page = pageData.page;
+    const breadcrumbs = getFilteredBreadcrumbs(getBreadcrumbsFromPage(page));
     return {
       props: {
-        page: pageData.page,
+        page,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, [
           'event',
           'search',

--- a/apps/hobbies-helsinki/src/pages/search/search.module.scss
+++ b/apps/hobbies-helsinki/src/pages/search/search.module.scss
@@ -1,8 +1,0 @@
-@import 'variables';
-
-.koros {
-  fill: $color-silver-light;
-  margin-top: -1rem;
-  margin-bottom: -5rem;
-  grid-column: 1 / -1 !important;
-}

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha255",
+    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
+    "react-helsinki-headless-cms": "1.0.0-alpha259",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
+++ b/apps/sports-helsinki/src/domain/event/EventPageContainer.tsx
@@ -10,8 +10,10 @@ import {
   EventPageMeta,
   EventContent,
   RouteMeta,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
 import type { EventFields } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
@@ -36,12 +38,14 @@ export interface EventPageContainerProps {
   loading: boolean;
   event?: EventFields;
   showSimilarEvents?: boolean;
+  breadcrumbs?: BreadcrumbListItem[];
 }
 
 const EventPageContainer: React.FC<EventPageContainerProps> = ({
   event,
   loading,
   showSimilarEvents = true,
+  breadcrumbs,
 }) => {
   const { t } = useTranslation('event');
   const router = useRouter();
@@ -66,6 +70,7 @@ const EventPageContainer: React.FC<EventPageContainerProps> = ({
   const similarEventsFilters = useSimilarEventsQueryVariables(event!);
   return (
     <div className={styles.eventPageWrapper}>
+      {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
       <main id={MAIN_CONTENT_ID}>
         <LoadingSpinner isLoading={loading}>
           {event ? (

--- a/apps/sports-helsinki/src/domain/venue/VenuePageContainer.tsx
+++ b/apps/sports-helsinki/src/domain/venue/VenuePageContainer.tsx
@@ -5,8 +5,10 @@ import {
   addParamsToQueryString,
   MAIN_CONTENT_ID,
   RouteMeta,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
 import classNames from 'classnames';
+import type { BreadcrumbListItem } from 'hds-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
@@ -42,6 +44,7 @@ export interface VenuePageContainerProps {
   venue: Venue | undefined;
   showUpcomingEvents?: boolean;
   showSimilarVenues?: boolean;
+  breadcrumbs?: BreadcrumbListItem[];
 }
 
 const VenuePageContainer: React.FC<VenuePageContainerProps> = ({
@@ -49,6 +52,7 @@ const VenuePageContainer: React.FC<VenuePageContainerProps> = ({
   loading,
   showUpcomingEvents = true,
   showSimilarVenues = true,
+  breadcrumbs,
 }) => {
   const venueId = venue?.id ?? '';
   const { t } = useTranslation('event');
@@ -78,6 +82,7 @@ const VenuePageContainer: React.FC<VenuePageContainerProps> = ({
 
   return (
     <div className={styles.venuePageWrapper}>
+      {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
       <main id={MAIN_CONTENT_ID}>
         <LoadingSpinner isLoading={loading}>
           {venue ? (

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -10,9 +10,19 @@ import {
   useResilientTranslation,
   RouteMeta,
   getLanguageCodeFilter,
+  getFilteredBreadcrumbs,
+  TemplateEnum,
+  getQlLanguage,
+  defaultArticleArchiveBreadcrumbTitle,
+  PageByTemplateBreadcrumbTitleDocument,
 } from '@events-helsinki/components';
-import type { AppLanguage } from '@events-helsinki/components';
+import type {
+  AppLanguage,
+  PageByTemplateBreadcrumbTitleQuery,
+  PageByTemplateBreadcrumbTitleQueryVariables,
+} from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
+import type { BreadcrumbListItem } from 'hds-react';
 import type {
   GetStaticPropsContext,
   GetStaticPropsResult,
@@ -20,16 +30,13 @@ import type {
 } from 'next';
 import { useRouter } from 'next/router';
 import { useContext } from 'react';
-import type {
-  Breadcrumb,
-  CollectionType,
-  ArticleType,
-} from 'react-helsinki-headless-cms';
+import type { CollectionType, ArticleType } from 'react-helsinki-headless-cms';
 import {
   getCollections,
   PageContent as RHHCPageContent,
   Page as RHHCPage,
   useConfig,
+  getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
 import type {
   ArticleQuery,
@@ -50,7 +57,7 @@ const CATEGORIES_AMOUNT = 20;
 
 const NextCmsArticle: NextPage<{
   article: ArticleType;
-  breadcrumbs: Breadcrumb[] | null;
+  breadcrumbs: BreadcrumbListItem[] | null;
   collections: CollectionType[];
 }> = ({ article, breadcrumbs, collections }) => {
   const router = useRouter();
@@ -152,7 +159,7 @@ type ResultProps =
   | {
       initialApolloState: NormalizedCacheObject;
       article: ArticleQuery['post'];
-      breadcrumbs: Breadcrumb[];
+      breadcrumbs?: BreadcrumbListItem[];
       collections: CollectionType[];
     }
   | {
@@ -224,10 +231,24 @@ const getProps = async (context: GetStaticPropsContext) => {
     fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
   });
 
+  const { data: articleArchiveTitleData } = await sportsApolloClient.query<
+    PageByTemplateBreadcrumbTitleQuery,
+    PageByTemplateBreadcrumbTitleQueryVariables
+  >({
+    query: PageByTemplateBreadcrumbTitleDocument,
+    variables: {
+      template: TemplateEnum.PostsPage,
+      language: getQlLanguage(language).toLocaleLowerCase(),
+    },
+  });
+
   const currentArticle = articleData.post;
 
-  // TODO: Breadcrumbs are unstyled, so left disabled
-  const breadcrumbs: Breadcrumb[] = []; // await _getBreadcrumbs(cmsClient, currentArticle);
+  const breadcrumbs = cmsHelper.withArticleArchiveBreadcrumb(
+    getFilteredBreadcrumbs(getBreadcrumbsFromPage(currentArticle)),
+    articleArchiveTitleData?.pageByTemplate?.title ??
+      defaultArticleArchiveBreadcrumbTitle[language]
+  );
 
   return { currentArticle, breadcrumbs, apolloClient: sportsApolloClient };
 };
@@ -249,33 +270,5 @@ function _getURIQueryParameter(slugs: string[], locale: AppLanguage) {
   // when it's included in the article URL settings
   return `${AppConfig.cmsArticlesContextPath}${uri}`;
 }
-
-// async function _getBreadcrumbs(
-//   cmsClient: ApolloClient<NormalizedCacheObject>,
-//   currentArticle: ArticleType
-// ) {
-//   // Fetch all parent pages for navigation data
-//   const uriSegments = [ROUTES.ARTICLE_ARCHIVE];
-//   const apolloPageResponses = await Promise.all(
-//     uriSegments.map((uri) => {
-//       return cmsClient.query<PageQuery, PageQueryVariables>({
-//         query: PageDocument,
-//         variables: {
-//           id: uri,
-//         },
-//       });
-//     })
-//   );
-//   const pages = apolloPageResponses.map((res) => res.data.page);
-//   const breadcrumbs = pages
-//     .map((page) => ({
-//       link: page?.link ?? '',
-//       title: page?.title ?? '',
-//     }))
-//     .concat([
-//       { link: currentArticle?.link ?? '', title: currentArticle?.title ?? '' },
-//     ]);
-//   return breadcrumbs;
-// }
 
 export default NextCmsArticle;

--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -11,7 +11,9 @@ import {
   RouteMeta,
   useResilientTranslation,
   getLanguageCodeFilter,
+  getFilteredBreadcrumbs,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -23,6 +25,7 @@ import {
   SearchPageContent,
   useConfig,
   TemplateEnum,
+  getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
 import type { ArticleType, PageType } from 'react-helsinki-headless-cms';
 import {
@@ -51,7 +54,11 @@ interface ArticleFilters {
 
 export default function ArticleArchive({
   page,
-}: SportsGlobalPageProps & { page: PageType }) {
+  breadcrumbs,
+}: SportsGlobalPageProps & {
+  page: PageType;
+  breadcrumbs?: BreadcrumbListItem[];
+}) {
   const router = useRouter();
   const { resilientT } = useResilientTranslation();
 
@@ -152,6 +159,7 @@ export default function ArticleArchive({
           <RouteMeta origin={AppConfig.origin} page={page} />
           <SearchPageContent
             page={page}
+            breadcrumbs={breadcrumbs}
             isLoading={isLoading || isLoadingMore}
             className="articlesArchive"
             noResults={!isLoading && articles?.length === 0}
@@ -160,7 +168,6 @@ export default function ArticleArchive({
             currentTags={currentCategories}
             currentText={text ?? ''}
             withQuery
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onSearch={(freeSearch, tags) => {
               const query: ParsedUrlQueryInput = getArticlesSearchQuery(
                 freeSearch,
@@ -219,7 +226,6 @@ export default function ArticleArchive({
 
                     text: '', // A design decision: The text is not wanted in the small cards
                   }}
-                  // todo: fix any type
                   customContent={
                     <ArticleDetails
                       keywords={
@@ -267,9 +273,11 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       };
     }
     const page = pageData.pageByTemplate;
+    const breadcrumbs = getFilteredBreadcrumbs(getBreadcrumbsFromPage(page));
     return {
       props: {
         page,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, ['event'])),
       },
     };

--- a/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
+++ b/apps/sports-helsinki/src/pages/cookie-consent/index.tsx
@@ -1,3 +1,11 @@
+import commonTranslationsEn from '@events-helsinki/common-i18n/locales/en/common.json';
+import commonTranslationsFi from '@events-helsinki/common-i18n/locales/fi/common.json';
+import commonTranslationsSv from '@events-helsinki/common-i18n/locales/sv/common.json';
+import type {
+  AppLanguage,
+  PageByTemplateBreadcrumbTitleQuery,
+  PageByTemplateBreadcrumbTitleQueryVariables,
+} from '@events-helsinki/components';
 import {
   NavigationContext,
   Navigation,
@@ -7,17 +15,37 @@ import {
   EventsCookieConsent,
   RouteMeta,
   useResilientTranslation,
+  getQlLanguage,
+  PageByTemplateBreadcrumbTitleDocument,
+  getFilteredBreadcrumbs,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useCallback, useContext } from 'react';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import type { PageType } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  TemplateEnum,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
 import AppConfig from '../../domain/app/AppConfig';
 import getSportsStaticProps from '../../domain/app/getSportsStaticProps';
 import ConsentPageContent from '../../domain/cookieConsent/ConsentPageContent';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 
-export default function CookieConsent() {
+const cookieConsentBreadcrumbTitle: Record<AppLanguage, string> = {
+  fi: commonTranslationsFi['cookies'] ?? 'Evästeet',
+  en: commonTranslationsEn['cookies'] ?? 'Cookies',
+  sv: commonTranslationsSv['cookies'] ?? 'Cookies',
+};
+
+export default function CookieConsent({
+  breadcrumbs,
+}: {
+  breadcrumbs?: BreadcrumbListItem[];
+}) {
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
   const router = useRouter();
@@ -45,6 +73,7 @@ export default function CookieConsent() {
       content={
         <>
           <RouteMeta origin={AppConfig.origin} />
+          {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
           <ConsentPageContent>
             <EventsCookieConsent
               appName={resilientT('appSports:appName')}
@@ -66,10 +95,29 @@ export default function CookieConsent() {
 }
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-  return getSportsStaticProps(context, async () => {
+  return getSportsStaticProps(context, async ({ apolloClient }) => {
     const language = getLanguageOrDefault(context.locale);
+    const { data: pageBreadcrumbTitleData } = await apolloClient.query<
+      PageByTemplateBreadcrumbTitleQuery,
+      PageByTemplateBreadcrumbTitleQueryVariables
+    >({
+      query: PageByTemplateBreadcrumbTitleDocument,
+      variables: {
+        template: TemplateEnum.FrontPage,
+        language: getQlLanguage(language).toLocaleLowerCase(),
+      },
+    });
+    const breadcrumbs: BreadcrumbListItem[] = [
+      ...getFilteredBreadcrumbs(
+        getBreadcrumbsFromPage(
+          pageBreadcrumbTitleData.pageByTemplate as PageType
+        )
+      ),
+      { title: cookieConsentBreadcrumbTitle[language], path: null },
+    ];
     return {
       props: {
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language)),
       },
     };

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -10,24 +10,23 @@ import {
   FooterSection,
   getLanguageOrDefault,
   RouteMeta,
+  getFilteredBreadcrumbs,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
+import type { BreadcrumbListItem } from 'hds-react';
 import type {
   GetStaticPropsContext,
   GetStaticPropsResult,
   NextPage,
 } from 'next';
 import { useContext } from 'react';
-import type {
-  Breadcrumb,
-  CollectionType,
-  PageType,
-} from 'react-helsinki-headless-cms';
+import type { CollectionType, PageType } from 'react-helsinki-headless-cms';
 import {
   getCollections,
   PageContent as RHHCPageContent,
   Page as RHHCPage,
   useConfig,
+  getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
@@ -42,8 +41,9 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const NextCmsPage: NextPage<{
   page: PageType;
+  breadcrumbs: BreadcrumbListItem[] | null;
   collections: CollectionType[];
-}> = ({ page, collections }) => {
+}> = ({ page, breadcrumbs, collections }) => {
   const {
     utils: { getRoutedInternalHref },
   } = useConfig();
@@ -67,6 +67,9 @@ const NextCmsPage: NextPage<{
               collections
                 ? cmsHelper.getDefaultCollections(page, getRoutedInternalHref)
                 : []
+            }
+            breadcrumbs={
+              breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined
             }
           />
         </>
@@ -109,7 +112,7 @@ type ResultProps =
   | {
       initialApolloState: NormalizedCacheObject;
       page: PageQuery['page'];
-      breadcrumbs: Breadcrumb[];
+      breadcrumbs?: BreadcrumbListItem[];
       collections: CollectionType[];
     }
   | {
@@ -180,13 +183,11 @@ const getProps = async (context: GetStaticPropsContext) => {
   });
 
   const currentPage = pageData.page;
-  // TODO: Breadcrumbs are unstyled, so left disabled
-  // const breadcrumbs = _getBreadcrumbs(
-  //   apolloClient,
-  //   (context.params?.slug ?? []) as string[]
-  // );
+  const breadcrumbs = getFilteredBreadcrumbs(
+    getBreadcrumbsFromPage(currentPage)
+  );
 
-  return { currentPage, breadcrumbs: [], apolloClient: sportsApolloClient };
+  return { currentPage, breadcrumbs, apolloClient: sportsApolloClient };
 };
 
 /**
@@ -209,32 +210,5 @@ function _getURIQueryParameter(slugs: string[], locale: AppLanguage) {
   // to be subpages for a page with slug 'pages'
   return `${AppConfig.cmsPagesContextPath}${uri}`;
 }
-
-// async function _getBreadcrumbs(
-//   cmsClient: ApolloClient<NormalizedCacheObject>,
-//   slugs: string[]
-// ) {
-//   // Fetch all parent pages for navigation data.
-//   // These breadcrumb uris are used to fetch all the parent pages of the current page
-//   // so that all the childrens of parent page can be figured out and sub page navigations can be formed
-//   // for rendering
-//   const uriSegments = slugsToUriSegments(slugs);
-//   const apolloPageResponses = await Promise.all(
-//     uriSegments.map((uri) => {
-//       return cmsClient.query<PageQuery, PageQueryVariables>({
-//         query: PageDocument,
-//         variables: {
-//           id: uri,
-//         },
-//       });
-//     })
-//   );
-//   const pages = apolloPageResponses.map((res) => res.data.page);
-//   const breadcrumbs = pages.map((page) => ({
-//     link: page?.link ?? '',
-//     title: page?.title ?? '',
-//   }));
-//   return breadcrumbs;
-// }
 
 export default NextCmsPage;

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -7,11 +7,17 @@ import {
   RouteMeta,
   PageMeta,
   useResilientTranslation,
+  getFilteredBreadcrumbs,
+  BreadcrumbContainer,
 } from '@events-helsinki/components';
+import type { BreadcrumbListItem } from 'hds-react';
 import type { GetStaticPropsContext, NextPage } from 'next';
 import React, { useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { Page as RHHCPage } from 'react-helsinki-headless-cms';
+import {
+  Page as RHHCPage,
+  getBreadcrumbsFromPage,
+} from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -26,7 +32,8 @@ import CombinedSearchPage from '../../domain/search/combinedSearch/CombinedSearc
 
 const Search: NextPage<{
   page: PageType;
-}> = ({ page }) => {
+  breadcrumbs?: BreadcrumbListItem[];
+}> = ({ page, breadcrumbs }) => {
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
   usePageScrollRestoration();
@@ -38,6 +45,7 @@ const Search: NextPage<{
         <>
           <RouteMeta origin={AppConfig.origin} />
           <PageMeta {...page?.seo} />
+          {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
           <CombinedSearchPage defaultTab="Venue" />
         </>
       }
@@ -67,10 +75,12 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       },
       fetchPolicy: 'no-cache', // FIXME: network-only should work better, but for some reason it only updates once.
     });
-
+    const page = pageData.page;
+    const breadcrumbs = getFilteredBreadcrumbs(getBreadcrumbsFromPage(page));
     return {
       props: {
-        page: pageData.page,
+        page,
+        breadcrumbs,
         ...(await serverSideTranslationsWithCommon(language, [
           'event',
           'search',

--- a/apps/sports-helsinki/src/pages/search/search.module.scss
+++ b/apps/sports-helsinki/src/pages/search/search.module.scss
@@ -1,8 +1,0 @@
-@import 'variables';
-
-.koros {
-  fill: $color-silver-light;
-  margin-top: -1rem;
-  margin-bottom: -5rem;
-  grid-column: 1 / -1 !important;
-}

--- a/packages/common-i18n/src/locales/en/common.json
+++ b/packages/common-i18n/src/locales/en/common.json
@@ -114,5 +114,6 @@
     "showSearchParameters": "Show search",
     "hideSearchParameters": "Hide search",
     "showSearchParametersA11y": "Go to the search form"
-  }
+  },
+  "cookies": "Cookies"
 }

--- a/packages/common-i18n/src/locales/fi/common.json
+++ b/packages/common-i18n/src/locales/fi/common.json
@@ -114,5 +114,6 @@
     "showSearchParameters": "Näytä haku",
     "hideSearchParameters": "Sulje haku",
     "showSearchParametersA11y": "Siirry hakulomakkeelle"
-  }
+  },
+  "cookies": "Evästeet"
 }

--- a/packages/common-i18n/src/locales/sv/common.json
+++ b/packages/common-i18n/src/locales/sv/common.json
@@ -114,5 +114,6 @@
     "showSearchParameters": "Visa sökningen",
     "hideSearchParameters": "Stänga sökningen",
     "showSearchParametersA11y": "Gå till ansökningsblanketten"
-  }
+  },
+  "cookies": "Cookies"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,7 +76,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
+    "react-helsinki-headless-cms": "1.0.0-alpha259",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,7 +76,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0-alpha255",
+    "react-helsinki-headless-cms": "1.0.0-alpha256-canary-b81812e",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/packages/components/src/components/domain/breadcrumb/BreadcrumbContainer.tsx
+++ b/packages/components/src/components/domain/breadcrumb/BreadcrumbContainer.tsx
@@ -1,0 +1,15 @@
+import type { BreadcrumbListItem } from 'hds-react';
+import { PageContentBreadcrumb } from 'react-helsinki-headless-cms';
+import styles from './breadcrumb.module.scss';
+
+type BreadcrumbContainerProps = {
+  breadcrumbs: BreadcrumbListItem[];
+};
+
+export function BreadcrumbContainer({ breadcrumbs }: BreadcrumbContainerProps) {
+  return (
+    <div className={styles.breadcrumbs}>
+      <PageContentBreadcrumb breadcrumbs={breadcrumbs} />
+    </div>
+  );
+}

--- a/packages/components/src/components/domain/breadcrumb/breadcrumb.module.scss
+++ b/packages/components/src/components/domain/breadcrumb/breadcrumb.module.scss
@@ -1,0 +1,14 @@
+@import '/src/styles/variables';
+
+.breadcrumbs {
+  --header-max-width: var(--breakpoint-xl);
+  width: 100%;
+  max-width: var(--header-max-width);
+  margin: 0 auto;
+  padding: 0 var(--spacing-m);
+  box-sizing: border-box;
+
+  & nav {
+    margin: 0;
+  }
+}

--- a/packages/components/src/components/domain/breadcrumb/index.ts
+++ b/packages/components/src/components/domain/breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export { BreadcrumbContainer } from './BreadcrumbContainer';

--- a/packages/components/src/components/domain/breadcrumb/query.ts
+++ b/packages/components/src/components/domain/breadcrumb/query.ts
@@ -1,0 +1,28 @@
+import { gql } from '@apollo/client';
+
+export const QUERY_PAGETEMPLATE_BREADCRUMB_TITLE = gql`
+  query pageByTemplateBreadcrumbTitle(
+    $template: TemplateEnum
+    $language: String
+  ) {
+    pageByTemplate(template: $template, language: $language) {
+      title
+      breadcrumbs {
+        title
+        uri
+      }
+    }
+  }
+`;
+
+export const QUERY_PAGE_BREADCRUMB_TITLE = gql`
+  query pageBreadcrumbTitle($id: ID!) {
+    page(id: $id, idType: URI) {
+      title
+      breadcrumbs {
+        title
+        uri
+      }
+    }
+  }
+`;

--- a/packages/components/src/components/domain/index.ts
+++ b/packages/components/src/components/domain/index.ts
@@ -1,3 +1,4 @@
+export * from './breadcrumb';
 export * from './event';
 export * from './neighborhood';
 export * from './seo';

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -12490,6 +12490,41 @@ export type WritingSettings = {
   useSmilies?: Maybe<Scalars['Boolean']['output']>;
 };
 
+export type PageByTemplateBreadcrumbTitleQueryVariables = Exact<{
+  template?: InputMaybe<TemplateEnum>;
+  language?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+export type PageByTemplateBreadcrumbTitleQuery = {
+  __typename?: 'Query';
+  pageByTemplate?: {
+    __typename?: 'Page';
+    title?: string | null;
+    breadcrumbs?: Array<{
+      __typename?: 'Breadcrumb';
+      title?: string | null;
+      uri?: string | null;
+    } | null> | null;
+  } | null;
+};
+
+export type PageBreadcrumbTitleQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+export type PageBreadcrumbTitleQuery = {
+  __typename?: 'Query';
+  page?: {
+    __typename?: 'Page';
+    title?: string | null;
+    breadcrumbs?: Array<{
+      __typename?: 'Breadcrumb';
+      title?: string | null;
+      uri?: string | null;
+    } | null> | null;
+  } | null;
+};
+
 export type LocalizedFieldsFragment = {
   __typename?: 'LocalizedObject';
   en?: string | null;
@@ -14404,6 +14439,134 @@ export const VenueFieldsFragmentDoc = gql`
     }
   }
 `;
+export const PageByTemplateBreadcrumbTitleDocument = gql`
+  query pageByTemplateBreadcrumbTitle(
+    $template: TemplateEnum
+    $language: String
+  ) {
+    pageByTemplate(template: $template, language: $language) {
+      title
+      breadcrumbs {
+        title
+        uri
+      }
+    }
+  }
+`;
+
+/**
+ * __usePageByTemplateBreadcrumbTitleQuery__
+ *
+ * To run a query within a React component, call `usePageByTemplateBreadcrumbTitleQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePageByTemplateBreadcrumbTitleQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePageByTemplateBreadcrumbTitleQuery({
+ *   variables: {
+ *      template: // value for 'template'
+ *      language: // value for 'language'
+ *   },
+ * });
+ */
+export function usePageByTemplateBreadcrumbTitleQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    PageByTemplateBreadcrumbTitleQuery,
+    PageByTemplateBreadcrumbTitleQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    PageByTemplateBreadcrumbTitleQuery,
+    PageByTemplateBreadcrumbTitleQueryVariables
+  >(PageByTemplateBreadcrumbTitleDocument, options);
+}
+export function usePageByTemplateBreadcrumbTitleLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    PageByTemplateBreadcrumbTitleQuery,
+    PageByTemplateBreadcrumbTitleQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    PageByTemplateBreadcrumbTitleQuery,
+    PageByTemplateBreadcrumbTitleQueryVariables
+  >(PageByTemplateBreadcrumbTitleDocument, options);
+}
+export type PageByTemplateBreadcrumbTitleQueryHookResult = ReturnType<
+  typeof usePageByTemplateBreadcrumbTitleQuery
+>;
+export type PageByTemplateBreadcrumbTitleLazyQueryHookResult = ReturnType<
+  typeof usePageByTemplateBreadcrumbTitleLazyQuery
+>;
+export type PageByTemplateBreadcrumbTitleQueryResult = Apollo.QueryResult<
+  PageByTemplateBreadcrumbTitleQuery,
+  PageByTemplateBreadcrumbTitleQueryVariables
+>;
+export const PageBreadcrumbTitleDocument = gql`
+  query pageBreadcrumbTitle($id: ID!) {
+    page(id: $id, idType: URI) {
+      title
+      breadcrumbs {
+        title
+        uri
+      }
+    }
+  }
+`;
+
+/**
+ * __usePageBreadcrumbTitleQuery__
+ *
+ * To run a query within a React component, call `usePageBreadcrumbTitleQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePageBreadcrumbTitleQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePageBreadcrumbTitleQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function usePageBreadcrumbTitleQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    PageBreadcrumbTitleQuery,
+    PageBreadcrumbTitleQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    PageBreadcrumbTitleQuery,
+    PageBreadcrumbTitleQueryVariables
+  >(PageBreadcrumbTitleDocument, options);
+}
+export function usePageBreadcrumbTitleLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    PageBreadcrumbTitleQuery,
+    PageBreadcrumbTitleQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    PageBreadcrumbTitleQuery,
+    PageBreadcrumbTitleQueryVariables
+  >(PageBreadcrumbTitleDocument, options);
+}
+export type PageBreadcrumbTitleQueryHookResult = ReturnType<
+  typeof usePageBreadcrumbTitleQuery
+>;
+export type PageBreadcrumbTitleLazyQueryHookResult = ReturnType<
+  typeof usePageBreadcrumbTitleLazyQuery
+>;
+export type PageBreadcrumbTitleQueryResult = Apollo.QueryResult<
+  PageBreadcrumbTitleQuery,
+  PageBreadcrumbTitleQueryVariables
+>;
 export const EventDetailsDocument = gql`
   query EventDetails($id: ID!, $include: [String]) {
     eventDetails(id: $id, include: $include) {

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -164,23 +164,32 @@ export type BannerPage = {
   titleAndDescriptionColor?: Maybe<LocalizedObject>;
 };
 
+/** Breadcumb field */
+export type Breadcrumb = {
+  __typename?: 'Breadcrumb';
+  /** The title of the page */
+  title?: Maybe<Scalars['String']['output']>;
+  /** The link of the page. */
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
 export enum CacheControlScope {
   Private = 'PRIVATE',
   Public = 'PUBLIC',
 }
 
-/** Card field */
+/** Kortin kenttä */
 export type Card = {
   __typename?: 'Card';
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Icon */
+  /** Ikoni */
   icon?: Maybe<Scalars['String']['output']>;
-  /** Link */
+  /** Linkki */
   link?: Maybe<Link>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -619,7 +628,7 @@ export type Collection = ContentNode &
   Previewable &
   UniformResourceIdentifiable & {
     __typename?: 'Collection';
-    /** Background Color */
+    /** Taustaväri */
     backgroundColor?: Maybe<Scalars['String']['output']>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
@@ -636,7 +645,7 @@ export type Collection = ContentNode &
     date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
     dateGmt?: Maybe<Scalars['String']['output']>;
-    /** Description */
+    /** Kuvaus */
     description?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
     desiredSlug?: Maybe<Scalars['String']['output']>;
@@ -654,7 +663,7 @@ export type Collection = ContentNode &
     guid?: Maybe<Scalars['String']['output']>;
     /** The globally unique identifier of the collection-cpt object. */
     id: Scalars['ID']['output'];
-    /** Image */
+    /** Kuva */
     image?: Maybe<Scalars['String']['output']>;
     /** Whether the node is a Content Node */
     isContentNode: Scalars['Boolean']['output'];
@@ -676,7 +685,7 @@ export type Collection = ContentNode &
     modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
     modifiedGmt?: Maybe<Scalars['String']['output']>;
-    /** List of modules */
+    /** Moduulilistaus */
     modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
     /** Connection between the Collection type and the collection type */
     preview?: Maybe<CollectionToPreviewConnectionEdge>;
@@ -690,7 +699,7 @@ export type Collection = ContentNode &
     revisions?: Maybe<CollectionToRevisionConnection>;
     /** The SEO Framework data of the collection */
     seo?: Maybe<Seo>;
-    /** Show on front page */
+    /** Näytä etusivulla */
     showOnFrontPage?: Maybe<Scalars['Boolean']['output']>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
     slug?: Maybe<Scalars['String']['output']>;
@@ -1258,7 +1267,7 @@ export type Contact = ContentNode &
     date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
     dateGmt?: Maybe<Scalars['String']['output']>;
-    /** Description */
+    /** Kuvaus */
     description?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
     desiredSlug?: Maybe<Scalars['String']['output']>;
@@ -1276,7 +1285,7 @@ export type Contact = ContentNode &
     featuredImageDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** Globally unique ID of the featured image assigned to the node */
     featuredImageId?: Maybe<Scalars['ID']['output']>;
-    /** First name */
+    /** Etunimi */
     firstName?: Maybe<Scalars['String']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
     guid?: Maybe<Scalars['String']['output']>;
@@ -1298,7 +1307,7 @@ export type Contact = ContentNode &
     language?: Maybe<Language>;
     /** The user that most recently edited the node */
     lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
-    /** Last name */
+    /** Sukunimi */
     lastName?: Maybe<Scalars['String']['output']>;
     /** The permalink of the post */
     link?: Maybe<Scalars['String']['output']>;
@@ -1931,7 +1940,7 @@ export type CreateCategoryPayload = {
 export type CreateCollectionInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
@@ -1971,7 +1980,7 @@ export type CreateCommentInput = {
   commentOn?: InputMaybe<Scalars['Int']['input']>;
   /** Content of the comment. */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** Parent comment ID of current comment. */
   parent?: InputMaybe<Scalars['ID']['input']>;
@@ -1996,7 +2005,7 @@ export type CreateCommentPayload = {
 export type CreateContactInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
@@ -2024,7 +2033,7 @@ export type CreateContactPayload = {
 export type CreateLandingPageInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
@@ -2100,7 +2109,7 @@ export type CreatePageInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
@@ -2159,7 +2168,7 @@ export type CreatePostInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
@@ -2193,7 +2202,7 @@ export type CreateReleaseInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   language?: InputMaybe<LanguageCodeEnum>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
@@ -2245,7 +2254,7 @@ export type CreateTagPayload = {
 export type CreateTranslationInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types. */
   menuOrder?: InputMaybe<Scalars['Int']['input']>;
@@ -2280,7 +2289,7 @@ export type CreateUserInput = {
   displayName?: InputMaybe<Scalars['String']['input']>;
   /** A string containing the user's email address. */
   email?: InputMaybe<Scalars['String']['input']>;
-  /** 	The user's first name. */
+  /** The user's first name. */
   firstName?: InputMaybe<Scalars['String']['input']>;
   /** User's Jabber account. */
   jabber?: InputMaybe<Scalars['String']['input']>;
@@ -2363,7 +2372,7 @@ export type DateQueryInput = {
   year?: InputMaybe<Scalars['Int']['input']>;
 };
 
-/** Default images of different post types. Returns url of image of queried post type. Values come from Sivuston Asetukset -&gt; Oletuskuvat. */
+/** Oletuskuva */
 export type DefaultImages = {
   __typename?: 'DefaultImages';
   /** Attachment URL for article image */
@@ -2978,14 +2987,14 @@ export type EventPricing = {
   todo?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: EventSearch */
+/** Kokoelmamoduuli: EventSearch */
 export type EventSearch = {
   __typename?: 'EventSearch';
-  /** Amount of events listed before &quot;show more -button&quot; */
+  /** Listattujen tapahtumien määrä “Näytä lisää” -painiketta */
   initAmountOfEvents?: Maybe<Scalars['Int']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /**
    * Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
@@ -2993,26 +3002,26 @@ export type EventSearch = {
    *                 https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
    */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLinkCustom?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** Search query */
+  /** Hakukysely */
   url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: EventSearchCarousel */
+/** Kokoelmamoduuli: EventSearchCarousel */
 export type EventSearchCarousel = {
   __typename?: 'EventSearchCarousel';
-  /** Amount of cards in carousel */
+  /** Korttien määrä karusellissa */
   amountOfCards?: Maybe<Scalars['Int']['output']>;
-  /** Events nearby */
+  /** Tapahtumat lähellä */
   eventsNearby?: Maybe<Scalars['Boolean']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
-  /** Events order */
+  /** Tapahtumien järjestys */
   orderNewestFirst?: Maybe<Scalars['Boolean']['output']>;
   /**
    * Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
@@ -3020,49 +3029,49 @@ export type EventSearchCarousel = {
    *                                     https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
    */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLinkCustom?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** Search query */
+  /** Hakukysely */
   url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: EventSelected */
+/** Kokoelmamoduuli: EventSelected */
 export type EventSelected = {
   __typename?: 'EventSelected';
-  /** List of event IDs */
+  /** Lista tapahtumien ID-tiedoista */
   events?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Amount of events listed before &quot;show more -button&quot; */
+  /** Listattujen tapahtumien määrä “Näytä lisää” -painiketta */
   initAmountOfEvents?: Maybe<Scalars['Int']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: EventSelectedCarousel */
+/** Kokoelmamoduuli: EventSelectedCarousel */
 export type EventSelectedCarousel = {
   __typename?: 'EventSelectedCarousel';
-  /** Amount of cards in carousel */
+  /** Korttien määrä karusellissa */
   amountOfCards?: Maybe<Scalars['Int']['output']>;
-  /** Amount of cards per row */
+  /** Korttien määrä riviä kohden */
   amountOfCardsPerRow?: Maybe<Scalars['Int']['output']>;
-  /** List of event IDs */
+  /** Lista tapahtumien ID-tiedoista */
   events?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Events nearby */
+  /** Tapahtumat lähellä */
   eventsNearby?: Maybe<Scalars['Boolean']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3078,22 +3087,24 @@ export type ExternalLink = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
-/** Gallery Image */
+export type FooterBlocksUnion = LayoutEditor | LayoutImage | LayoutMenu;
+
+/** Galleriakuva */
 export type GalleryImage = {
   __typename?: 'GalleryImage';
-  /** Caption of the image */
+  /** Kuvan lainaus */
   caption?: Maybe<Scalars['String']['output']>;
-  /** Description of the image */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** The url of the large image */
+  /** Kuvan (large) URL-osoite */
   large?: Maybe<Scalars['String']['output']>;
-  /** The url of the medium image */
+  /** Kuvan (medium) URL-osoite */
   medium?: Maybe<Scalars['String']['output']>;
-  /** The url of the medium large image */
+  /** Kuvan (medium large) URL-osoite */
   medium_large?: Maybe<Scalars['String']['output']>;
-  /** The url of the thumbnail image */
+  /** Kuvan URL-osoite */
   thumbnail?: Maybe<Scalars['String']['output']>;
-  /** Title of the image */
+  /** Kuvan otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3264,20 +3275,25 @@ export enum GeoJsonType {
   Polygon = 'Polygon',
 }
 
-/** Hero field */
+export type GlobalSidebarBlocksUnion =
+  | LayoutArticleHighlights
+  | LayoutArticles
+  | LayoutEditor;
+
+/** Hero kenttä */
 export type Hero = {
   __typename?: 'Hero';
-  /** The background color of the hero */
+  /** Hero taustaväri */
   background_color?: Maybe<Scalars['String']['output']>;
-  /** The background color of the hero */
+  /** Hero taustaväri */
   background_image_url?: Maybe<Scalars['String']['output']>;
-  /** The desctiption of the hero */
+  /** Hero sisältö */
   description?: Maybe<Scalars['String']['output']>;
-  /** The title of the hero link */
+  /** Hero linkin otsikko */
   link?: Maybe<Link>;
-  /** The title of the hero */
+  /** Hero otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** The wave motif of the hero */
+  /** Heron koro */
   wave_motif?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3615,22 +3631,22 @@ export enum IdentificationStrength {
   Unidentified = 'UNIDENTIFIED',
 }
 
-/** Image */
+/** Kuva */
 export type Image = {
   __typename?: 'Image';
-  /** Caption of the image */
+  /** Kuvan lainaus */
   caption?: Maybe<Scalars['String']['output']>;
-  /** Description of the image */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** The url of the large image */
+  /** Kuvan (large) URL-osoite */
   large?: Maybe<Scalars['String']['output']>;
-  /** The url of the medium image */
+  /** Kuvan (medium) URL-osoite */
   medium?: Maybe<Scalars['String']['output']>;
-  /** The url of the medium large image */
+  /** Kuvan (medium large) URL-osoite */
   medium_large?: Maybe<Scalars['String']['output']>;
-  /** The url of the thumbnail image */
+  /** Kuvan URL-osoite */
   thumbnail?: Maybe<Scalars['String']['output']>;
-  /** Title of the image */
+  /** Kuvan otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3693,7 +3709,7 @@ export type LandingPage = ContentNode &
   Previewable &
   UniformResourceIdentifiable & {
     __typename?: 'LandingPage';
-    /** Background Color */
+    /** Taustaväri */
     backgroundColor?: Maybe<Scalars['String']['output']>;
     /** Box Color */
     boxColor?: Maybe<Scalars['String']['output']>;
@@ -3707,7 +3723,7 @@ export type LandingPage = ContentNode &
     date?: Maybe<Scalars['String']['output']>;
     /** The publishing date set in GMT. */
     dateGmt?: Maybe<Scalars['String']['output']>;
-    /** Description */
+    /** Kuvaus */
     description?: Maybe<Scalars['String']['output']>;
     /** The desired slug of the post */
     desiredSlug?: Maybe<Scalars['String']['output']>;
@@ -3756,7 +3772,7 @@ export type LandingPage = ContentNode &
     modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
     modifiedGmt?: Maybe<Scalars['String']['output']>;
-    /** List of modules */
+    /** Moduulilistaus */
     modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
     /** Connection between the LandingPage type and the landingPage type */
     preview?: Maybe<LandingPageToPreviewConnectionEdge>;
@@ -4177,89 +4193,89 @@ export type LanguageString = {
 /** Layout: LayoutArticleHighlights */
 export type LayoutArticleHighlights = {
   __typename?: 'LayoutArticleHighlights';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Articles */
+  /** Artikkelit */
   articles?: Maybe<Array<Maybe<Post>>>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Category */
+  /** Kategoria */
   category?: Maybe<Scalars['Int']['output']>;
-  /** Amount of articles to list */
+  /** Valitse montako artikkelia näytetään */
   limit?: Maybe<Scalars['Int']['output']>;
-  /** Show more link */
+  /** Näytä lisää linkki */
   showMore?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Tag */
+  /** Tagi */
   tag?: Maybe<Scalars['Int']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutArticles */
 export type LayoutArticles = {
   __typename?: 'LayoutArticles';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Articles */
+  /** Artikkelit */
   articles?: Maybe<Array<Maybe<Post>>>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Category */
+  /** Kategoria */
   category?: Maybe<Scalars['Int']['output']>;
-  /** Tag */
+  /** Tagi */
   limit?: Maybe<Scalars['Int']['output']>;
-  /** Show all -link */
+  /** Näytä lisää linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Tag */
+  /** Tagi */
   tag?: Maybe<Scalars['Int']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutArticlesCarousel */
 export type LayoutArticlesCarousel = {
   __typename?: 'LayoutArticlesCarousel';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Articles */
+  /** Artikkelit */
   articles?: Maybe<Array<Maybe<Post>>>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Category */
+  /** Kategoria */
   category?: Maybe<Scalars['Int']['output']>;
-  /** Amount of articles to list */
+  /** Valitse montako artikkelia näytetään */
   limit?: Maybe<Scalars['Int']['output']>;
-  /** Show all -link */
+  /** Näytä lisää linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Show more link */
+  /** Näytä lisää linkki */
   showMore?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Tag */
+  /** Tagi */
   tag?: Maybe<Scalars['Int']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutCard */
 export type LayoutCard = {
   __typename?: 'LayoutCard';
-  /** Alignment */
+  /** Tasaus */
   alignment?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Image */
+  /** Kuva */
   image?: Maybe<Image>;
-  /** Link */
+  /** Linkki */
   link?: Maybe<Link>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutCards */
 export type LayoutCards = {
   __typename?: 'LayoutCards';
-  /** Cards */
+  /** Ikoni kortti */
   cards?: Maybe<Array<Maybe<Card>>>;
 };
 
@@ -4284,117 +4300,131 @@ export type LayoutContact = {
 /** Layout: LayoutContent */
 export type LayoutContent = {
   __typename?: 'LayoutContent';
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   content?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Layout: LayoutEditor */
+export type LayoutEditor = {
+  __typename?: 'LayoutEditor';
+  /** Editor */
+  editor?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutImage */
 export type LayoutImage = {
   __typename?: 'LayoutImage';
-  /** Border */
+  /** Reunus */
   border?: Maybe<Scalars['Boolean']['output']>;
-  /** Image */
+  /** Kuva */
   image?: Maybe<Image>;
-  /** Photographer name (overwrite) */
+  /** Valokuvaajan nimi (ylikirjoitus) */
   photographer_name?: Maybe<Scalars['String']['output']>;
-  /** Lightbox */
+  /** Näytä lighboxissa */
   show_on_lightbox?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Layout: LayoutImageGallery */
 export type LayoutImageGallery = {
   __typename?: 'LayoutImageGallery';
-  /** Gallery */
+  /** Galleria */
   gallery?: Maybe<Array<Maybe<GalleryImage>>>;
 };
 
 /** Layout: LayoutLinkList */
 export type LayoutLinkList = {
   __typename?: 'LayoutLinkList';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   description?: Maybe<Scalars['String']['output']>;
-  /** Links */
+  /** Linkit */
   links?: Maybe<Array<Maybe<Link>>>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Layout: LayoutMenu */
+export type LayoutMenu = {
+  __typename?: 'LayoutMenu';
+  /** Menu */
+  menu?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutPages */
 export type LayoutPages = {
   __typename?: 'LayoutPages';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Pages */
+  /** Sivut */
   pages?: Maybe<Array<Maybe<Page>>>;
-  /** Show all -link */
+  /** Näytä lisää linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutPagesCarousel */
 export type LayoutPagesCarousel = {
   __typename?: 'LayoutPagesCarousel';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Pages */
+  /** Sivut */
   pages?: Maybe<Array<Maybe<Page>>>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutSocialMediaFeed */
 export type LayoutSocialMediaFeed = {
   __typename?: 'LayoutSocialMediaFeed';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Script */
+  /** Scripti */
   script?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutSteps */
 export type LayoutSteps = {
   __typename?: 'LayoutSteps';
-  /** Color */
+  /** Väri */
   color?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Steps */
+  /** Vaiheistus */
   steps?: Maybe<Array<Maybe<Step>>>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** Type */
+  /** Tyyppi */
   type?: Maybe<Scalars['String']['output']>;
 };
 
 export type LegalEntity = Organisation | Person;
 
-/** Link field */
+/** Linkin kenttä */
 export type Link = {
   __typename?: 'Link';
-  /** The target of the link */
+  /** Linkin kohde */
   target?: Maybe<Scalars['String']['output']>;
-  /** The title of the link */
+  /** Linkin otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** The url of the link */
+  /** Linkin URL osoite */
   url?: Maybe<Scalars['String']['output']>;
 };
 
@@ -4492,27 +4522,27 @@ export type LocationImage = {
   url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: LocationsSelected */
+/** Kokoelmamoduuli: LocationsSelected */
 export type LocationsSelected = {
   __typename?: 'LocationsSelected';
   /** List of location IDs */
   locations?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   /** Module type */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Module title */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: LocationsSelectedCarousel */
+/** Kokoelmamoduuli: LocationsSelectedCarousel */
 export type LocationsSelectedCarousel = {
   __typename?: 'LocationsSelectedCarousel';
   /** List of location IDs */
   locations?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   /** Module type */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Module title */
   title?: Maybe<Scalars['String']['output']>;
@@ -5667,22 +5697,22 @@ export type NodeWithTitleTitleArgs = {
   format?: InputMaybe<PostObjectFieldFormatEnum>;
 };
 
-/** Describe what a CustomType is */
+/** Selitä mikä CustomType on */
 export type Notification = {
   __typename?: 'Notification';
-  /** Notification content */
+  /** Ilmoituksen sisältö */
   content?: Maybe<Scalars['String']['output']>;
-  /** Notification end date */
+  /** Ilmoituksen päättymispäivä */
   endDate?: Maybe<Scalars['String']['output']>;
-  /** Notification level */
+  /** Ilmoituksen tärkeys */
   level?: Maybe<Scalars['String']['output']>;
-  /** Notification link text */
+  /** Ilmoitus linkin teksti */
   linkText?: Maybe<Scalars['String']['output']>;
-  /** Notification link url */
+  /** Ilmoitus linkin url */
   linkUrl?: Maybe<Scalars['String']['output']>;
-  /** Notification start date */
+  /** Ilmoituksen aloituspäivä */
   startDate?: Maybe<Scalars['String']['output']>;
-  /** Notification title */
+  /** Ilmoituksen otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -5835,6 +5865,8 @@ export type Page = ContentNode &
     authorDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the author of the node */
     authorId?: Maybe<Scalars['ID']['output']>;
+    /** Breadcrumb fields */
+    breadcrumbs?: Maybe<Array<Maybe<Breadcrumb>>>;
     /** Connection between the HierarchicalContentNode type and the ContentNode type */
     children?: Maybe<HierarchicalContentNodeToContentNodeChildrenConnection>;
     /** The content of the post. */
@@ -5869,7 +5901,7 @@ export type Page = ContentNode &
     featuredImageId?: Maybe<Scalars['ID']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
     guid?: Maybe<Scalars['String']['output']>;
-    /** Hero fields */
+    /** Hero kentät */
     hero?: Maybe<Hero>;
     /** The globally unique identifier of the page object. */
     id: Scalars['ID']['output'];
@@ -5903,7 +5935,7 @@ export type Page = ContentNode &
     modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
     modifiedGmt?: Maybe<Scalars['String']['output']>;
-    /** List of modules */
+    /** Moduuli listaus */
     modules?: Maybe<Array<Maybe<PageModulesUnionType>>>;
     /**
      * The id field matches the WP_Post-&gt;ID field.
@@ -5930,7 +5962,7 @@ export type Page = ContentNode &
     seo?: Maybe<Seo>;
     /** Näytä alisivut */
     showChildPages?: Maybe<Scalars['Boolean']['output']>;
-    /** List of modules */
+    /** Moduuli listaus */
     sidebar?: Maybe<Array<Maybe<PageSidebarUnionType>>>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
     slug?: Maybe<Scalars['String']['output']>;
@@ -6339,6 +6371,8 @@ export type Post = ContentNode &
     authorDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the author of the node */
     authorId?: Maybe<Scalars['ID']['output']>;
+    /** Breadcrumb fields */
+    breadcrumbs?: Maybe<Array<Maybe<Breadcrumb>>>;
     /** Connection between the Post type and the category type */
     categories?: Maybe<PostToCategoryConnection>;
     /** The content of the post. */
@@ -6373,7 +6407,7 @@ export type Post = ContentNode &
     featuredImageId?: Maybe<Scalars['ID']['output']>;
     /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
     guid?: Maybe<Scalars['String']['output']>;
-    /** Hide Published Date */
+    /** Piilota julkaisupäivämäärä */
     hidePublishedDate?: Maybe<Scalars['Boolean']['output']>;
     /** The globally unique identifier of the post object. */
     id: Scalars['ID']['output'];
@@ -6401,7 +6435,7 @@ export type Post = ContentNode &
     modified?: Maybe<Scalars['String']['output']>;
     /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
     modifiedGmt?: Maybe<Scalars['String']['output']>;
-    /** List of modules */
+    /** Moduuli listaus */
     modules?: Maybe<Array<Maybe<PostModulesUnionType>>>;
     /** Connection between the Post type and the postFormat type */
     postFormats?: Maybe<PostToPostFormatConnection>;
@@ -6422,7 +6456,7 @@ export type Post = ContentNode &
     revisions?: Maybe<PostToRevisionConnection>;
     /** The SEO Framework data of the post */
     seo?: Maybe<Seo>;
-    /** List of modules */
+    /** Moduuli listaus */
     sidebar?: Maybe<Array<Maybe<PostSidebarUnionType>>>;
     /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
     slug?: Maybe<Scalars['String']['output']>;
@@ -7459,7 +7493,7 @@ export type Query = {
   categories?: Maybe<RootQueryToCategoryConnection>;
   /** A 0bject */
   category?: Maybe<Category>;
-  /** An object of the collection Type. Collections */
+  /** An object of the collection Type. Kokoelmat */
   collection?: Maybe<Collection>;
   /**
    * A collection object
@@ -7472,7 +7506,7 @@ export type Query = {
   comment?: Maybe<Comment>;
   /** Connection between the RootQuery type and the Comment type */
   comments?: Maybe<RootQueryToCommentConnection>;
-  /** An object of the contact Type. Contacts */
+  /** An object of the contact Type. Yhteystiedot */
   contact?: Maybe<Contact>;
   /**
    * A contact object
@@ -7489,7 +7523,7 @@ export type Query = {
   contentType?: Maybe<ContentType>;
   /** Connection between the RootQuery type and the ContentType type */
   contentTypes?: Maybe<RootQueryToContentTypeConnection>;
-  /** Default Images */
+  /** Oletuskuvat */
   defaultImages?: Maybe<DefaultImages>;
   /** Get language list */
   defaultLanguage?: Maybe<Language>;
@@ -7498,11 +7532,15 @@ export type Query = {
   eventDetails: EventDetails;
   eventList: EventListResponse;
   eventsByIds: EventListResponse;
+  /** Footer blocks */
+  footerBlocks?: Maybe<Array<Maybe<FooterBlocksUnion>>>;
   /** Fields of the &#039;GeneralSettings&#039; settings group */
   generalSettings?: Maybe<GeneralSettings>;
+  /** Global Sidebar blocks */
+  globalSidebarBlocks?: Maybe<Array<Maybe<GlobalSidebarBlocksUnion>>>;
   keywordDetails: Keyword;
   keywordList: KeywordListResponse;
-  /** An object of the landingPage Type. Landing Pages */
+  /** An object of the landingPage Type. Laskeutumissivut */
   landingPage?: Maybe<LandingPage>;
   /**
    * A landingPage object
@@ -7546,7 +7584,7 @@ export type Query = {
    * @deprecated Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)
    */
   pageBy?: Maybe<Page>;
-  /** Returns ID of page that uses the given template */
+  /** Palauttaa sivun ID:n, joka käyttää annettua sivupohjaa */
   pageByTemplate?: Maybe<Page>;
   /** Connection between the RootQuery type and the page type */
   pages?: Maybe<RootQueryToPageConnection>;
@@ -7575,7 +7613,7 @@ export type Query = {
   registeredScripts?: Maybe<RootQueryToEnqueuedScriptConnection>;
   /** Connection between the RootQuery type and the EnqueuedStylesheet type */
   registeredStylesheets?: Maybe<RootQueryToEnqueuedStylesheetConnection>;
-  /** An object of the release Type. Releases */
+  /** An object of the release Type. Tiedotteet */
   release?: Maybe<Release>;
   /**
    * A release object
@@ -7588,7 +7626,7 @@ export type Query = {
   revisions?: Maybe<RootQueryToRevisionsConnection>;
   /** The SEO Framework settings */
   seoSettings?: Maybe<SeoSettings>;
-  /** Site Settings */
+  /** Sivuston asetukset */
   siteSettings?: Maybe<SiteSettings>;
   /** A 0bject */
   tag?: Maybe<Tag>;
@@ -7608,7 +7646,7 @@ export type Query = {
   themes?: Maybe<RootQueryToThemeConnection>;
   /** Translate string using pll_translate_string() (Polylang) */
   translateString?: Maybe<Scalars['String']['output']>;
-  /** An object of the translation Type. Translations */
+  /** An object of the translation Type. Käännökset */
   translation?: Maybe<Translation>;
   /**
    * A translation object
@@ -7828,6 +7866,16 @@ export type QueryEventsByIdsArgs = {
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;
   start?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** The root entry point into the Graph */
+export type QueryFooterBlocksArgs = {
+  language: Scalars['String']['input'];
+};
+
+/** The root entry point into the Graph */
+export type QueryGlobalSidebarBlocksArgs = {
+  language: Scalars['String']['input'];
 };
 
 /** The root entry point into the Graph */
@@ -10189,12 +10237,12 @@ export type StaticPage = {
   urlPath?: Maybe<Scalars['String']['output']>;
 };
 
-/** Step field */
+/** Vaiheen kenttä */
 export type Step = {
   __typename?: 'Step';
-  /** The content of the step */
+  /** Vaiheen sisältö */
   content?: Maybe<Scalars['String']['output']>;
-  /** The title of the step */
+  /** Vaiheen otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -10616,7 +10664,7 @@ export type TaxonomyToContentTypeConnectionEdge = ContentTypeConnectionEdge &
     node: ContentType;
   };
 
-/** Get page object by template */
+/** Hae sivuobjekti sivupohjan mukaan */
 export enum TemplateEnum {
   FrontPage = 'frontPage',
   PostsPage = 'postsPage',
@@ -10906,7 +10954,7 @@ export type Translation = ContentNode &
      * @deprecated Deprecated in favor of the databaseId field
      */
     translationId: Scalars['Int']['output'];
-    /** Translations */
+    /** Käännökset */
     translations?: Maybe<Array<Maybe<TranslationResponse>>>;
     /** The unique resource identifier path */
     uri?: Maybe<Scalars['String']['output']>;
@@ -10970,23 +11018,23 @@ export enum TranslationIdType {
   Uri = 'URI',
 }
 
-/** Translation with language/value pairs */
+/** Käännöksen kieli/arvo-parit */
 export type TranslationItems = {
   __typename?: 'TranslationItems';
-  /** Translation string */
+  /** Käännöksen merkkijono */
   en?: Maybe<Scalars['String']['output']>;
-  /** Translation string */
+  /** Käännöksen merkkijono */
   fi?: Maybe<Scalars['String']['output']>;
-  /** Translation string */
+  /** Käännöksen merkkijono */
   sv?: Maybe<Scalars['String']['output']>;
 };
 
-/** Translation response contains translation key and translations */
+/** Käännösvastaus sisältää käännösavaimen ja käännökset */
 export type TranslationResponse = {
   __typename?: 'TranslationResponse';
-  /** Translation key for frontend */
+  /** Käyttöliittymän käännösavain */
   key?: Maybe<Scalars['String']['output']>;
-  /** Translations for frontend */
+  /** Käännökset käyttöliittymälle */
   translations?: Maybe<TranslationItems>;
 };
 
@@ -11173,7 +11221,7 @@ export type UpdateCategoryPayload = {
 export type UpdateCollectionInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the collection object */
   id: Scalars['ID']['input'];
@@ -11215,7 +11263,7 @@ export type UpdateCommentInput = {
   commentOn?: InputMaybe<Scalars['Int']['input']>;
   /** Content of the comment. */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day ( e.g. 01/31/2017 ) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the comment being updated. */
   id: Scalars['ID']['input'];
@@ -11242,7 +11290,7 @@ export type UpdateCommentPayload = {
 export type UpdateContactInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the contact object */
   id: Scalars['ID']['input'];
@@ -11272,7 +11320,7 @@ export type UpdateContactPayload = {
 export type UpdateLandingPageInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the landingPage object */
   id: Scalars['ID']['input'];
@@ -11352,7 +11400,7 @@ export type UpdatePageInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the page object */
   id: Scalars['ID']['input'];
@@ -11415,7 +11463,7 @@ export type UpdatePostInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the post object */
   id: Scalars['ID']['input'];
@@ -11451,7 +11499,7 @@ export type UpdateReleaseInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** The content of the object */
   content?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the release object */
   id: Scalars['ID']['input'];
@@ -11564,7 +11612,7 @@ export type UpdateTagPayload = {
 export type UpdateTranslationInput = {
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 */
+  /** The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17  */
   date?: InputMaybe<Scalars['String']['input']>;
   /** The ID of the translation object */
   id: Scalars['ID']['input'];
@@ -12346,7 +12394,7 @@ export enum UsersConnectionSearchColumnEnum {
   Login = 'LOGIN',
   /** A URL-friendly name for the user. The default is the user's username. */
   Nicename = 'NICENAME',
-  /** The URL of the user's website. */
+  /** The URL of the user\s website. */
   Url = 'URL',
 }
 

--- a/packages/components/src/utils/headless-cms/HeadlessCMSHelper.tsx
+++ b/packages/components/src/utils/headless-cms/HeadlessCMSHelper.tsx
@@ -1,4 +1,5 @@
 import format from 'date-fns/format';
+import type { BreadcrumbListItem } from 'hds-react';
 import parse from 'html-react-parser';
 import React from 'react';
 import type {
@@ -28,6 +29,17 @@ import {
   LocationsSelectionCollection,
 } from 'react-helsinki-headless-cms';
 import type { AppLanguage } from '../../types';
+
+/**
+ * A braedcrumb title of article archive in every language.
+ * @deprecated Needed only while the CMS does not offer the article archive in the breadcrumb module.
+ * */
+export const defaultArticleArchiveBreadcrumbTitle: Record<AppLanguage, string> =
+  {
+    fi: 'Artikkelit',
+    sv: 'Artiklar',
+    en: 'Articles',
+  };
 
 export interface HeadlessCMSApp {
   cmsArticlesContextPath: string;
@@ -247,5 +259,28 @@ export class HeadlessCMSHelper {
       }
       return collectionElements;
     }, []);
+  }
+
+  /**
+   * The article archive should always be the second item in the breadcrumbs list.
+   * If the article archive is missing from the breadcrumbs, but is wanted to be included,
+   * the withArticleArchiveBreadcrumb forces the article archive breadcrumb.
+   * @deprecated The breadcrumbs should be handled from the CMS-site and the HCRC-lib takes care of it.
+   * While the article archive is never included in the breadcrumbs that the CMS serves,
+   * this method fullfills the need.
+   * */
+  withArticleArchiveBreadcrumb(
+    breadcrumbs: BreadcrumbListItem[],
+    articlesTitle: string
+  ) {
+    if (breadcrumbs[1].path !== this.cmsArticlesContextPath) {
+      const [firstItem, ...rest] = breadcrumbs;
+      const articleArchive: BreadcrumbListItem = {
+        title: articlesTitle,
+        path: this.cmsArticlesContextPath,
+      };
+      return [firstItem, articleArchive, ...rest];
+    }
+    return breadcrumbs;
   }
 }

--- a/packages/components/src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx
+++ b/packages/components/src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx
@@ -1,0 +1,51 @@
+import type { Breadcrumb } from 'react-helsinki-headless-cms';
+import getFilteredBreadcrumbs, {
+  defaultExcludedBreadcrumbPaths,
+} from '../getFilteredBreadcrumbs';
+
+describe('defaultExcludedBreadcrumbPaths', () => {
+  it.each(['/pages', '/fi/pages', '/sv/pages', '/en/pages'])(
+    'contains %s',
+    (pathname) => {
+      expect(defaultExcludedBreadcrumbPaths).toContain(pathname);
+    }
+  );
+});
+
+describe('getFilteredBreadcrumbs', () => {
+  describe('uses defaultExcludedBreadcrumbPaths as default list of excluded paths', () => {
+    it.each<[Breadcrumb[], Breadcrumb[]]>([
+      [
+        [
+          { title: 'Etusivu', link: '/fi/' },
+          { title: 'Pages', link: '/fi/pages/' },
+        ],
+        [{ title: 'Etusivu', link: '/fi/' }],
+      ],
+      [
+        [
+          { title: 'Etusivu', link: '/' },
+          { title: 'Pages', link: '/pages/' },
+        ],
+        [{ title: 'Etusivu', link: '/' }],
+      ],
+      [
+        [
+          { title: '/pages', link: '/pages' },
+          { title: '/fi/pages', link: '/fi/pages' },
+          { title: '/fi/pages/', link: '/fi/pages/' },
+          { title: '/sv/pages', link: '/sv/pages' },
+          { title: '/sv/pages/', link: '/sv/pages/' },
+          { title: '/en/pages', link: '/en/pages' },
+          { title: '/en/pages/', link: '/en/pages/' },
+        ],
+        [],
+      ],
+    ])(
+      'removes the defaultExcludedBreadcrumbPaths from the given breadcrumbs - %#',
+      (breadcrumbs, result) => {
+        expect(getFilteredBreadcrumbs(breadcrumbs)).toStrictEqual(result);
+      }
+    );
+  });
+});

--- a/packages/components/src/utils/headless-cms/getFilteredBreadcrumbs.tsx
+++ b/packages/components/src/utils/headless-cms/getFilteredBreadcrumbs.tsx
@@ -1,0 +1,30 @@
+import type { BreadcrumbListItem } from 'hds-react';
+import { APP_LANGUAGES } from '../../constants';
+
+const defaultExcludedBreadcrumbBasePaths = ['/pages'];
+
+export const defaultExcludedBreadcrumbPaths = [
+  ...defaultExcludedBreadcrumbBasePaths,
+  ...defaultExcludedBreadcrumbBasePaths
+    .map((pathname) => APP_LANGUAGES.map((lang) => `/${lang}${pathname}`))
+    .flat(),
+];
+
+/**
+ *
+ * @param breadcrumbs
+ * @param excludedPaths paths to be excluded from the list of breadcrumbs. Defaults to `defaultExcludedBreadcrumbPaths`.
+ * @returns a filtered list of breadcrumb objects
+ */
+export default function getFilteredBreadcrumbs(
+  breadcrumbs: BreadcrumbListItem[],
+  excludedPaths = defaultExcludedBreadcrumbPaths
+) {
+  // new RegExp(`${breadcrumb.path}((/w+)+|/?)$`, 'g');
+  return breadcrumbs.filter(
+    (breadcrumb) =>
+      !breadcrumb.path ||
+      (!excludedPaths.includes(breadcrumb.path) &&
+        !excludedPaths.includes(breadcrumb.path.replace(/\/$/, '')))
+  );
+}

--- a/packages/components/src/utils/headless-cms/index.tsx
+++ b/packages/components/src/utils/headless-cms/index.tsx
@@ -1,3 +1,4 @@
 export * from './service';
 export * from './HeadlessCMSHelper';
 export * from './HeadlessCmsRoutedAppHelper';
+export { default as getFilteredBreadcrumbs } from './getFilteredBreadcrumbs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,7 +3326,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha255"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -14035,7 +14035,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha255"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -15910,7 +15910,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha255"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -23042,9 +23042,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha255":
-  version: 1.0.0-alpha255
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha255"
+"react-helsinki-headless-cms@npm:1.0.0-alpha256-canary-b81812e":
+  version: 1.0.0-alpha256-canary-b81812e
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha256-canary-b81812e"
   dependencies:
     hds-design-tokens: "npm:^3.5.0"
     html-entities: "npm:^2.4.0"
@@ -23061,7 +23061,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: facc59231404aff3922212340c5bbaf837351b6e0f530e324ae3c93d9c417967f6aa7e1479a25c104b9f8cc986c620e1a7879f5945a145c1b4f94cc8dd0eccc5
+  checksum: 9e9e96d8002600db3fb66b902f6f3bd7fc2feb67cac3fe37e7b6632c36fdd429834ffe557d2e4309e455829c40d0223fb86c8e0354912cecb6452145b167d970
   languageName: node
   linkType: hard
 
@@ -25119,7 +25119,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha255"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,7 +3326,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha259"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -14035,7 +14035,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha259"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -15910,7 +15910,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha259"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -23042,9 +23042,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0-alpha256-canary-b81812e":
-  version: 1.0.0-alpha256-canary-b81812e
-  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha256-canary-b81812e"
+"react-helsinki-headless-cms@npm:1.0.0-alpha259":
+  version: 1.0.0-alpha259
+  resolution: "react-helsinki-headless-cms@npm:1.0.0-alpha259"
   dependencies:
     hds-design-tokens: "npm:^3.5.0"
     html-entities: "npm:^2.4.0"
@@ -23061,7 +23061,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: 9e9e96d8002600db3fb66b902f6f3bd7fc2feb67cac3fe37e7b6632c36fdd429834ffe557d2e4309e455829c40d0223fb86c8e0354912cecb6452145b167d970
+  checksum: 743081990001538922e49e99a68fe51459918a64111fa315c3021715682721dec8d279aac21a93b47dbe4bc189a42236c4760729f7f9dd68924902077682a806
   languageName: node
   linkType: hard
 
@@ -25119,7 +25119,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0-alpha256-canary-b81812e"
+    react-helsinki-headless-cms: "npm:1.0.0-alpha259"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"


### PR DESCRIPTION
NOTE: Depends on router changes of https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/650 and HCRC-lib changes of https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/165

LIIKUNTA-611.

The HDS breadcrumbs are used from HCRC-lib.

The dynamic CMS pages and the CMS articles now renders
the breadcrumbs that the CMS API offers.

The page and article query is defined in the RCHC-lib
and the RCHC-lib also takes cares of duplicates links in a list of
breadcrumbs, since there could be for example a duplicated root / home.

The common-packages package removes some excluded paths, since
the `/pages` path is not wanted to be included in the breadcrumbs.

Other features added:
- Force add the article archive list item in the breadcrumbs
of any CMS article page.
- Add breadcrumbs to article archive page
- Add breadcrumbs to search page
- Add breadcrumbs to venue details page
- Add breadcrumbs to event and course detail pages
- Add breadcrumbs to cookie consent page

----
### Desktop view of a 3rd level page

The full breadcrumb is visible

<img width="1118" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/b6b3e086-46bb-4ca6-8c7b-6b9bc1707448">

### Mobile view of a 3rd level page

The parent page is visible in the breadcrumb. The rest of the breadcrumbs are hidden. This feature comes from the HDS.

<img width="445" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/2873f327-a46d-4366-9f32-4089855343c7">

### Translations of the breadcrumbs

The translations are taken care of

<img width="1122" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/7647f773-4bec-4642-adca-15918be8f2ae">


<img width="1121" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/81b000a6-bd62-4f10-b282-39a09fc174ee">

<img width="1114" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/7cba3277-792c-4c58-a814-b2640eb96341">

### Article archive

The article archive has a special breadcrumbs handling because the articles does not have the breadcrumbs feature in CMS yet.

<img width="1115" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/2148446e-bf8a-4c97-bfdd-f9499350c2fb">

In Swedish

<img width="1114" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/36fadce1-203b-488b-b417-a64cff74e00e">

### Articles

The article has a special breadcrumbs handling because the articles does not have the breadcrumbs feature in CMS yet. The archive is added in the breadcrumbs manually.

<img width="1115" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/07fae174-b932-46f1-b81e-c21b6d24d140">


<img width="1119" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/1b7cc5cd-31c9-4a8f-b51c-0bd7ebda94a7">


### Search page

The breadcrumbs are fetched from the search cms page

<img width="1123" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/078d29df-d7f2-409a-82fa-68ca596b2f12">

Swedish -- the translations are taken care of

<img width="1116" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/11f666d0-baad-431f-908d-f2363e450e72">


### Venue details

<img width="1247" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/44b472f7-b068-4e7f-b6b5-a998c7f3c0d3">

<img width="1040" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/980e3969-d04f-410e-aebe-2e3aca65d5bf">

<img width="754" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/0087e88f-4b87-4efd-ab50-a1c0b5b2ee1b">


### Event and course details

<img width="1258" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/74e1ad58-c2cd-4cc2-a162-adc9f770e40a">

Smaller view

<img width="950" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/192299e2-e7de-42eb-9343-ac4e1be0d503">

Smallest view

<img width="714" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/c877721e-81cf-4bbc-abbd-1327d2607c4f">

in Swedish

<img width="964" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/562cbb24-dba6-4f53-92c8-58e2afe529e0">

### Cookie consent page

<img width="1120" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/50a2b873-ff76-47a2-9b44-98d413cf10f8">

<img width="1115" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/389204/55c37293-1266-4258-a323-1945a492a51f">

