### PR TITLE
LIIKUNTA-647 | feat: show neighborhood, not district in Linked Events location info

### DIFF
--- a/apps/events-helsinki/src/domain/event/eventDetails/EventDetails.tsx
+++ b/apps/events-helsinki/src/domain/event/eventDetails/EventDetails.tsx
@@ -54,7 +54,7 @@ const EventDetails: React.FC<EventDetailsProps> = (props) => {
             <div className={styles.text}>
               <LocationText
                 event={event}
-                showDistrict={false}
+                showNeighborhood={false}
                 showLocationName
               />
             </div>

--- a/apps/hobbies-helsinki/src/domain/event/eventDetails/EventDetails.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/eventDetails/EventDetails.tsx
@@ -55,7 +55,7 @@ const EventDetails: React.FC<EventDetailsProps> = (props) => {
             <div className={styles.text}>
               <LocationText
                 event={event}
-                showDistrict={false}
+                showNeighborhood={false}
                 showLocationName
               />
             </div>

--- a/apps/sports-helsinki/src/domain/event/eventDetails/EventDetails.tsx
+++ b/apps/sports-helsinki/src/domain/event/eventDetails/EventDetails.tsx
@@ -54,7 +54,7 @@ const EventDetails: React.FC<EventDetailsProps> = (props) => {
             <div className={styles.text}>
               <LocationText
                 event={event}
-                showDistrict={false}
+                showNeighborhood={false}
                 showLocationName
               />
             </div>

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -25,7 +25,6 @@
     "checkboxOnlyRemoteEvents": "Show only remote events",
     "labelCategory": "What kind of event you are looking for?",
     "labelDateRange": "For what period you are looking for?",
-    "labelDistrict": "From where are you looking for?",
     "labelTargetGroup": "Whom you are looking for?",
     "selectAllDivisions": "All areas",
     "selectAllPlaces": "All venues",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -38,7 +38,6 @@
     "checkboxOnlyRemoteEvents": "Näytä vain etätapahtumat",
     "labelCategory": "Millaista haet?",
     "labelDateRange": "Mille ajankohdalle etsit?",
-    "labelDistrict": "Mistä etsit?",
     "labelTargetGroup": "Kenelle etsit?",
     "selectAllDivisions": "Kaikki alueet",
     "selectAllPlaces": "Kaikki tapahtumapaikat",

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -25,7 +25,6 @@
     "checkboxOnlyRemoteEvents": "Visa enbart distansevenemang",
     "labelCategory": "Vilken typ av evenemang du letar efter?",
     "labelDateRange": "För vilken period du letar efter?",
-    "labelDistrict": "Varifrån letar du efter??",
     "labelTargetGroup": "Vem du letar efter?",
     "selectAllDivisions": "Alla områden",
     "selectAllPlaces": "Alla ställen",

--- a/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -14,7 +14,7 @@ const description = 'Event description';
 const email = 'test@email.com';
 const telephone = '0441234567';
 const addressLocality = 'Helsinki';
-const district = 'Malmi';
+const neighborhood = 'Malmi';
 const locationName = 'Location name';
 const streetAddress = 'Test address 1';
 const photographerName = 'Kuvaaja Helsinki';
@@ -24,7 +24,7 @@ const event = fakeEvent({
   description: { fi: description },
   publisher: '',
   location: {
-    divisions: [{ name: { fi: district }, type: 'neighborhood' }],
+    divisions: [{ name: { fi: neighborhood }, type: 'neighborhood' }],
     email,
     telephone: { fi: telephone },
     internalId: 'tprek:8740',
@@ -74,7 +74,7 @@ it('should render event content fields', async () => {
   const itemsByText = [
     description,
     `Kuva: ${photographerName}`,
-    [streetAddress, district, addressLocality].join(', '),
+    [streetAddress, neighborhood, addressLocality].join(', '),
   ];
 
   itemsByText.forEach((item) => {

--- a/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
@@ -108,7 +108,7 @@ const DateInfo: React.FC<{
   const { getPlainEventUrl } = useAppRoutingContext();
   const {
     addressLocality,
-    district,
+    neighborhood,
     endTime,
     locationName,
     name,
@@ -126,7 +126,7 @@ const DateInfo: React.FC<{
           link: `${domain}${getPlainEventUrl(event, locale)}`,
         }),
         end: endTime ? getDateArray(endTime) : getDateArray(startTime),
-        location: [locationName, streetAddress, district, addressLocality]
+        location: [locationName, streetAddress, neighborhood, addressLocality]
           .filter((e) => e)
           .join(', '),
         productId: domain,
@@ -174,7 +174,7 @@ const LocationInfo: React.FC<{ event: EventFields }> = ({ event }) => {
   const { t } = useTranslation('event');
   const locale = useLocale();
 
-  const { addressLocality, district, locationName, streetAddress } =
+  const { addressLocality, neighborhood, locationName, streetAddress } =
     getEventFields(event, locale);
 
   const serviceMapUrl = getServiceMapUrl(event, locale, false);
@@ -185,12 +185,12 @@ const LocationInfo: React.FC<{ event: EventFields }> = ({ event }) => {
       title={t('info.labelLocation')}
     >
       <Visible below="s">
-        {[locationName, streetAddress, district, addressLocality]
+        {[locationName, streetAddress, neighborhood, addressLocality]
           .filter((e) => e)
           .join(', ')}
       </Visible>
       <Visible above="s">
-        {[locationName, streetAddress, district, addressLocality]
+        {[locationName, streetAddress, neighborhood, addressLocality]
           .filter((e) => e)
           .map((item) => {
             return <div key={item}>{item}</div>;

--- a/packages/components/src/components/domain/event/eventInfo/utils/EventInfo.mocks.ts
+++ b/packages/components/src/components/domain/event/eventInfo/utils/EventInfo.mocks.ts
@@ -37,7 +37,7 @@ export const endTime = '2020-06-22T10:00:00.000000Z';
 export const email = 'test@email.com';
 export const telephone = '0441234567';
 export const addressLocality = 'Helsinki';
-export const district = 'Malmi';
+export const neighborhood = 'Malmi';
 export const locationName = 'Location name';
 export const streetAddress = 'Test address 1';
 export const price = '12 €';
@@ -56,7 +56,7 @@ export const event = fakeEvent({
   provider: { fi: organizerName },
   publisher: organizationId,
   location: {
-    divisions: [{ name: { fi: district }, type: 'neighborhood' }],
+    divisions: [{ name: { fi: neighborhood }, type: 'neighborhood' }],
     email,
     telephone: { fi: telephone },
     internalId: 'tprek:8740',

--- a/packages/components/src/components/domain/event/eventLocation/EventLocation.tsx
+++ b/packages/components/src/components/domain/event/eventLocation/EventLocation.tsx
@@ -18,16 +18,16 @@ interface Props {
 export const getLocationStr = (
   event: EventFields,
   locale: AppLanguage,
-  showDistrict: boolean,
+  showNeighborhood: boolean,
   showLocationName: boolean
 ) => {
-  const { addressLocality, district, locationName, streetAddress } =
+  const { addressLocality, neighborhood, locationName, streetAddress } =
     getEventFields(event, locale);
 
   return [
     showLocationName ? locationName : null,
     streetAddress,
-    showDistrict ? district : null,
+    showNeighborhood ? neighborhood : null,
     addressLocality,
   ]
     .filter((e) => e)

--- a/packages/components/src/components/domain/event/eventLocation/EventLocationText.tsx
+++ b/packages/components/src/components/domain/event/eventLocation/EventLocationText.tsx
@@ -6,25 +6,25 @@ import { getEventFields } from '../../../../utils';
 
 interface Props {
   event: EventFields;
-  showDistrict: boolean;
+  showNeighborhood: boolean;
   showLocationName: boolean;
 }
 
 const EventLocationText: React.FC<Props> = ({
   event,
-  showDistrict,
+  showNeighborhood,
   showLocationName,
 }) => {
   const locale = useLocale();
 
   const getLocationStr = () => {
-    const { addressLocality, district, locationName, streetAddress } =
+    const { addressLocality, neighborhood, locationName, streetAddress } =
       getEventFields(event, locale);
 
     return [
       showLocationName ? locationName : null,
       streetAddress,
-      showDistrict ? district : null,
+      showNeighborhood ? neighborhood : null,
       addressLocality,
     ]
       .filter((e) => e)

--- a/packages/components/src/components/domain/event/eventLocation/__tests__/EventLocationText.test.tsx
+++ b/packages/components/src/components/domain/event/eventLocation/__tests__/EventLocationText.test.tsx
@@ -21,7 +21,7 @@ it('should render event location text', () => {
   const { container } = render(
     <EventLocationText
       event={event}
-      showDistrict={true}
+      showNeighborhood={true}
       showLocationName={true}
     />
   );

--- a/packages/components/src/components/eventCard/EventCard.tsx
+++ b/packages/components/src/components/eventCard/EventCard.tsx
@@ -71,7 +71,7 @@ const EventCard: React.FC<EventCardProps> = ({ event, eventUrl }) => {
               <div className={styles.eventLocation}>
                 <EventLocationText
                   event={event}
-                  showDistrict={false}
+                  showNeighborhood={false}
                   showLocationName={true}
                 />
               </div>

--- a/packages/components/src/components/eventCard/LargeEventCard.tsx
+++ b/packages/components/src/components/eventCard/LargeEventCard.tsx
@@ -77,7 +77,7 @@ const LargeEventCard: React.FC<LargeEventCardProps> = ({
               <IconLocation aria-hidden />
               <EventLocationText
                 event={event}
-                showDistrict={false}
+                showNeighborhood={false}
                 showLocationName={true}
               />
             </div>

--- a/packages/components/src/components/eventHero/EventHero.tsx
+++ b/packages/components/src/components/eventHero/EventHero.tsx
@@ -130,7 +130,7 @@ const EventHero: React.FC<EventHeroProps> = ({
                     >
                       <EventLocationText
                         event={event}
-                        showDistrict={false}
+                        showNeighborhood={false}
                         showLocationName={true}
                       />
                     </InfoWithIcon>

--- a/packages/components/src/utils/eventUtils.ts
+++ b/packages/components/src/utils/eventUtils.ts
@@ -186,35 +186,32 @@ export const getEventSomeImageUrl = (event: EventFields): string => {
 };
 
 /**
- * Get event district info as string
+ * Get event neighborhood info as string
  * @param {object} event
  * @param {string} locale
  * @return {string}
  */
-export const getEventDistrict = (
+export const getEventNeighborhood = (
   event: EventFields,
   locale: AppLanguage
 ): string | null => {
-  const location = event.location;
-  const district = location?.divisions?.find((division) =>
-    ['district', 'neighborhood'].includes(division.type)
+  const neighborhood = event.location?.divisions?.find(
+    (division) => division.type === 'neighborhood'
   );
-
-  return getLocalizedString(district?.name, locale);
+  return getLocalizedString(neighborhood?.name, locale);
 };
 
 /**
  * Get event location fields
- * @param {object} event
- * @param {string} locale
- * @return {string}
+ * @param {EventFields} event
+ * @param {AppLanguage} locale
  */
 const getEventLocationFields = (event: EventFields, locale: AppLanguage) => {
   const location = event.location;
   return {
     addressLocality: getLocalizedString(location?.addressLocality, locale),
     coordinates: [...(location?.position?.coordinates || [])].reverse(),
-    district: getEventDistrict(event, locale),
+    neighborhood: getEventNeighborhood(event, locale),
     location,
     postalCode: location?.postalCode,
     streetAddress: getLocalizedString(location?.streetAddress, locale),
@@ -326,7 +323,6 @@ export const getEventFields = (event: EventFields, locale: AppLanguage) => {
   const startTime = event.startTime;
   return {
     description: getLocalizedString(event.description, locale),
-    // district: getEventDistrict(event, locale),
     email: eventLocation?.email,
     endTime: event.endTime,
     id: event.id,

--- a/packages/components/src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx
+++ b/packages/components/src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx
@@ -1,4 +1,4 @@
-import type { Breadcrumb } from 'react-helsinki-headless-cms';
+import type { BreadcrumbListItem } from 'hds-react';
 import getFilteredBreadcrumbs, {
   defaultExcludedBreadcrumbPaths,
 } from '../getFilteredBreadcrumbs';
@@ -14,30 +14,30 @@ describe('defaultExcludedBreadcrumbPaths', () => {
 
 describe('getFilteredBreadcrumbs', () => {
   describe('uses defaultExcludedBreadcrumbPaths as default list of excluded paths', () => {
-    it.each<[Breadcrumb[], Breadcrumb[]]>([
+    it.each<[BreadcrumbListItem[], BreadcrumbListItem[]]>([
       [
         [
-          { title: 'Etusivu', link: '/fi/' },
-          { title: 'Pages', link: '/fi/pages/' },
+          { title: 'Etusivu', path: '/fi/' },
+          { title: 'Pages', path: '/fi/pages/' },
         ],
-        [{ title: 'Etusivu', link: '/fi/' }],
+        [{ title: 'Etusivu', path: '/fi/' }],
       ],
       [
         [
-          { title: 'Etusivu', link: '/' },
-          { title: 'Pages', link: '/pages/' },
+          { title: 'Etusivu', path: '/' },
+          { title: 'Pages', path: '/pages/' },
         ],
-        [{ title: 'Etusivu', link: '/' }],
+        [{ title: 'Etusivu', path: '/' }],
       ],
       [
         [
-          { title: '/pages', link: '/pages' },
-          { title: '/fi/pages', link: '/fi/pages' },
-          { title: '/fi/pages/', link: '/fi/pages/' },
-          { title: '/sv/pages', link: '/sv/pages' },
-          { title: '/sv/pages/', link: '/sv/pages/' },
-          { title: '/en/pages', link: '/en/pages' },
-          { title: '/en/pages/', link: '/en/pages/' },
+          { title: '/pages', path: '/pages' },
+          { title: '/fi/pages', path: '/fi/pages' },
+          { title: '/fi/pages/', path: '/fi/pages/' },
+          { title: '/sv/pages', path: '/sv/pages' },
+          { title: '/sv/pages/', path: '/sv/pages/' },
+          { title: '/en/pages', path: '/en/pages' },
+          { title: '/en/pages/', path: '/en/pages/' },
         ],
         [],
       ],


### PR DESCRIPTION
## Description

### feat: show neighborhood, not district in Linked Events location info

also:
 - remove district handling as unused, easy to add if needed
 - fix getFilteredBreadcrumbs test, it was broken before this

refs LIIKUNTA-647

## Issues

### Closes

[LIIKUNTA-647](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-647)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
