### PR TITLE
HH-308 | fix: cards and hero long text break

### DIFF
--- a/packages/components/src/components/eventCard/largeEventCard.module.scss
+++ b/packages/components/src/components/eventCard/largeEventCard.module.scss
@@ -64,6 +64,8 @@
 
       svg {
         margin-right: var(--spacing-2-xs);
+        min-width: var(--spacing-layout-xs);
+        min-height: var(--spacing-layout-xs);
       }
     }
 
@@ -91,6 +93,8 @@
       color: var(color-black-80);
       svg {
         margin-right: var(--spacing-2-xs);
+        min-width: var(--spacing-layout-xs);
+        min-height: var(--spacing-layout-xs);
       }
     }
 
@@ -103,6 +107,8 @@
       color: var(color-black-80);
       svg {
         margin-right: var(--spacing-2-xs);
+        min-width: var(--spacing-layout-xs);
+        min-height: var(--spacing-layout-xs);
       }
     }
 

--- a/packages/components/src/components/eventHero/eventHero.module.scss
+++ b/packages/components/src/components/eventHero/eventHero.module.scss
@@ -108,6 +108,7 @@ $logoWidth: 5.5rem;
       }
 
       .title {
+        hyphens: auto;
         order: 3;
         font-size: var(--fontsize-heading-l);
         line-height: var(--lineheight-m);
@@ -119,6 +120,7 @@ $logoWidth: 5.5rem;
       }
 
       .description {
+        word-break: break-word;
         order: 4;
         font-size: var(--fontsize-body-xl);
         line-height: var(--spacing-l);

--- a/packages/components/src/components/infoWithIcon/infoWithIcon.module.scss
+++ b/packages/components/src/components/infoWithIcon/infoWithIcon.module.scss
@@ -17,6 +17,7 @@
   }
 
   .iconTextWrapper {
+    word-break: break-word;
     flex: 1 1 0%;
 
     .title {


### PR DESCRIPTION
## Description
1. Event Hero title hyphens
2. Search card info word break and icons min size
3. Hero word breaks on description and info fiends 

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
