### PR TITLE
fix: upcoming event types

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx
+++ b/apps/sports-helsinki/src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx
@@ -1,4 +1,5 @@
 import { EVENT_SORT_OPTIONS } from '@events-helsinki/components/constants';
+import { EventTypeId } from '@events-helsinki/components/types';
 import * as React from 'react';
 import { render, screen, waitFor } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
@@ -29,7 +30,7 @@ const similarEventQueryVariables = {
   keywordNot: undefined,
   publisher: undefined,
   keywordOrSet2: undefined,
-  eventType: undefined,
+  eventType: [EventTypeId.Course, EventTypeId.General],
 };
 
 const mocks = [

--- a/packages/components/src/components/domain/event/queryUtils.ts
+++ b/packages/components/src/components/domain/event/queryUtils.ts
@@ -7,7 +7,7 @@ import {
   SIMILAR_EVENTS_AMOUNT,
 } from '../../../constants/event-constants';
 import type { EventFields } from '../../../types/event-types';
-import type {
+import {
   EventListQuery,
   EventListQueryVariables,
   EventTypeId,
@@ -222,6 +222,7 @@ export const useLocationUpcomingEventsQuery = ({
     publisherAncestor: null,
     // superEventType: 'none', // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
     pageSize,
+    eventType: [EventTypeId.Course, EventTypeId.General],
   };
   return useEventListQuery({ variables, ssr: false });
 };


### PR DESCRIPTION
## Description
Venue page carousels should support events and courses.

## Issues

### Closes

**[LIIKUNTA-639](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-639):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-639]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ