### PR TITLE
LIIKUNTA-627 | fix: fix margin only in header navigation menu's top level buttons

### DIFF
--- a/packages/components/src/components/navigation/navigation.module.scss
+++ b/packages/components/src/components/navigation/navigation.module.scss
@@ -3,7 +3,15 @@
   a:hover > span {
     color: var(--colors-white);
   }
-  button {
-    margin: 0 0 0 var(--spacing-s) !important;
+
+  // Match only the header navigation menu,
+  // e.g. "HeaderNavigationMenu-module_headerNavigationMenu__3G6-N"
+  // in order to exclude header action bar with language selector & header universal bar
+  nav[class*='HeaderNavigationMenu'] {
+    // Match only top level buttons in header navigation menu,
+    // e.g. "HeaderLinkDropdown-module_depth-0__Xeyks"
+    button[class*='depth-0'] {
+      margin: 0 0 0 var(--spacing-s) !important;
+    }
   }
 }


### PR DESCRIPTION
## Description

### fix: fix margin only in header navigation menu's top level buttons

refs LIIKUNTA-627

## Issues

### Closes

### Related

[LIIKUNTA-627](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-627)

## Testing

### Automated tests

### Manual testing

## Screenshots

![image](https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/77663720/0c9388a8-2924-4e16-b3ef-27a3269fc0a0)

## Additional notes


[LIIKUNTA-627]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ