### PR TITLE
chore: ignore ResizeObserver client Sentry errors

### DIFF
--- a/apps/events-helsinki/sentry.client.config.ts
+++ b/apps/events-helsinki/sentry.client.config.ts
@@ -44,5 +44,6 @@ Sentry.init({
      * @link https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded/50387233#50387233
      */
     'ResizeObserver loop limit exceeded',
+    'ResizeObserver loop completed with undelivered notifications.',
   ],
 });

--- a/apps/hobbies-helsinki/sentry.client.config.ts
+++ b/apps/hobbies-helsinki/sentry.client.config.ts
@@ -43,5 +43,6 @@ Sentry.init({
      * @link https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded/50387233#50387233
      */
     'ResizeObserver loop limit exceeded',
+    'ResizeObserver loop completed with undelivered notifications.',
   ],
 });

--- a/apps/sports-helsinki/sentry.client.config.ts
+++ b/apps/sports-helsinki/sentry.client.config.ts
@@ -43,5 +43,6 @@ Sentry.init({
      * @link https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded/50387233#50387233
      */
     'ResizeObserver loop limit exceeded',
+    'ResizeObserver loop completed with undelivered notifications.',
   ],
 });


### PR DESCRIPTION
TH-1342.

See more: https://github.com/vercel/next.js/discussions/51551.
