### PR TITLE
fix(search): filter event search with division

### DIFF
--- a/apps/events-helsinki/config/vitest/mocks/eventListMocks.ts
+++ b/apps/events-helsinki/config/vitest/mocks/eventListMocks.ts
@@ -12,6 +12,7 @@ import {
   EventTypeId,
   DEFAULT_EVENT_SORT_OPTION,
   EVENT_SEARCH_FILTERS,
+  HELSINKI_OCD_DIVISION_ID,
 } from '@events-helsinki/components';
 import AppConfig from '../../../src/domain/app/AppConfig';
 
@@ -27,6 +28,8 @@ export const baseVariables = {
   sort: DEFAULT_EVENT_SORT_OPTION,
   start: 'now',
   startsAfter: undefined,
+  // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+  [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
   // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   // superEventType: ['umbrella', 'none'],
   [EVENT_SEARCH_FILTERS.ONGOING]: true,

--- a/apps/events-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
+++ b/apps/events-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
@@ -1,7 +1,8 @@
 import {
   EVENT_SEARCH_FILTERS,
   EVENT_SORT_OPTIONS,
-} from '@events-helsinki/components/constants/event-constants';
+  HELSINKI_OCD_DIVISION_ID,
+} from '@events-helsinki/components';
 import type { EventFields } from '@events-helsinki/components/types/event-types';
 import React from 'react';
 
@@ -32,6 +33,10 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
       pageSize: 100,
       params: new URLSearchParams(searchParams),
       sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+      // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+      // NOTE: This is not needed if using any `*Ongoing` -filter as
+      // they automatically limit the results to city of Helsinki events.
+      [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
       // Don't use superEventType when experimenting:
       // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
       // superEventType: ['umbrella', 'none']

--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -14,6 +14,8 @@ import {
   isEventSortOption,
   EventList,
   useClearClosedEventsFromApolloCache,
+  HELSINKI_OCD_DIVISION_ID,
+  EVENT_SEARCH_FILTERS,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -45,6 +47,10 @@ const useSearchQuery = () => {
       sortOrder: isEventSortOption(sortParam)
         ? sortParam
         : DEFAULT_EVENT_SORT_OPTION,
+      // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+      // NOTE: This is not needed if using any `*Ongoing` -filter as
+      // they automatically limit the results to city of Helsinki events.
+      [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
       // Don't use superEventType when experimenting
       // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
       // superEventType: ['umbrella', 'none']

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -141,6 +141,7 @@ export const getEventSearchVariables = ({
   superEventType,
   superEvent,
   place,
+  division,
 }: {
   include: string[];
   language?: AppLanguage;
@@ -150,6 +151,7 @@ export const getEventSearchVariables = ({
   superEventType?: string[];
   superEvent?: string;
   place?: string;
+  division?: string[];
 }): QueryEventListArgs => {
   const {
     categories,
@@ -212,6 +214,7 @@ export const getEventSearchVariables = ({
   return {
     [EVENT_SEARCH_FILTERS.TEXT]: !isEmpty(text) ? text?.join(',') : undefined, // NOTE: only *OngoingAnd supports Array.
     [EVENT_SEARCH_FILTERS.ONGOING]: true,
+    [EVENT_SEARCH_FILTERS.DIVISIONS]: division,
     end,
     include,
     publisherAncestor,

--- a/apps/hobbies-helsinki/config/vitest/mocks/eventListMocks.ts
+++ b/apps/hobbies-helsinki/config/vitest/mocks/eventListMocks.ts
@@ -11,6 +11,7 @@ import {
   EVENT_SEARCH_FILTERS,
   EventListDocument,
   EventTypeId,
+  HELSINKI_OCD_DIVISION_ID,
 } from '@events-helsinki/components';
 import AppConfig from '../../../src/domain/app/AppConfig';
 
@@ -29,6 +30,8 @@ export const baseVariables = {
   sort: 'end_time',
   start: 'now',
   startsAfter: undefined,
+  // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+  [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
   // Removed to experiment:
   // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   // superEventType: ['umbrella', 'none'],

--- a/apps/hobbies-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
@@ -1,8 +1,9 @@
 import {
   EVENT_SEARCH_FILTERS,
   EVENT_SORT_OPTIONS,
-} from '@events-helsinki/components/constants/event-constants';
-import type { EventFields } from '@events-helsinki/components/types/event-types';
+  HELSINKI_OCD_DIVISION_ID,
+} from '@events-helsinki/components';
+import type { EventFields } from '@events-helsinki/components';
 import React from 'react';
 import {
   getEventCategories,
@@ -34,6 +35,8 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
         pageSize: 100,
         params: new URLSearchParams(searchParams),
         sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+        // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+        [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
         // Don't use superEventType when experimenting:
         // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
         // superEventType: ['umbrella', 'none']

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -12,6 +12,8 @@ import {
   EVENT_SORT_OPTIONS,
   EventList,
   useClearClosedEventsFromApolloCache,
+  HELSINKI_OCD_DIVISION_ID,
+  EVENT_SEARCH_FILTERS,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -41,6 +43,10 @@ const useSearchQuery = () => {
       params: searchParams,
       place: params.place,
       sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+      // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+      // NOTE: This is not needed if using any `*Ongoing` -filter as
+      // they automatically limit the results to city of Helsinki events.
+      [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
       // Don't use superEventType when experimenting:
       // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
       // superEventType: ['umbrella', 'none']

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -181,6 +181,7 @@ export const getEventSearchVariables = ({
   superEventType,
   superEvent,
   place,
+  division,
 }: {
   include: string[];
   language?: AppLanguage;
@@ -190,6 +191,7 @@ export const getEventSearchVariables = ({
   superEventType?: string[];
   superEvent?: string;
   place?: string;
+  division?: string[];
 }): QueryEventListArgs => {
   const {
     categories,
@@ -259,6 +261,7 @@ export const getEventSearchVariables = ({
   return {
     [EVENT_SEARCH_FILTERS.TEXT]: !isEmpty(text) ? text?.join(',') : undefined, // NOTE: only *OngoingAnd supports Array.
     [EVENT_SEARCH_FILTERS.ONGOING]: true,
+    [EVENT_SEARCH_FILTERS.DIVISIONS]: division,
     end,
     include,
     publisherAncestor,

--- a/apps/sports-helsinki/config/vitest/mocks/eventListMocks.ts
+++ b/apps/sports-helsinki/config/vitest/mocks/eventListMocks.ts
@@ -7,7 +7,12 @@ import type {
   EventType,
   QueryEventListArgs,
 } from '@events-helsinki/components';
-import { EventListDocument, EventTypeId } from '@events-helsinki/components';
+import {
+  EVENT_SEARCH_FILTERS,
+  EventListDocument,
+  EventTypeId,
+  HELSINKI_OCD_DIVISION_ID,
+} from '@events-helsinki/components';
 
 export const baseVariables = {
   end: '',
@@ -21,6 +26,8 @@ export const baseVariables = {
   publisherAncestor: null,
   sort: 'end_time',
   start: 'now',
+  // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+  [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
   // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   // superEventType: ['umbrella', 'none'],
 };

--- a/apps/sports-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
+++ b/apps/sports-helsinki/src/domain/event/useSimilarEventsQueryVariables.tsx
@@ -1,5 +1,8 @@
-import { EVENT_SORT_OPTIONS } from '@events-helsinki/components/constants/event-constants';
-import { EventTypeId } from '@events-helsinki/components/types';
+import {
+  EVENT_SORT_OPTIONS,
+  EventTypeId,
+  HELSINKI_OCD_DIVISION_ID,
+} from '@events-helsinki/components';
 import type { EventFields } from '@events-helsinki/components/types/event-types';
 import React from 'react';
 import { EVENT_SEARCH_FILTERS } from '../search/eventSearch/constants';
@@ -31,6 +34,8 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
         pageSize: 100,
         params: new URLSearchParams(searchParams),
         sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+        // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+        [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
         // Don't use superEventType when experimenting:
         // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512)
         // superEventType: ['umbrella', 'none']

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
@@ -37,6 +37,7 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
   publisherAncestor: EventSearchParams['publisherAncestor'];
   page: EventSearchParams['page'];
   pageSize: EventSearchParams['pageSize'];
+  division: EventSearchParams['division'];
 
   /**
    * Map the combined search form fields to the event search query variables.

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -1,7 +1,9 @@
 import {
   EventTypeId,
   UnifiedSearchLanguage,
-} from '@events-helsinki/components/types';
+  EVENT_SEARCH_FILTERS,
+  HELSINKI_OCD_DIVISION_ID,
+} from '@events-helsinki/components';
 import mockRouter from 'next-router-mock';
 import qs from 'query-string';
 import type {
@@ -161,6 +163,10 @@ describe('CombinedSearchFormAdapter', () => {
           publisher: null,
           publisherAncestor: null,
           include: ['keywords', 'location'],
+          // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+          // NOTE: This is not needed if using any `*Ongoing` -filter as
+          // they automatically limit the results to city of Helsinki events.
+          [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
           // Removed to experiment:
           // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
           // superEventType: ['umbrella', 'none'],

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
@@ -1,4 +1,9 @@
-import { EventTypeId, TARGET_GROUPS } from '@events-helsinki/components';
+import {
+  EVENT_SEARCH_FILTERS,
+  EventTypeId,
+  HELSINKI_OCD_DIVISION_ID,
+  TARGET_GROUPS,
+} from '@events-helsinki/components';
 import type { CombinedSearchAdapterInput } from '../../types';
 import EventSearchAdapter from '../EventSearchAdapter';
 
@@ -69,6 +74,10 @@ describe('EventSearchAdapter', () => {
           publisher: null,
           publisherAncestor: 'ahjo:00001',
           include: ['keywords', 'location'],
+          // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+          // NOTE: This is not needed if using any `*Ongoing` -filter as
+          // they automatically limit the results to city of Helsinki events.
+          [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
           // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
           // superEventType: ['umbrella', 'none'],
           // Added for courses in LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`CombinedSearchProvider > reads the context properly 1`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
 </div>
 `;
@@ -35,17 +35,17 @@ exports[`CombinedSearchProvider > reads the context properly 2`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
+    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
 </div>
 `;
@@ -60,92 +60,17 @@ exports[`CombinedSearchProvider > reads the context properly 3`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":"testorg","publisherAncestor":null,"pageSize":10}
+    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":"testorg","publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10}
+    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10}
-  </p>
-</div>
-`;
-
-exports[`CombinedSearchProvider reads the context properly 1`] = `
-<div>
-  <p
-    data-test-id="formValues"
-  >
-    {"text":"test text","sportsCategories":[],"targetGroups":[],"keywords":[]}
-  </p>
-  <p
-    data-test-id="event-searchVariables"
-  >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10}
-  </p>
-  <p
-    data-test-id="course-searchVariables"
-  >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
-  </p>
-  <p
-    data-test-id="venue-searchVariables"
-  >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
-  </p>
-</div>
-`;
-
-exports[`CombinedSearchProvider reads the context properly 2`] = `
-<div>
-  <p
-    data-test-id="formValues"
-  >
-    {"text":"test text","sportsCategories":["gym","playgrounds"],"targetGroups":[],"keywords":[]}
-  </p>
-  <p
-    data-test-id="event-searchVariables"
-  >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":10}
-  </p>
-  <p
-    data-test-id="course-searchVariables"
-  >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
-  </p>
-  <p
-    data-test-id="venue-searchVariables"
-  >
-    {"xFullText":"test text","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":10}
-  </p>
-</div>
-`;
-
-exports[`CombinedSearchProvider reads the context properly 3`] = `
-<div>
-  <p
-    data-test-id="formValues"
-  >
-    {"text":"","sportsCategories":[],"targetGroups":[],"organization":"testorg","keywords":[]}
-  </p>
-  <p
-    data-test-id="event-searchVariables"
-  >
-    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":"testorg","publisherAncestor":null,"pageSize":10}
-  </p>
-  <p
-    data-test-id="course-searchVariables"
-  >
-    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10}
-  </p>
-  <p
-    data-test-id="venue-searchVariables"
-  >
-    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10}
+    {"xFullText":"","xOngoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":"testorg","publisherAncestor":null,"pageSize":10,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
 </div>
 `;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
@@ -66,5 +66,9 @@ export const initialEventSearchAdapterValues = {
   superEvent: undefined,
   publisher: null,
   publisherAncestor: null,
+  // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+  // NOTE: This is not needed if using any `*Ongoing` -filter as
+  // they automatically limit the results to city of Helsinki events.
+  division: [HELSINKI_OCD_DIVISION_ID],
   pageSize: 10,
 } as const satisfies EventSearchParams;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -114,6 +114,7 @@ export type EventSearchParams = Pick<
   | 'publisherAncestor'
   | 'page'
   | 'pageSize'
+  | 'division'
 >;
 
 /** The fields that are used by the Venue search. */

--- a/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -1,5 +1,9 @@
 import type { AppLanguage } from '@events-helsinki/components';
-import { DATE_TYPES, EVENT_SORT_OPTIONS } from '@events-helsinki/components';
+import {
+  DATE_TYPES,
+  EVENT_SORT_OPTIONS,
+  HELSINKI_OCD_DIVISION_ID,
+} from '@events-helsinki/components';
 import { advanceTo, clear } from 'jest-date-mock';
 
 import { EVENT_DEFAULT_SEARCH_FILTERS } from '../constants';
@@ -40,6 +44,7 @@ describe('getEventSearchVariables function', () => {
     pageSize: 10,
     sortOrder: EVENT_SORT_OPTIONS.END_TIME,
     superEventType: [],
+    division: [HELSINKI_OCD_DIVISION_ID],
   };
 
   it('should return start=now if start time is in past/today', () => {

--- a/apps/sports-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -191,6 +191,7 @@ export enum EVENT_SEARCH_FILTERS {
   SUITABLE = 'suitableFor',
   EVENT_TYPE = 'eventType',
   TEXT = 'text',
+  DIVISIONS = 'division',
 }
 
 export const CATEGORY_CATALOG = {

--- a/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -175,6 +175,7 @@ export const getEventSearchVariables = ({
   superEvent,
   place,
   eventType,
+  division,
 }: {
   include: string[];
   language?: AppLanguage;
@@ -185,6 +186,7 @@ export const getEventSearchVariables = ({
   superEvent?: string;
   place?: string;
   eventType?: (EventTypeId.Course | EventTypeId.General)[];
+  division: string[];
 }): QueryEventListArgs => {
   const {
     keyword,
@@ -229,6 +231,7 @@ export const getEventSearchVariables = ({
   return {
     xFullText: text?.join(', '),
     xOngoing: true,
+    [EVENT_SEARCH_FILTERS.DIVISIONS]: division,
     isFree: isFree || undefined,
     end,
     include,

--- a/apps/sports-helsinki/src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx
+++ b/apps/sports-helsinki/src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx
@@ -1,5 +1,9 @@
-import { EVENT_SORT_OPTIONS } from '@events-helsinki/components/constants';
-import { EventTypeId } from '@events-helsinki/components/types';
+import {
+  EventTypeId,
+  EVENT_SEARCH_FILTERS,
+  EVENT_SORT_OPTIONS,
+  HELSINKI_OCD_DIVISION_ID,
+} from '@events-helsinki/components';
 import * as React from 'react';
 import { render, screen, waitFor } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
@@ -22,6 +26,10 @@ const similarEventQueryVariables = {
   include: ['keywords', 'location'],
   start: 'now',
   sort: EVENT_SORT_OPTIONS.END_TIME,
+  // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+  // NOTE: This is not needed if using any `*Ongoing` -filter as
+  // they automatically limit the results to city of Helsinki events.
+  [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
   // Removed to experiment:
   // LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   // superEventType: 'none',

--- a/packages/components/config/tests/mocks/eventListMocks.ts
+++ b/packages/components/config/tests/mocks/eventListMocks.ts
@@ -1,6 +1,10 @@
 import type { FetchResult, GraphQLRequest } from '@apollo/client/core/index.js';
 import type { MockedResponse } from '@apollo/client/testing/index.js';
-import { DEFAULT_EVENT_SORT_OPTION } from '../../../src/constants/event-constants';
+import {
+  DEFAULT_EVENT_SORT_OPTION,
+  EVENT_SEARCH_FILTERS,
+} from '../../../src/constants/event-constants';
+import { HELSINKI_OCD_DIVISION_ID } from '../../../src/constants/venue-constants';
 import type { EventType } from '../../../src/types/event-types';
 import type {
   EventListQueryVariables,
@@ -24,6 +28,10 @@ export const baseVariables = {
   sort: DEFAULT_EVENT_SORT_OPTION,
   start: 'now',
   startsAfter: undefined,
+  // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+  // NOTE: This is not needed if using any `*Ongoing` -filter as
+  // they automatically limit the results to city of Helsinki events.
+  [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
   // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   // superEventType: ['umbrella', 'none'],
 };

--- a/packages/components/src/components/domain/event/queryUtils.ts
+++ b/packages/components/src/components/domain/event/queryUtils.ts
@@ -6,6 +6,7 @@ import {
   EVENT_SORT_OPTIONS,
   SIMILAR_EVENTS_AMOUNT,
 } from '../../../constants/event-constants';
+import { HELSINKI_OCD_DIVISION_ID } from '../../../constants/venue-constants';
 import type { EventFields } from '../../../types/event-types';
 import type {
   EventListQuery,
@@ -223,6 +224,10 @@ export const useLocationUpcomingEventsQuery = ({
     start: 'now',
     sort: EVENT_SORT_OPTIONS.END_TIME,
     publisherAncestor: null,
+    // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+    // NOTE: This is not needed if using any `*Ongoing` -filter as
+    // they automatically limit the results to city of Helsinki events.
+    [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
     // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
     // superEventType: 'none',
     pageSize,

--- a/packages/components/src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
+++ b/packages/components/src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
@@ -1,8 +1,5 @@
 import { clear } from 'console';
 
-import { advanceTo } from 'jest-date-mock';
-import * as React from 'react';
-
 import { render, screen, waitFor } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
 import {
@@ -13,6 +10,10 @@ import {
   fakeTargetGroup,
 } from '@/test-utils/mockDataUtils';
 import { createEventListRequestAndResultMocks } from '@/test-utils/mocks/eventListMocks';
+import { advanceTo } from 'jest-date-mock';
+import * as React from 'react';
+import { EVENT_SEARCH_FILTERS } from '../../../../../constants/event-constants';
+import { HELSINKI_OCD_DIVISION_ID } from '../../../../../constants/venue-constants';
 import { EventTypeId } from '../../../../../types/generated/graphql';
 import type { EventFieldsFragment } from '../../../../../types/generated/graphql';
 import SimilarEvents from '../SimilarEvents';
@@ -73,6 +74,10 @@ const similarEventFilters = {
   publisher: null,
   sort: 'end_time',
   start: 'now',
+  // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
+  // NOTE: This is not needed if using any `*Ongoing` -filter as
+  // they automatically limit the results to city of Helsinki events.
+  [EVENT_SEARCH_FILTERS.DIVISIONS]: [HELSINKI_OCD_DIVISION_ID],
   // Removed to experiment LIIKUNTA-512 (https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-512).
   // superEventType: ['umbrella', 'none'],
   keywordOrSet2: [''],

--- a/packages/components/src/constants/event-constants.ts
+++ b/packages/components/src/constants/event-constants.ts
@@ -49,8 +49,21 @@ export enum EVENT_SEARCH_FILTERS {
   CATEGORIES = 'categories',
   HOBBY_TYPES = 'hobbyTypes',
   DATE_TYPES = 'dateTypes',
-  DIVISIONS = 'divisions',
+  /**
+   * Filter by city division ids.
+   *
+   * NOTE: Using any `*Ongoing` -filter will automatically limit the results to
+   * city of Helsinki events.
+   *
+   * NOTE 2: another option is to use `helsinkiOnly` filter to limit the results
+   * @see EVENT_SEARCH_FILTERS.HELSINKI_ONLY.
+   */
+  DIVISIONS = 'division',
   END = 'end',
+  /**
+   * The `helsinkiOnly` filter sets a `publisherAncestor` to city of Helsinki.
+   * @see CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID
+   */
   HELSINKI_ONLY = 'helsinkiOnly',
   IS_FREE = 'isFree',
   KEYWORD = 'keyword',


### PR DESCRIPTION
TH-1429.

NOTE: This affects in every apps searches:
- event / course search
- similar events
- upcoming events

The event search result list should not contain events outside the city of Helsinki. This commit fixes the event list search variables to contain a city of Helsinki division filter.

The `*Ongoing*` -queries in LinkedEvents are using a search index (cache) that stores only the city of Helsinki events, but when the *Ongoing* -filter is not in use, the result set will contain also events outside the city of Helsinki. When the `allOngoingAnd` text query filter was replaced with a newer `xFullText` filter, the result set was no longer limited to city of Helsinki events (by the search index). To fix that, a new division filter is taken in action.

NOTE: This should not be mixed with the `helsinkiOnly` -filter, that is still active in code base (but might be hidden in UI). The `helsinkiOnly` filter currently limits the result set by filtering it with `publisherAnchestor` field value (ahjo:00001; Helsinki;  https://api.hel.fi/linkedevents/v1/organization/ahjo:00001/).