### PR TITLE
Simplify & add FIXME to middleware's isPublicFile function

### DIFF
--- a/apps/events-helsinki/src/middleware.ts
+++ b/apps/events-helsinki/src/middleware.ts
@@ -11,8 +11,12 @@ const requestType = {
   isStaticFile: (req: NextRequest) => req.nextUrl.pathname.startsWith('/_next'),
   isPagesFolderApi: (req: NextRequest) =>
     req.nextUrl.pathname.includes('/api/'),
-  // eslint-disable-next-line regexp/no-unused-capturing-group
-  isPublicFile: (req: NextRequest) => /\.(.*)$/.test(req.nextUrl.pathname),
+  // FIXME: This seems broken, as it will match any pathname with a dot in it
+  // Originally probably from https://github.com/vercel/next.js/discussions/18419 or
+  // https://nextjs.org/docs/pages/building-your-application/routing/internationalization
+  // as `PUBLIC_FILE = /\.(.*)$/` and `PUBLIC_FILE.test(pathname)` and passed
+  // through hobbies-helsinki repo to events-helsinki-monorepo.
+  isPublicFile: (req: NextRequest) => req.nextUrl.pathname.includes('.'),
 };
 
 /** Get the preferred locale, similar to above or using a library */

--- a/apps/hobbies-helsinki/src/middleware.ts
+++ b/apps/hobbies-helsinki/src/middleware.ts
@@ -13,8 +13,12 @@ const requestType = {
   isStaticFile: (req: NextRequest) => req.nextUrl.pathname.startsWith('/_next'),
   isPagesFolderApi: (req: NextRequest) =>
     req.nextUrl.pathname.includes('/api/'),
-  // eslint-disable-next-line regexp/no-unused-capturing-group
-  isPublicFile: (req: NextRequest) => /\.(.*)$/.test(req.nextUrl.pathname),
+  // FIXME: This seems broken, as it will match any pathname with a dot in it
+  // Originally probably from https://github.com/vercel/next.js/discussions/18419 or
+  // https://nextjs.org/docs/pages/building-your-application/routing/internationalization
+  // as `PUBLIC_FILE = /\.(.*)$/` and `PUBLIC_FILE.test(pathname)` and passed
+  // through hobbies-helsinki repo to events-helsinki-monorepo.
+  isPublicFile: (req: NextRequest) => req.nextUrl.pathname.includes('.'),
 };
 
 /** Get the preferred locale, similar to above or using a library */

--- a/apps/sports-helsinki/src/middleware.ts
+++ b/apps/sports-helsinki/src/middleware.ts
@@ -12,7 +12,8 @@ const requestType = {
   isPagesFolderApi: (req: NextRequest) =>
     req.nextUrl.pathname.includes('/api/'),
   // FIXME: This seems broken, as it will match any pathname with a dot in it
-  // Originally probably from https://github.com/vercel/next.js/discussions/18419
+  // Originally probably from https://github.com/vercel/next.js/discussions/18419 or
+  // https://nextjs.org/docs/pages/building-your-application/routing/internationalization
   // as `PUBLIC_FILE = /\.(.*)$/` and `PUBLIC_FILE.test(pathname)` and passed
   // through hobbies-helsinki repo to events-helsinki-monorepo.
   isPublicFile: (req: NextRequest) => req.nextUrl.pathname.includes('.'),


### PR DESCRIPTION
## Description

Simplify & add FIXME to middleware's isPublicFile function.

Similar as in https://github.com/City-of-Helsinki/events-helsinki-monorepo/blob/sports-helsinki-v1.28.0/apps/sports-helsinki/src/middleware.ts#L14-L18

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
