### PR TITLE
LIIKUNTA-651 | fix(test): fix packages/components tests, remove unnecessary type casts

### DIFF
--- a/packages/components/src/components/domain/event/eventInfo/utils/EventInfo.mocks.ts
+++ b/packages/components/src/components/domain/event/eventInfo/utils/EventInfo.mocks.ts
@@ -18,7 +18,9 @@ import type {
   EventListQueryVariables,
   EventListResponse,
   Meta,
+  LocalizedObject,
 } from '../../../../../../src/types/generated/graphql';
+import type { ValidLocalizedObject } from '../../../../../types';
 
 export const organizationId = '1';
 export const organizationName = 'Organization name';
@@ -36,6 +38,12 @@ export const startTime = '2020-06-22T07:00:00.000000Z';
 export const endTime = '2020-06-22T10:00:00.000000Z';
 export const email = 'test@email.com';
 export const telephone = '0441234567';
+export const providerContactInfo: ValidLocalizedObject = {
+  __typename: 'LocalizedObject',
+  fi: 'Finnish provider contact info',
+  en: 'English provider contact info',
+  sv: 'Swedish provider contact info',
+} satisfies LocalizedObject;
 export const addressLocality = 'Helsinki';
 export const neighborhood = 'Malmi';
 export const locationName = 'Location name';
@@ -48,12 +56,13 @@ export const remainingAttendeeCapacity = 5;
 export const audienceMinAge = '5';
 export const audienceMaxAge = '15';
 export const organizerName = 'provider organisation';
-export const event = fakeEvent({
+export const event: EventFieldsFragment = fakeEvent({
   audienceMinAge,
   audienceMaxAge,
   startTime,
   endTime,
   provider: { fi: organizerName },
+  providerContactInfo,
   publisher: organizationId,
   location: {
     divisions: [{ name: { fi: neighborhood }, type: 'neighborhood' }],
@@ -72,7 +81,7 @@ export const event = fakeEvent({
     fakeTargetGroup({ name: fakeLocalizedObject(targetGroup) })
   ),
   typeId: EventTypeId.Course,
-}) as EventFieldsFragment;
+});
 
 export const meta: Meta = {
   count: 20,

--- a/packages/components/src/components/shareLinks/__tests__/FacebookShareLink.test.tsx
+++ b/packages/components/src/components/shareLinks/__tests__/FacebookShareLink.test.tsx
@@ -5,9 +5,11 @@ import type { ShareLinkProps } from '../types';
 const renderComponent = (props: ShareLinkProps) =>
   render(<FacebookShareLink {...props} />);
 
-it('should apply aria label', () => {
+it('should apply aria label', async () => {
   const sharedLink = 'https://helsinki.fi/some/';
   renderComponent({ sharedLink });
 
-  expect(screen.getByLabelText(/Jaa Facebookissa/)).toBeInTheDocument();
+  expect(
+    await screen.findByRole('button', { name: /Jaa Facebookissa/ })
+  ).toBeInTheDocument();
 });

--- a/packages/components/src/components/shareLinks/__tests__/LinkedInShareLink.test.tsx
+++ b/packages/components/src/components/shareLinks/__tests__/LinkedInShareLink.test.tsx
@@ -5,9 +5,11 @@ import type { ShareLinkProps } from '../types';
 const renderComponent = (props: ShareLinkProps) =>
   render(<LinkedInShareLink {...props} />);
 
-it('should apply aria label', () => {
+it('should apply aria label', async () => {
   const sharedLink = 'https://helsinki.fi/some/';
   renderComponent({ sharedLink });
 
-  expect(screen.getByLabelText(/Jaa LinkedInissä/i)).toBeInTheDocument();
+  expect(
+    await screen.findByRole('button', { name: /Jaa LinkedInissä/i })
+  ).toBeInTheDocument();
 });

--- a/packages/components/src/components/shareLinks/__tests__/ShareLinks.test.tsx
+++ b/packages/components/src/components/shareLinks/__tests__/ShareLinks.test.tsx
@@ -6,7 +6,7 @@ import ShareLinks from '../ShareLinks';
 const renderComponent = (props: ShareLinksProps) =>
   render(<ShareLinks {...props} />);
 
-it('should have discoverable link address copy button as well as Facebook, Twitter and LinkedIn share links', () => {
+it('should have discoverable link address copy button as well as Facebook, Twitter and LinkedIn share link buttons', async () => {
   renderComponent({ title: 'Jaa tapahtuma' });
   const shareLinkLabelsFI = [
     /Kopioi linkin osoite/,
@@ -15,7 +15,9 @@ it('should have discoverable link address copy button as well as Facebook, Twitt
     /Jaa LinkedInissä/,
   ];
 
-  shareLinkLabelsFI.forEach((label) => {
-    expect(screen.getByLabelText(label)).not.toStrictEqual(null);
-  });
+  for (const label of shareLinkLabelsFI) {
+    expect(
+      await screen.findByRole('button', { name: label })
+    ).toBeInTheDocument();
+  }
 });

--- a/packages/components/src/components/shareLinks/__tests__/TwitterShareLink.test.tsx
+++ b/packages/components/src/components/shareLinks/__tests__/TwitterShareLink.test.tsx
@@ -4,9 +4,11 @@ import TwitterShareLink from '../TwitterShareLink';
 const renderComponent = (props: { sharedLink: string }) =>
   render(<TwitterShareLink {...props} />);
 
-it('should apply aria label', () => {
+it('should apply aria label', async () => {
   const sharedLink = 'https://helsinki.fi/some/';
   renderComponent({ sharedLink });
 
-  expect(screen.getByLabelText(/Jaa Twitterissä/)).toBeInTheDocument();
+  expect(
+    await screen.findByRole('button', { name: /Jaa Twitterissä/ })
+  ).toBeInTheDocument();
 });

--- a/packages/components/src/types/types.ts
+++ b/packages/components/src/types/types.ts
@@ -2,10 +2,17 @@ import type { NextRouter } from 'next/router';
 import type React from 'react';
 import type { APP_LANGUAGES } from '../constants';
 import type { EventFields } from './event-types';
-import type { Venue } from './generated/graphql';
+import type { LocalizedObject, Venue } from './generated/graphql';
 export type AppLanguage = (typeof APP_LANGUAGES)[number];
 
 export type AutosuggestType = 'keyword' | 'text';
+
+export type ValidLocalizedObject = {
+  __typename: LocalizedObject['__typename'];
+  en: NonNullable<LocalizedObject['en']>;
+  fi: NonNullable<LocalizedObject['fi']>;
+  sv: NonNullable<LocalizedObject['sv']>;
+};
 
 /* eslint-enable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION
## Description

### fix(test): fix packages/components tests, remove unnecessary type casts

```
yarn
cd packages/components
yarn test
```
->
```
Test Suites: 1 skipped, 64 passed, 64 of 65 total
Tests:       24 skipped, 226 passed, 250 total
Snapshots:   28 passed, 28 total
Time:        34.789 s, estimated 36 s
Ran all test suites.
```

refs LIIKUNTA-651

## Issues

### Closes

### Related

[LIIKUNTA-651](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-651)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-651]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ