### PR TITLE
TH-1371 | Add `/merellinenhelsinki` campaign redirect to tapahtumat

### DIFF
--- a/apps/events-helsinki/redirectCampaignRoutes.config.js
+++ b/apps/events-helsinki/redirectCampaignRoutes.config.js
@@ -2,8 +2,9 @@
 // prettier-ignore
 const redirectCampaignRoutes = {
   // Finnish locale versions
-  '/maaginen': '/fi/articles/yleinen/maaginen-viikko-helsingin-kirjastoissa',
   '/ekoviikko': '/fi/articles/yleinen/ekoviikko-kirjastoissa',
+  '/maaginen': '/fi/articles/yleinen/maaginen-viikko-helsingin-kirjastoissa',
+  '/merellinenhelsinki': '/fi/articles/yleinen/merellinen-helsinki-viikonloppu-2025',
 
   // Swedish locale versions
   // None yet


### PR DESCRIPTION
## Description

Add `/merellinenhelsinki` campaign redirect to tapahtumat.

## Issues

### Closes

[TH-1371](https://helsinkisolutionoffice.atlassian.net/browse/TH-1371)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[TH-1371]: https://helsinkisolutionoffice.atlassian.net/browse/TH-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ