### PR TITLE
fix: hero image quality

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0",
+    "react-helsinki-headless-cms": "1.0.2",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -72,7 +72,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0",
+    "react-helsinki-headless-cms": "1.0.2",
     "react-i18next": "13.0.1",
     "react-scroll": "^1.8.9",
     "react-toastify": "^9.1.3",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -80,7 +80,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0",
+    "react-helsinki-headless-cms": "1.0.2",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.8.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -78,7 +78,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.0.0",
+    "react-helsinki-headless-cms": "1.0.2",
     "react-i18next": "13.0.1",
     "react-leaflet": "4.2.1",
     "react-toastify": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3526,7 +3526,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0"
+    react-helsinki-headless-cms: "npm:1.0.2"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^9.1.3"
@@ -14377,7 +14377,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0"
+    react-helsinki-headless-cms: "npm:1.0.2"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -16278,7 +16278,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0"
+    react-helsinki-headless-cms: "npm:1.0.2"
     react-i18next: "npm:13.0.1"
     react-scroll: "npm:^1.8.9"
     react-toastify: "npm:^9.1.3"
@@ -23401,9 +23401,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.0.0":
-  version: 1.0.0
-  resolution: "react-helsinki-headless-cms@npm:1.0.0"
+"react-helsinki-headless-cms@npm:1.0.2":
+  version: 1.0.2
+  resolution: "react-helsinki-headless-cms@npm:1.0.2"
   dependencies:
     hds-design-tokens: "npm:^3.11.0"
     html-entities: "npm:^2.5.2"
@@ -23420,7 +23420,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: 4ee7da4fb6ad7ff2539503888785d96724b8962a94ad11d6190839cd4fded671ce4d40280b4bd7f8c710ee981d7950b38f6252bbd102f3f345e64ac6f46bedcf
+  checksum: 40c222fe20017c6d847b8c06108b1423d20c8b36c70cc6407990b510c2cbb074380e5459f4e4b053d12a6a54c5a540c464c4305b17eb2f814621d0d3a2d79895
   languageName: node
   linkType: hard
 
@@ -25502,7 +25502,7 @@ __metadata:
     react-datepicker: "npm:^4.14.1"
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.0.0"
+    react-helsinki-headless-cms: "npm:1.0.2"
     react-i18next: "npm:13.0.1"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.8.9"


### PR DESCRIPTION
LIIKUNTA-700.

Upgrade `react-helsinki-headless-cms` to version 1.0.2 to get a better quality (a larger resolution image) for CMS page heroes.

The hero uses featuredImage property of CMS pages and articles. There are multiple versions of the featured image available which all represent different sizes and compression levels: thumbnail, medium, medium_large and large. The original image URI is set in `mediaItemUrl`. The hero earlier used the medium_large image, but now it is using a large version of it. An original image can be too large to be used in web.

The `react-helsinki-headless-cms` changes are in https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/204.
