### PR TITLE
HH-352 | fix: archive search button styles

### DIFF
--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -34,6 +34,8 @@ main {
   --hcrc-color-link-show-all: var(--color-coat-of-arms-dark);
   --hcrc-color-hero-bg: var(--color-theme-background);
   --hcrc-color-archive-search-bg: var(--color-theme-background);
+  --hcrc-color-archive-search-btn: var(--color-coat-of-arms);
+  --hcrc-color-archive-search-btn-hover: var(--color-coat-of-arms-dark);
   /*no need to defined btn colors variables as default coat of arms style is in use*/
 }
 


### PR DESCRIPTION
## Description
<img width="1285" alt="image" src="https://github.com/City-of-Helsinki/events-helsinki-monorepo/assets/16116141/b68c3f18-cfdb-484a-9292-6c98b801da11">


## Issues

### Closes

**[HH-352](https://helsinkisolutionoffice.atlassian.net/browse/HH-352):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-352]: https://helsinkisolutionoffice.atlassian.net/browse/HH-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ