### PR TITLE
HH-341 | fix: missing translations and load more logic

### DIFF
--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -256,12 +256,7 @@ export default function ArticleArchive({
                 />
               );
             }}
-            hasMore={Boolean(
-              !isLoading &&
-                articles?.length &&
-                articles?.length > 0 &&
-                hasMoreToLoad
-            )}
+            hasMore={Boolean(!isLoading && articles?.length && hasMoreToLoad)}
           />
         </>
       }

--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -256,7 +256,12 @@ export default function ArticleArchive({
                 />
               );
             }}
-            hasMore={hasMoreToLoad}
+            hasMore={Boolean(
+              !isLoading &&
+                articles?.length &&
+                articles?.length > 0 &&
+                hasMoreToLoad
+            )}
           />
         </>
       }

--- a/packages/common-i18n/src/locales/en/cms.json
+++ b/packages/common-i18n/src/locales/en/cms.json
@@ -6,8 +6,8 @@
     "searchTextPlaceholder": "Search text",
     "searchButtonLabelText": "Search",
     "loadMoreButtonLabelText": "Load more",
-    "noResultsTitle": "Valitsemillasi hakuehdoilla ei löytynyt ajankohtaisia aiheita",
-    "noResultsText": "Voit koittaa muuttaa tai vähentää hakuehtoja.",
+    "noResultsTitle": "No current topics were found with your search criteria.",
+    "noResultsText": "Please try changing or reducing the number of search criteria.",
     "buttonClearFilters": "Clear filters"
   }
 }

--- a/packages/common-i18n/src/locales/fi/cms.json
+++ b/packages/common-i18n/src/locales/fi/cms.json
@@ -6,7 +6,7 @@
     "searchTextPlaceholder": "Hakusana",
     "searchButtonLabelText": "Hae",
     "loadMoreButtonLabelText": "Lataa lisää",
-    "noResultsTitle": "Valitsemillasi hakuehdoilla ei löytynyt ajankohtaisia aiheita",
+    "noResultsTitle": "Valitsemillasi hakuehdoilla ei löytynyt ajankohtaisia aiheita.",
     "noResultsText": "Voit koittaa muuttaa tai vähentää hakuehtoja.",
     "buttonClearFilters": "Tyhjennä hakuehdot"
   }

--- a/packages/common-i18n/src/locales/sv/cms.json
+++ b/packages/common-i18n/src/locales/sv/cms.json
@@ -6,7 +6,8 @@
     "searchTextPlaceholder": "Söktext",
     "searchButtonLabelText": "Sök",
     "loadMoreButtonLabelText": "Ladda mer",
-    "noResultsText": "Inga resultat",
+    "noResultsTitle": "Med de sökkriterier du valde hittades inga aktuella ämnen.",
+    "noResultsText": "Du kan försöka ändra eller minska på antalet sökkriterier.",
     "buttonClearFilters": "Töm sökfilter"
   }
 }


### PR DESCRIPTION
## Description
- Added missing translations for no results article search page
- Fixed the logic of visibility of load more button

## Issues
Note: in the ticket there is extra issue with inconsistent Menu and breadcrumb labels, but its not a bug, menu is configured in cms. 

### Closes

**[HH-341](https://helsinkisolutionoffice.atlassian.net/browse/HH-341)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-341]: https://helsinkisolutionoffice.atlassian.net/browse/HH-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ