### PR TITLE
fix: remove dog beaches from swimming ontology

### DIFF
--- a/packages/components/src/components/domain/unifiedSearch/unifiedSearchConstants.ts
+++ b/packages/components/src/components/domain/unifiedSearch/unifiedSearchConstants.ts
@@ -21,7 +21,6 @@ export type UnifiedSearchOrderByType =
 
 // Swimming / Uinti
 export const SWIMMING_ONTOLOGY_TREE_IDS = [
-  20, // Koirauimarannat / Dog beaches
   684, // Vesiliikuntapaikat / Water sports facilities
 ];
 


### PR DESCRIPTION
**fix: remove dog beaches from swimming ontology**

refs LIIKUNTA-675

## Description

## Issues

### Closes

**[LIIKUNTA-675](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-675)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-675]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ