### PR TITLE
Fix proxy docker build

### DIFF
--- a/docker-compose.events-graphql-proxy.yml
+++ b/docker-compose.events-graphql-proxy.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: proxy.Dockerfile
-      target: develop
+      target: ${DOCKER_TARGET:-develop}
       args:
         - PROXY=events-graphql-proxy
         - GRAPHQL_PROXY_PORT=${GRAPHQL_PROXY_PORT}

--- a/docker-compose.events.yml
+++ b/docker-compose.events.yml
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: develop
+      target: ${DOCKER_TARGET:-develop}
       args:
         APP_PORT: 3000
         PROJECT: events-helsinki

--- a/docker-compose.hobbies.yml
+++ b/docker-compose.hobbies.yml
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: develop
+      target: ${DOCKER_TARGET:-develop}
       args:
         APP_PORT: 3000
         PROJECT: hobbies-helsinki

--- a/docker-compose.sports.yml
+++ b/docker-compose.sports.yml
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: develop
+      target: ${DOCKER_TARGET:-develop}
       args:
         APP_PORT: 3000
         PROJECT: sports-helsinki

--- a/docker-compose.venue-graphql-proxy.yml
+++ b/docker-compose.venue-graphql-proxy.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: proxy.Dockerfile
-      target: develop
+      target: ${DOCKER_TARGET:-develop}
       args:
         - PROXY=venue-graphql-proxy
         - GRAPHQL_PROXY_PORT=${GRAPHQL_PROXY_PORT}

--- a/package.json
+++ b/package.json
@@ -141,6 +141,5 @@
     "node": "^14.13.1 || >=16.0.0",
     "yarn": ">=1.22.0",
     "npm": "please-use-yarn"
-  },
-  "packageManager": "yarn@4.0.0-rc.15"
+  }
 }


### PR DESCRIPTION
1. Add DOCKER_TARGET to each docker-compose config
2. Remove the PackageManager config from the root package.json.

Fixes the following issue
```shell
[+] Running 1/1
 ✔ Container venue-graphql-proxy  Created                                                                                                                                                                                                                                                                                                                           0.1s 
Attaching to venue-graphql-proxy
venue-graphql-proxy  | error This project's package.json defines "packageManager": "yarn@4.0.0-rc.15". However the current global version of Yarn is 1.22.22.
venue-graphql-proxy  | 
venue-graphql-proxy  | Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
venue-graphql-proxy  | Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
venue-graphql-proxy exited with code 1
```