### PR TITLE
feat(apps): serve front page hero image with img-tag and photographer

### DIFF
--- a/apps/events-helsinki/src/domain/search/landingPage/LandingPage.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPage/LandingPage.tsx
@@ -16,7 +16,11 @@ export function LandingPageContentLayout({
   page,
   collections,
 }: LandingPageProps & PageContentLayoutProps) {
-  const heroImage = page?.featuredImage?.node?.mediaItemUrl ?? '';
+  const {
+    mediaItemUrl: heroImage,
+    altText: heroImageAlt,
+    photographerName,
+  } = page?.featuredImage?.node ?? {};
   const [firstCollection, ...restCollections] =
     (collections as React.ReactNode[]) ?? [];
   const lastCollection = restCollections.pop();
@@ -29,9 +33,13 @@ export function LandingPageContentLayout({
             className={styles.sectionHero}
             korosBottom
             korosBottomClassName={styles.korosBottomHero}
-            backgroundImageUrl={heroImage}
           >
-            <></>
+            <figure className={styles.heroFigure}>
+              <img src={heroImage ?? ''} alt={heroImageAlt ?? ''} />
+              {photographerName && (
+                <div className={styles.heroModuleLabel}>{photographerName}</div>
+              )}
+            </figure>
           </PageSection>
           <PageSection className={styles.sectionSearch}>
             <ContentContainer>

--- a/apps/events-helsinki/src/domain/search/landingPage/landingPage.module.scss
+++ b/apps/events-helsinki/src/domain/search/landingPage/landingPage.module.scss
@@ -54,3 +54,53 @@ $mainBackground: var(--color-theme-background);
 .korosTopCollectionsRest {
   fill: $mainBackground !important;
 }
+
+.sectionHero {
+  position: relative; /* Keep this if you position other elements absolutely */
+  display: flex; /* Keep this if you use flexbox for layout */
+  margin: 0;
+
+  .heroFigure {
+    /* Position and size the figure to cover the hero */
+    position: absolute; /* Position it behind other content */
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0; /* Remove default figure margin */
+    overflow: hidden; /* Hide any part of the image that extends beyond the figure */
+    z-index: -1; /* Set behind Koros */
+
+    img {
+      display: block; /* Remove potential extra space below image */
+      width: 100%;
+      height: 100%;
+      object-fit: cover; /* This makes the image cover the area while maintaining aspect ratio */
+      object-position: 50% 50%; /* Center the image, similar to background-position */
+    }
+  }
+
+  .heroModuleLabel {
+    position: absolute; /* Position the label relative to the figure */
+    padding: 5px 10px;
+    z-index: 1; /* Ensure label is above the image but possibly below other hero content */
+    background-color: var(--color-black);
+    top: 80px;
+    color: var(--color-white);
+    font-size: var(--fontsize-body-s);
+    margin: 0;
+    max-height: 80%;
+    opacity: 0.6;
+    overflow: hidden;
+    padding: 4px;
+    right: 0;
+    text-overflow: ellipsis;
+    -webkit-transform: rotate(180deg);
+    -moz-transform: rotate(180deg);
+    -o-transform: rotate(180deg);
+    -ms-transform: rotate(180deg);
+    transform: rotate(180deg);
+    white-space: nowrap;
+    writing-mode: vertical-lr;
+  }
+}

--- a/apps/hobbies-helsinki/src/domain/search/landingPage/LandingPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/landingPage/LandingPage.tsx
@@ -16,8 +16,11 @@ export function LandingPageContentLayout({
   page,
   collections,
 }: LandingPageProps & PageContentLayoutProps) {
-  const heroImage = page?.featuredImage?.node?.mediaItemUrl ?? '';
-
+  const {
+    mediaItemUrl: heroImage,
+    altText: heroImageAlt,
+    photographerName,
+  } = page?.featuredImage?.node ?? {};
   const [firstCollection, ...restCollections] =
     (collections as React.ReactNode[]) ?? [];
   const lastCollection = restCollections.pop();
@@ -30,9 +33,13 @@ export function LandingPageContentLayout({
             className={styles.sectionHero}
             korosBottom
             korosBottomClassName={styles.korosBottomHero}
-            backgroundImageUrl={heroImage}
           >
-            <></>
+            <figure className={styles.heroFigure}>
+              <img src={heroImage ?? ''} alt={heroImageAlt ?? ''} />
+              {photographerName && (
+                <div className={styles.heroModuleLabel}>{photographerName}</div>
+              )}
+            </figure>
           </PageSection>
           <PageSection className={styles.sectionSearch}>
             <ContentContainer>

--- a/apps/hobbies-helsinki/src/domain/search/landingPage/landingPage.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/landingPage/landingPage.module.scss
@@ -54,3 +54,53 @@ $mainBackground: var(--color-theme-background);
 .korosTopCollectionsRest {
   fill: $mainBackground !important;
 }
+
+.sectionHero {
+  position: relative; /* Keep this if you position other elements absolutely */
+  display: flex; /* Keep this if you use flexbox for layout */
+  margin: 0;
+
+  .heroFigure {
+    /* Position and size the figure to cover the hero */
+    position: absolute; /* Position it behind other content */
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0; /* Remove default figure margin */
+    overflow: hidden; /* Hide any part of the image that extends beyond the figure */
+    z-index: -1; /* Set behind Koros */
+
+    img {
+      display: block; /* Remove potential extra space below image */
+      width: 100%;
+      height: 100%;
+      object-fit: cover; /* This makes the image cover the area while maintaining aspect ratio */
+      object-position: 50% 50%; /* Center the image, similar to background-position */
+    }
+  }
+
+  .heroModuleLabel {
+    position: absolute; /* Position the label relative to the figure */
+    padding: 5px 10px;
+    z-index: 1; /* Ensure label is above the image but possibly below other hero content */
+    background-color: var(--color-black);
+    top: 80px;
+    color: var(--color-white);
+    font-size: var(--fontsize-body-s);
+    margin: 0;
+    max-height: 80%;
+    opacity: 0.6;
+    overflow: hidden;
+    padding: 4px;
+    right: 0;
+    text-overflow: ellipsis;
+    -webkit-transform: rotate(180deg);
+    -moz-transform: rotate(180deg);
+    -o-transform: rotate(180deg);
+    -ms-transform: rotate(180deg);
+    transform: rotate(180deg);
+    white-space: nowrap;
+    writing-mode: vertical-lr;
+  }
+}

--- a/apps/sports-helsinki/src/domain/search/landingPage/LandingPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/landingPage/LandingPage.tsx
@@ -16,8 +16,11 @@ export function LandingPageContentLayout({
   page,
   collections,
 }: PageProps & PageContentLayoutProps) {
-  const heroImage = page?.featuredImage?.node?.mediaItemUrl ?? '';
-
+  const {
+    mediaItemUrl: heroImage,
+    altText: heroImageAlt,
+    photographerName,
+  } = page?.featuredImage?.node ?? {};
   const [firstCollection, ...restCollections] =
     (collections as React.ReactNode[]) ?? [];
   const lastCollection = restCollections.pop();
@@ -30,9 +33,13 @@ export function LandingPageContentLayout({
             className={styles.sectionHero}
             korosBottom
             korosBottomClassName={styles.korosBottomHero}
-            backgroundImageUrl={heroImage}
           >
-            <></>
+            <figure className={styles.heroFigure}>
+              <img src={heroImage ?? ''} alt={heroImageAlt ?? ''} />
+              {photographerName && (
+                <div className={styles.heroModuleLabel}>{photographerName}</div>
+              )}
+            </figure>
           </PageSection>
           <PageSection className={styles.sectionSearch}>
             <ContentContainer>

--- a/apps/sports-helsinki/src/domain/search/landingPage/landingPage.module.scss
+++ b/apps/sports-helsinki/src/domain/search/landingPage/landingPage.module.scss
@@ -54,3 +54,53 @@ $mainBackground: var(--color-theme-background);
 .korosTopCollectionsRest {
   fill: $mainBackground !important;
 }
+
+.sectionHero {
+  position: relative; /* Keep this if you position other elements absolutely */
+  display: flex; /* Keep this if you use flexbox for layout */
+  margin: 0;
+
+  .heroFigure {
+    /* Position and size the figure to cover the hero */
+    position: absolute; /* Position it behind other content */
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0; /* Remove default figure margin */
+    overflow: hidden; /* Hide any part of the image that extends beyond the figure */
+    z-index: -1; /* Set behind Koros */
+
+    img {
+      display: block; /* Remove potential extra space below image */
+      width: 100%;
+      height: 100%;
+      object-fit: cover; /* This makes the image cover the area while maintaining aspect ratio */
+      object-position: 50% 50%; /* Center the image, similar to background-position */
+    }
+  }
+
+  .heroModuleLabel {
+    position: absolute; /* Position the label relative to the figure */
+    padding: 5px 10px;
+    z-index: 1; /* Ensure label is above the image but possibly below other hero content */
+    background-color: var(--color-black);
+    top: 80px;
+    color: var(--color-white);
+    font-size: var(--fontsize-body-s);
+    margin: 0;
+    max-height: 80%;
+    opacity: 0.6;
+    overflow: hidden;
+    padding: 4px;
+    right: 0;
+    text-overflow: ellipsis;
+    -webkit-transform: rotate(180deg);
+    -moz-transform: rotate(180deg);
+    -o-transform: rotate(180deg);
+    -ms-transform: rotate(180deg);
+    transform: rotate(180deg);
+    white-space: nowrap;
+    writing-mode: vertical-lr;
+  }
+}


### PR DESCRIPTION
TH-1367.

The front page hero image has been odd to other pages, because it's hero image has been served as a background image for a hero section (div-element). Other pages have used img-element, which is semantically more correct for content images and better for accessibility, because of it's alt-texts and other features. Also, the front page hero image has not rendered any information about the photographer, unlike the other heroes have.

This commit changes the landing page / front page background image to a real image element and adds the prohotgrapher information on the side of the photo figure element.

### Sports app in desktop size
<img width="1506" height="1214" alt="image" src="https://github.com/user-attachments/assets/bd10a8d1-c7f7-482e-925d-6c1d0a56e888" />

### Sports app in mobile size
<img width="403" height="887" alt="image" src="https://github.com/user-attachments/assets/dab33f35-36f9-4085-a933-44e68a993460" />

### Events app in desktop size
<img width="1514" height="1217" alt="image" src="https://github.com/user-attachments/assets/b8594605-60c8-494e-9bb7-40a7e34dce21" />


### Events app in mobile size

<img width="402" height="892" alt="image" src="https://github.com/user-attachments/assets/f760e0e3-7cb5-4142-ba5d-8990d8619858" />


### Hobies app in portrait

<img width="861" height="1217" alt="image" src="https://github.com/user-attachments/assets/2a2f7f20-4e5b-4c82-af87-db238fcd788e" />


### Hobies app without photographer info

<img width="1512" height="1221" alt="image" src="https://github.com/user-attachments/assets/d4b77a4a-6b2c-404e-9764-80ef4a9c1dd3" />

<img width="414" height="912" alt="image" src="https://github.com/user-attachments/assets/e4beb440-d6c3-4d02-b5f2-643230672581" />

