### PR TITLE
LIIKUNTA-686 | fix: landing page meta

### DIFF
--- a/apps/events-helsinki/src/pages/index.tsx
+++ b/apps/events-helsinki/src/pages/index.tsx
@@ -10,6 +10,7 @@ import {
   RouteMeta,
   useResilientTranslation,
   PreviewNotification,
+  PageMeta,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
 import type {
@@ -63,6 +64,10 @@ const HomePage: NextPage<{
         <>
           <PreviewNotification token={previewToken} />
           <RouteMeta origin={AppConfig.origin} />
+          <PageMeta
+            {...page?.seo}
+            image={page?.featuredImage?.node?.mediaItemUrl || ''}
+          />
           <RHHCPageContentNoSSR
             page={page}
             PageContentLayoutComponent={LandingPageContentLayout}

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -74,13 +74,12 @@ const NextCmsArticle: NextPage<{
   const { resilientT } = useResilientTranslation();
   const { footerMenu } = useContext(NavigationContext);
 
-  const { data: categoriesData, loading: loadingCategories } =
-    useCategoriesQuery({
-      variables: {
-        first: CATEGORIES_AMOUNT,
-        language: getLanguageCodeFilter(currentLanguageCode),
-      },
-    });
+  const { data: categoriesData } = useCategoriesQuery({
+    variables: {
+      first: CATEGORIES_AMOUNT,
+      language: getLanguageCodeFilter(currentLanguageCode),
+    },
+  });
 
   const categories = categoriesData?.categories?.nodes ?? [];
 

--- a/apps/hobbies-helsinki/src/pages/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/index.tsx
@@ -9,6 +9,7 @@ import {
   RouteMeta,
   useResilientTranslation,
   PreviewNotification,
+  PageMeta,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
 import type { GetStaticPropsContext, NextPage } from 'next';
@@ -57,6 +58,10 @@ const HomePage: NextPage<{
         <>
           <PreviewNotification token={previewToken} />
           <RouteMeta origin={AppConfig.origin} />
+          <PageMeta
+            {...page?.seo}
+            image={page?.featuredImage?.node?.mediaItemUrl || ''}
+          />
           <RHHCPageContentNoSSR
             page={page}
             PageContentLayoutComponent={LandingPageContentLayout}

--- a/apps/sports-helsinki/src/pages/index.tsx
+++ b/apps/sports-helsinki/src/pages/index.tsx
@@ -9,6 +9,7 @@ import {
   getLanguageOrDefault,
   RouteMeta,
   PreviewNotification,
+  PageMeta,
 } from '@events-helsinki/components';
 import { logger } from '@events-helsinki/components/loggers/logger';
 import type { GetStaticPropsContext, NextPage } from 'next';
@@ -58,6 +59,10 @@ const HomePage: NextPage<{
         <>
           <PreviewNotification token={previewToken} />
           <RouteMeta origin={AppConfig.origin} />
+          <PageMeta
+            {...page?.seo}
+            image={page?.featuredImage?.node?.mediaItemUrl || ''}
+          />
           <RHHCPageContentNoSSR
             page={page}
             PageContentLayoutComponent={LandingPageContentLayout}

--- a/packages/components/src/components/domain/seo/meta/PageMeta.tsx
+++ b/packages/components/src/components/domain/seo/meta/PageMeta.tsx
@@ -44,7 +44,9 @@ function PageMeta({
     <>
       <Head>
         {title && <title>{unescapeDash(title)}</title>}
-        {description && <meta name="description" content={description} />}
+        {description && (
+          <meta name="description" content={unescapeDash(description)} />
+        )}
         <meta property="og:title" content={openGraphTitle || ''} />
         <meta name="twitter:card" content="summary_large_image" />
         {description && (

--- a/packages/components/src/components/eventList/eventList.module.scss
+++ b/packages/components/src/components/eventList/eventList.module.scss
@@ -14,7 +14,7 @@
   .loadMoreWrapper {
     display: flex;
     justify-content: center;
-    
+
     &.buttonCentered {
       text-align: center;
     }

--- a/packages/components/src/components/footer/Footer.tsx
+++ b/packages/components/src/components/footer/Footer.tsx
@@ -46,8 +46,7 @@ const FooterSection: FunctionComponent<FooterSectionProps> = ({
   };
 
   const UserTrackingFeatures = dynamic(
-    () =>
-      import('../widgets/UserTrackingFeatures').then((mod) => mod),
+    () => import('../widgets/UserTrackingFeatures').then((mod) => mod),
     {
       ssr: false,
     }

--- a/packages/components/src/components/widgets/UserTrackingFeatures.tsx
+++ b/packages/components/src/components/widgets/UserTrackingFeatures.tsx
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router';
+import { useCookieConfigurationContext } from '../../cookieConfigurationProvider';
 import { AskemFeedbackContainer, AskemProvider } from '../askem';
 import useAskemContext from '../askem/useAskemContext';
 import EventsCookieConsent from '../eventsCookieConsent/EventsCookieConsent';
-import { useCookieConfigurationContext } from '../../cookieConfigurationProvider';
 
 type UserTrackingFeaturesProps = {
   appName: string;


### PR DESCRIPTION
## Description
Hion fixed the SEO prop on the landing page, so the page meta can be added.
Still one minor bug in cms to consider:

When setting the SEO title in Wordpress, the placeholder of the field will should postfix:
<img width="621" alt="image" src="https://github.com/user-attachments/assets/b70e7c49-ad2d-41c9-8016-ca8832b103be" />
But the actual value in page source will be:
`<title>Löydä liikuntaa - Liikunta</title>`

The description field is going to the tag value as it is without any automatic modifications.

## Issues

### Closes

**[LIIKUNTA-686](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-686)**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-686]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ