### PR TITLE
HH-308 | Consistently use both "hyphens: auto" and "word-break: break-word"

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueCard/largeVenueCard.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueCard/largeVenueCard.module.scss
@@ -4,6 +4,7 @@
 .eventCard {
   --height-image: 14.5rem;
 
+  hyphens: auto;
   word-break: break-word;
   min-width: fit-content;
   text-decoration: none;
@@ -14,7 +15,6 @@
 
   @include respond_above(s) {
     grid-template-columns: 4fr 5fr;
-    word-break: unset;
   }
 
   .imageWrapper {

--- a/packages/components/src/components/eventCard/eventCard.module.scss
+++ b/packages/components/src/components/eventCard/eventCard.module.scss
@@ -5,6 +5,7 @@
   --height-image-desktop: 14.5rem;
   --width-image: 6.375rem;
 
+  hyphens: auto;
   word-break: break-word;
   min-width: fit-content;
   background-color: var(--color-white);
@@ -19,7 +20,6 @@
     grid-template-columns: none;
     grid-template-rows: auto 1fr;
     margin-bottom: 0;
-    word-break: unset;
   }
 
   .imageWrapper {

--- a/packages/components/src/components/eventCard/largeEventCard.module.scss
+++ b/packages/components/src/components/eventCard/largeEventCard.module.scss
@@ -6,6 +6,7 @@
   --link-arrow-label-color: var(--color-black-80);
   --link-arrow-label-alert-color: #b01038;
 
+  hyphens: auto;
   word-break: break-word;
   min-width: fit-content;
   text-decoration: none;
@@ -16,7 +17,6 @@
 
   @include respond_above(s) {
     grid-template-columns: 4fr 5fr;
-    word-break: unset;
   }
 
   .imageWrapper {

--- a/packages/components/src/components/eventHero/eventHero.module.scss
+++ b/packages/components/src/components/eventHero/eventHero.module.scss
@@ -109,6 +109,7 @@ $logoWidth: 5.5rem;
 
       .title {
         hyphens: auto;
+        word-break: break-word;
         order: 3;
         font-size: var(--fontsize-heading-l);
         line-height: var(--lineheight-m);
@@ -120,6 +121,7 @@ $logoWidth: 5.5rem;
       }
 
       .description {
+        hyphens: auto;
         word-break: break-word;
         order: 4;
         font-size: var(--fontsize-body-xl);

--- a/packages/components/src/components/infoWithIcon/infoWithIcon.module.scss
+++ b/packages/components/src/components/infoWithIcon/infoWithIcon.module.scss
@@ -17,6 +17,7 @@
   }
 
   .iconTextWrapper {
+    hyphens: auto;
     word-break: break-word;
     flex: 1 1 0%;
 


### PR DESCRIPTION
## Description

### fix: consistently use both "hyphens: auto" and "word-break: break-word"

This applies both "hyphens: auto" and "word-break: break-word" styles
where previously only one of the styles were used, and removes the
conditional "word-break: unset" setting from those styles.

This makes use of hyphenation where it works (it doesn't work for e.g.
Google Chrome on Windows in Finnish language currently), and also word
breaking on top of the hyphenation, whether it works or not.

refs HH-308

## Issues

[HH-308](https://helsinkisolutionoffice.atlassian.net/browse/HH-308)

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

On Linux using Firefox:
- ![image](https://github.com/user-attachments/assets/b5e2b435-6a6b-4afa-84cb-1d90df1120f1)

## Additional notes


[HH-308]: https://helsinkisolutionoffice.atlassian.net/browse/HH-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ