### PR TITLE
fix(apps): use legacyBehavior for next-links used by RCHC-lib

### DIFF
--- a/apps/events-helsinki/src/hooks/useEventsRHHCConfig.tsx
+++ b/apps/events-helsinki/src/hooks/useEventsRHHCConfig.tsx
@@ -71,7 +71,7 @@ export default function useEventsRHHCConfig(args: {
         Head: (props: any) => <Head {...props} />,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Link: ({ href, ...props }: any) => (
-          <Link href={href || ''} {...props} />
+          <Link legacyBehavior href={href || ''} {...props} />
         ),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         EventCardContent: (props: any) => (

--- a/apps/hobbies-helsinki/src/hooks/useHobbiesRHHCConfig.tsx
+++ b/apps/hobbies-helsinki/src/hooks/useHobbiesRHHCConfig.tsx
@@ -69,7 +69,7 @@ export default function useHobbiesRHHCConfig(args: {
         Head: (props: any) => <Head {...props} />,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Link: ({ href, ...props }: any) => (
-          <Link href={href || ''} {...props} />
+          <Link legacyBehavior href={href || ''} {...props} />
         ),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         EventCardContent: (props: any) => (

--- a/apps/sports-helsinki/src/hooks/useSportsRHHCConfig.tsx
+++ b/apps/sports-helsinki/src/hooks/useSportsRHHCConfig.tsx
@@ -69,7 +69,7 @@ export default function useSportsRHHCConfig(args: {
         Head: (props: any) => <Head {...props} />,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Link: ({ href, ...props }: any) => (
-          <Link href={href || ''} {...props} />
+          <Link legacyBehavior href={href || ''} {...props} />
         ),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         EventCardContent: (props: any) => (


### PR DESCRIPTION
TH-1427.

Use a `legacyBehavior` for next/link used by RCHC-lib to get rid of double a-elements (a-element inside another), which broke the event info link styles by adding text decorations etc. It is also against the HTML-standard. See more about `legacyBehavior` from https://nextjs.org/docs/14/pages/api-reference/components/link#legacybehavior.

The `legacyBehavior` for next/link is needed while the `<a>` is still injected in the Link component in react-helsinki-headless-cms -library. See
https://github.com/City-of-Helsinki/react-helsinki-headless-cms/blob/130fafdabf8007143ae32f4866d8062c3e5afbcd/src/core/link/LinkBase.tsx#L229-L258.

<img width="1296" height="679" alt="image" src="https://github.com/user-attachments/assets/e51cd155-a307-40b2-a53b-58e22b70890c" />

<img width="367" height="911" alt="image" src="https://github.com/user-attachments/assets/d5bbb8a4-1a38-4d5e-bf39-ea585e52f654" />
