### PR TITLE
chore(test-coverage): add vitest coverage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ yarn-error.log*
 
 .vercel
 proxies/events-graphql-federation/router
+sonar-report.json
+sonar-report.xml

--- a/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
+++ b/apps/events-helsinki/browser-tests/search-page/search-page.testcafe.ts
@@ -32,7 +32,7 @@ test('Verify searching', async () => {
 test('Verify navigation between the search page and event details page', async (t) => {
   await searchPage.verify();
   const results = searchPage.results;
-  await t.expect(results.count).eql(10 * 2); // all links twice
+  await t.expect(results.count).eql(10);
   const firstCard = results.nth(0);
   const lastCard = results.nth(-1);
   testNavigationFromSearchToDetailsAndBack(firstCard);

--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -159,6 +159,7 @@
     "vite-plugin-css-injected-by-js": "3.5.2",
     "vitest": "3.2.4",
     "vitest-axe": "0.1.0",
+    "vitest-sonar-reporter": "2.0.4",
     "waait": "^1.0.5",
     "webpack": "5.100.1"
   }

--- a/apps/events-helsinki/sonar-project.properties
+++ b/apps/events-helsinki/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey = City-of-Helsinki_tapahtumat-ui
 sonar.organization = city-of-helsinki
-sonar.exclusions = **/__tests__/**,**/browser-tests/**
+sonar.exclusions = **/__tests__/**,**/browser-tests/**,<rootDir>/.next/**,<rootDir>/public/**,<rootDir>/styles/**,<rootDir>/node_modules/**,<rootDir>/coverage/**,<rootDir>/pages/**
 sonar.sources = src
 sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/apps/events-helsinki/vitest.config.ts
+++ b/apps/events-helsinki/vitest.config.ts
@@ -53,10 +53,7 @@ const aliasPaths = paths
   : [];
 
 export default defineConfig({
-  plugins: [
-    react(),
-    cssInjectedByJsPlugin(), // CSS transformation: CSS/Image handling in Jest's transform.
-  ],
+  plugins: [react(), cssInjectedByJsPlugin()],
   test: {
     environment: 'jsdom',
     globals: true, // Makes test, expect, vi global
@@ -64,25 +61,41 @@ export default defineConfig({
     cache: {
       dir: '../../.cache/events-helsinki/vitest', // Vitest specific cache
     },
-    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'], // Match your Jest testMatch
+    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: [...configDefaults.exclude, './.next/', '/__mocks__/'],
-    // Optional: Configure coverage if needed (equivalent to Jest's collectCoverageFrom, coverageDirectory)
-    // coverage: {
-    //   provider: 'v8', // or 'istanbul'
-    //   reporter: ['json', 'html', 'text'],
-    //   include: ['src/**/*.{ts,tsx,js,jsx}'],
-    //   exclude: [
-    //     'src/**/*.test.ts',
-    //     'src/.next/**',
-    //     // Add other patterns from Jest's coveragePathIgnorePatterns if needed
-    //     // Be careful with node_modules here, Vitest handles them differently
-    //   ],
-    // },
-    // deps: {
-    //   interopDefault: true, // Helps with CommonJS default exports
-    // Force these packages to be transformed
-    //   inline: ['react-helsinki-headless-cms', '@apollo/client', '@next/env'],
-    // },
+    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      json: 'sonar-report.json',
+      'vitest-sonar-reporter': 'sonar-report.xml',
+    },
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['lcov', 'html', 'text'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/.next/**',
+        '**/*.d.ts',
+        '**/*.json',
+        '**/*.xml',
+        '**/*.yaml',
+        '**/*.md',
+        '**/*.html',
+        '**/*.css',
+        '**/*.properties',
+        '*.config.*js',
+        'node_modules/',
+        'browser-tests/',
+        'build/',
+        'codegen.ts',
+        'src/index.tsx',
+        '**/__tests__/**',
+        '**/__snapshots__/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/query.ts',
+      ],
+    },
   },
   resolve: {
     alias: [

--- a/apps/hobbies-helsinki/browser-tests/search-page/search-page.testcafe.ts
+++ b/apps/hobbies-helsinki/browser-tests/search-page/search-page.testcafe.ts
@@ -28,7 +28,7 @@ test('Verify searching', async () => {
 test('Verify navigation between the search page and event details page', async (t) => {
   await searchPage.verify();
   const results = searchPage.results;
-  await t.expect(results.count).eql(10 * 2); // all links twice
+  await t.expect(results.count).eql(10);
   const firstCard = results.nth(0);
   const lastCard = results.nth(-1);
   testNavigationFromSearchToDetailsAndBack(firstCard);

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -159,6 +159,7 @@
     "vite-plugin-css-injected-by-js": "3.5.2",
     "vitest": "3.2.4",
     "vitest-axe": "0.1.0",
+    "vitest-sonar-reporter": "2.0.4",
     "waait": "^1.0.5",
     "webpack": "5.100.1"
   }

--- a/apps/hobbies-helsinki/sonar-project.properties
+++ b/apps/hobbies-helsinki/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey = City-of-Helsinki_harrastukset-ui
 sonar.organization = city-of-helsinki
-sonar.exclusions = **/__tests__/**,**/browser-tests/**
+sonar.exclusions = **/__tests__/**,**/browser-tests/**,<rootDir>/.next/**,<rootDir>/public/**,<rootDir>/styles/**,<rootDir>/node_modules/**,<rootDir>/coverage/**,<rootDir>/pages/**
 sonar.sources = src
 sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/apps/hobbies-helsinki/vitest.config.ts
+++ b/apps/hobbies-helsinki/vitest.config.ts
@@ -53,10 +53,7 @@ const aliasPaths = paths
   : [];
 
 export default defineConfig({
-  plugins: [
-    react(),
-    cssInjectedByJsPlugin(), // CSS transformation: CSS/Image handling in Jest's transform.
-  ],
+  plugins: [react(), cssInjectedByJsPlugin()],
   test: {
     environment: 'jsdom',
     globals: true, // Makes test, expect, vi global
@@ -64,25 +61,41 @@ export default defineConfig({
     cache: {
       dir: '../../.cache/hobbies-helsinki/vitest', // Vitest specific cache
     },
-    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'], // Match your Jest testMatch
+    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: [...configDefaults.exclude, './.next/', '/__mocks__/'],
-    // Optional: Configure coverage if needed (equivalent to Jest's collectCoverageFrom, coverageDirectory)
-    // coverage: {
-    //   provider: 'v8', // or 'istanbul'
-    //   reporter: ['json', 'html', 'text'],
-    //   include: ['src/**/*.{ts,tsx,js,jsx}'],
-    //   exclude: [
-    //     'src/**/*.test.ts',
-    //     'src/.next/**',
-    //     // Add other patterns from Jest's coveragePathIgnorePatterns if needed
-    //     // Be careful with node_modules here, Vitest handles them differently
-    //   ],
-    // },
-    // deps: {
-    //   interopDefault: true, // Helps with CommonJS default exports
-    // Force these packages to be transformed
-    //   inline: ['react-helsinki-headless-cms', '@apollo/client', '@next/env'],
-    // },
+    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      json: 'sonar-report.json',
+      'vitest-sonar-reporter': 'sonar-report.xml',
+    },
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['lcov', 'html', 'text'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/.next/**',
+        '**/*.d.ts',
+        '**/*.json',
+        '**/*.xml',
+        '**/*.yaml',
+        '**/*.md',
+        '**/*.html',
+        '**/*.css',
+        '**/*.properties',
+        '*.config.*js',
+        'node_modules/',
+        'browser-tests/',
+        'build/',
+        'codegen.ts',
+        'src/index.tsx',
+        '**/__tests__/**',
+        '**/__snapshots__/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/query.ts',
+      ],
+    },
   },
   resolve: {
     alias: [

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -167,6 +167,7 @@
     "vite-plugin-css-injected-by-js": "3.5.2",
     "vitest": "3.2.4",
     "vitest-axe": "0.1.0",
+    "vitest-sonar-reporter": "2.0.4",
     "waait": "^1.0.5",
     "webpack": "5.100.1"
   }

--- a/apps/sports-helsinki/sonar-project.properties
+++ b/apps/sports-helsinki/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey = City-of-Helsinki_liikunta-ui
 sonar.organization = city-of-helsinki
-sonar.exclusions = **/__tests__/**,**/browser-tests/**
+sonar.exclusions = **/__tests__/**,**/browser-tests/**,<rootDir>/.next/**,<rootDir>/public/**,<rootDir>/styles/**,<rootDir>/node_modules/**,<rootDir>/coverage/**,<rootDir>/pages/**
 sonar.sources = src
 sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/apps/sports-helsinki/vitest.config.ts
+++ b/apps/sports-helsinki/vitest.config.ts
@@ -53,10 +53,7 @@ const aliasPaths = paths
   : [];
 
 export default defineConfig({
-  plugins: [
-    react(),
-    cssInjectedByJsPlugin(), // CSS transformation: CSS/Image handling in Jest's transform.
-  ],
+  plugins: [react(), cssInjectedByJsPlugin()],
   test: {
     environment: 'jsdom',
     globals: true, // Makes test, expect, vi global
@@ -64,25 +61,41 @@ export default defineConfig({
     cache: {
       dir: '../../.cache/sports-helsinki/vitest', // Vitest specific cache
     },
-    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'], // Match your Jest testMatch
+    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: [...configDefaults.exclude, './.next/', '/__mocks__/'],
-    // Optional: Configure coverage if needed (equivalent to Jest's collectCoverageFrom, coverageDirectory)
-    // coverage: {
-    //   provider: 'v8', // or 'istanbul'
-    //   reporter: ['json', 'html', 'text'],
-    //   include: ['src/**/*.{ts,tsx,js,jsx}'],
-    //   exclude: [
-    //     'src/**/*.test.ts',
-    //     'src/.next/**',
-    //     // Add other patterns from Jest's coveragePathIgnorePatterns if needed
-    //     // Be careful with node_modules here, Vitest handles them differently
-    //   ],
-    // },
-    // deps: {
-    //   interopDefault: true, // Helps with CommonJS default exports
-    // Force these packages to be transformed
-    //   inline: ['react-helsinki-headless-cms', '@apollo/client', '@next/env'],
-    // },
+    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      json: 'sonar-report.json',
+      'vitest-sonar-reporter': 'sonar-report.xml',
+    },
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['lcov', 'html', 'text'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/.next/**',
+        '**/*.d.ts',
+        '**/*.json',
+        '**/*.xml',
+        '**/*.yaml',
+        '**/*.md',
+        '**/*.html',
+        '**/*.css',
+        '**/*.properties',
+        '*.config.*js',
+        'node_modules/',
+        'browser-tests/',
+        'build/',
+        'codegen.ts',
+        'src/index.tsx',
+        '**/__tests__/**',
+        '**/__snapshots__/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/query.ts',
+      ],
+    },
   },
   resolve: {
     alias: [

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -99,9 +99,8 @@ class EventSearchPage {
     if (searchType === 'Venue')
       await t.expect(this.notFoundResultVenues.exists).notOk();
     const results = this.results;
-    // NOTE: the link is there twice
-    await t.expect(results.count).gte(minResults * 2); // At least one result should be found.
-    await t.expect(results.count).lte(maxResults * 2); // max 10 result per page
+    await t.expect(results.count).gte(minResults); // At least one result should be found.
+    await t.expect(results.count).lte(maxResults); // max 10 result per page
   }
 
   public async expectNoSearchResults(searchType: SearchType = 'GeneralEvent') {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -155,6 +155,7 @@
     "vite": "7.0.4",
     "vitest": "3.2.4",
     "vitest-axe": "0.1.0",
+    "vitest-sonar-reporter": "2.0.4",
     "waait": "^1.0.5",
     "webpack": "5.100.1"
   },

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -19,25 +19,41 @@ export default defineConfig(({ mode }) => ({
     cache: {
       dir: '../../.cache/events-helsinki-components/vitest', // Vitest specific cache
     },
-    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'], // Match your Jest testMatch
+    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: [...configDefaults.exclude, './.next/', '/__mocks__/'],
-    // Optional: Configure coverage if needed (equivalent to Jest's collectCoverageFrom, coverageDirectory)
-    // coverage: {
-    //   provider: 'v8', // or 'istanbul'
-    //   reporter: ['json', 'html', 'text'],
-    //   include: ['src/**/*.{ts,tsx,js,jsx}'],
-    //   exclude: [
-    //     'src/**/*.test.ts',
-    //     'src/.next/**',
-    //     // Add other patterns from Jest's coveragePathIgnorePatterns if needed
-    //     // Be careful with node_modules here, Vitest handles them differently
-    //   ],
-    // },
-    // deps: {
-    //   interopDefault: true, // Helps with CommonJS default exports
-    // Force these packages to be transformed
-    //   inline: ['react-helsinki-headless-cms', '@apollo/client', '@next/env'],
-    // },
+    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      json: 'sonar-report.json',
+      'vitest-sonar-reporter': 'sonar-report.xml',
+    },
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['lcov', 'html', 'text'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/.next/**',
+        '**/*.d.ts',
+        '**/*.json',
+        '**/*.xml',
+        '**/*.yaml',
+        '**/*.md',
+        '**/*.html',
+        '**/*.css',
+        '**/*.properties',
+        '*.config.*js',
+        'node_modules/',
+        'browser-tests/',
+        'build/',
+        'codegen.ts',
+        'src/index.tsx',
+        '**/__tests__/**',
+        '**/__snapshots__/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/query.ts',
+      ],
+    },
   },
   resolve: {
     alias: [

--- a/packages/graphql-proxy-server/package.json
+++ b/packages/graphql-proxy-server/package.json
@@ -71,6 +71,7 @@
     "typescript": "5.8.3",
     "vite": "7.0.4",
     "vitest": "3.2.4",
+    "vitest-sonar-reporter": "2.0.4",
     "webpack": "5.100.1",
     "winston": "3.17.0"
   },

--- a/packages/graphql-proxy-server/vitest.config.ts
+++ b/packages/graphql-proxy-server/vitest.config.ts
@@ -16,25 +16,41 @@ export default defineConfig(({ mode }) => ({
     cache: {
       dir: '../../.cache/events-graphql-proxy/vitest', // Vitest specific cache
     },
-    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'], // Match your Jest testMatch
+    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: [...configDefaults.exclude, './.next/', '/__mocks__/'],
-    // Optional: Configure coverage if needed (equivalent to Jest's collectCoverageFrom, coverageDirectory)
-    // coverage: {
-    //   provider: 'v8', // or 'istanbul'
-    //   reporter: ['json', 'html', 'text'],
-    //   include: ['src/**/*.{ts,tsx,js,jsx}'],
-    //   exclude: [
-    //     'src/**/*.test.ts',
-    //     'src/.next/**',
-    //     // Add other patterns from Jest's coveragePathIgnorePatterns if needed
-    //     // Be careful with node_modules here, Vitest handles them differently
-    //   ],
-    // },
-    // deps: {
-    //   interopDefault: true, // Helps with CommonJS default exports
-    // Force these packages to be transformed
-    //   inline: ['react-helsinki-headless-cms', '@apollo/client', '@next/env'],
-    // },
+    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      json: 'sonar-report.json',
+      'vitest-sonar-reporter': 'sonar-report.xml',
+    },
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['lcov', 'html', 'text'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/.next/**',
+        '**/*.d.ts',
+        '**/*.json',
+        '**/*.xml',
+        '**/*.yaml',
+        '**/*.md',
+        '**/*.html',
+        '**/*.css',
+        '**/*.properties',
+        '*.config.*js',
+        'node_modules/',
+        'browser-tests/',
+        'build/',
+        'codegen.ts',
+        'src/index.tsx',
+        '**/__tests__/**',
+        '**/__snapshots__/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/query.ts',
+      ],
+    },
   },
   resolve: {
     alias: [],

--- a/proxies/events-graphql-proxy/package.json
+++ b/proxies/events-graphql-proxy/package.json
@@ -63,6 +63,7 @@
     "typescript": "5.8.3",
     "vite": "7.0.4",
     "vitest": "3.2.4",
+    "vitest-sonar-reporter": "2.0.4",
     "webpack": "5.100.1",
     "webpack-cli": "6.0.1",
     "webpack-node-externals": "3.0.0"

--- a/proxies/events-graphql-proxy/sonar-project.properties
+++ b/proxies/events-graphql-proxy/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey = City-of-Helsinki_events-graphql-proxy
 sonar.organization = city-of-helsinki
-sonar.exclusions = **/__tests__/**,**/browser-tests/**
+sonar.exclusions = **/__tests__/**,**/browser-tests/**,<rootDir>/coverage/**
 sonar.sources = src
 sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/proxies/events-graphql-proxy/vitest.config.ts
+++ b/proxies/events-graphql-proxy/vitest.config.ts
@@ -17,25 +17,41 @@ export default defineConfig(({ mode }) => ({
     cache: {
       dir: '../../.cache/events-graphql-proxy/vitest', // Vitest specific cache
     },
-    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'], // Match your Jest testMatch
+    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: [...configDefaults.exclude, './.next/', '/__mocks__/'],
-    // Optional: Configure coverage if needed (equivalent to Jest's collectCoverageFrom, coverageDirectory)
-    // coverage: {
-    //   provider: 'v8', // or 'istanbul'
-    //   reporter: ['json', 'html', 'text'],
-    //   include: ['src/**/*.{ts,tsx,js,jsx}'],
-    //   exclude: [
-    //     'src/**/*.test.ts',
-    //     'src/.next/**',
-    //     // Add other patterns from Jest's coveragePathIgnorePatterns if needed
-    //     // Be careful with node_modules here, Vitest handles them differently
-    //   ],
-    // },
-    // deps: {
-    //   interopDefault: true, // Helps with CommonJS default exports
-    // Force these packages to be transformed
-    //   inline: ['react-helsinki-headless-cms', '@apollo/client', '@next/env'],
-    // },
+    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      json: 'sonar-report.json',
+      'vitest-sonar-reporter': 'sonar-report.xml',
+    },
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['lcov', 'html', 'text'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/.next/**',
+        '**/*.d.ts',
+        '**/*.json',
+        '**/*.xml',
+        '**/*.yaml',
+        '**/*.md',
+        '**/*.html',
+        '**/*.css',
+        '**/*.properties',
+        '*.config.*js',
+        'node_modules/',
+        'browser-tests/',
+        'build/',
+        'codegen.ts',
+        'src/index.tsx',
+        '**/__tests__/**',
+        '**/__snapshots__/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/query.ts',
+      ],
+    },
   },
   resolve: {
     alias: [

--- a/proxies/venue-graphql-proxy/package.json
+++ b/proxies/venue-graphql-proxy/package.json
@@ -64,6 +64,7 @@
     "typescript": "5.8.3",
     "vite": "7.0.4",
     "vitest": "3.2.4",
+    "vitest-sonar-reporter": "2.0.4",
     "webpack": "5.100.1",
     "webpack-cli": "6.0.1",
     "webpack-node-externals": "3.0.0"

--- a/proxies/venue-graphql-proxy/sonar-project.properties
+++ b/proxies/venue-graphql-proxy/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey = City-of-Helsinki_venue-graphql-proxy
 sonar.organization = city-of-helsinki
-sonar.exclusions = **/__tests__/**,**/browser-tests/**
+sonar.exclusions = **/__tests__/**,**/browser-tests/**,<rootDir>/coverage/**
 sonar.sources = src
 sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/proxies/venue-graphql-proxy/vitest.config.ts
+++ b/proxies/venue-graphql-proxy/vitest.config.ts
@@ -17,25 +17,41 @@ export default defineConfig(({ mode }) => ({
     cache: {
       dir: '../../.cache/venue-graphql-proxy/vitest', // Vitest specific cache
     },
-    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'], // Match your Jest testMatch
+    include: ['src/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: [...configDefaults.exclude, './.next/', '/__mocks__/'],
-    // Optional: Configure coverage if needed (equivalent to Jest's collectCoverageFrom, coverageDirectory)
-    // coverage: {
-    //   provider: 'v8', // or 'istanbul'
-    //   reporter: ['json', 'html', 'text'],
-    //   include: ['src/**/*.{ts,tsx,js,jsx}'],
-    //   exclude: [
-    //     'src/**/*.test.ts',
-    //     'src/.next/**',
-    //     // Add other patterns from Jest's coveragePathIgnorePatterns if needed
-    //     // Be careful with node_modules here, Vitest handles them differently
-    //   ],
-    // },
-    // deps: {
-    //   interopDefault: true, // Helps with CommonJS default exports
-    // Force these packages to be transformed
-    //   inline: ['react-helsinki-headless-cms', '@apollo/client', '@next/env'],
-    // },
+    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      json: 'sonar-report.json',
+      'vitest-sonar-reporter': 'sonar-report.xml',
+    },
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['lcov', 'html', 'text'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/.next/**',
+        '**/*.d.ts',
+        '**/*.json',
+        '**/*.xml',
+        '**/*.yaml',
+        '**/*.md',
+        '**/*.html',
+        '**/*.css',
+        '**/*.properties',
+        '*.config.*js',
+        'node_modules/',
+        'browser-tests/',
+        'build/',
+        'codegen.ts',
+        'src/index.tsx',
+        '**/__tests__/**',
+        '**/__snapshots__/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/query.ts',
+      ],
+    },
   },
   resolve: {
     alias: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,6 +3193,7 @@ __metadata:
     vite: "npm:7.0.4"
     vitest: "npm:3.2.4"
     vitest-axe: "npm:0.1.0"
+    vitest-sonar-reporter: "npm:2.0.4"
     waait: "npm:^1.0.5"
     webpack: "npm:5.100.1"
   peerDependencies:
@@ -3314,6 +3315,7 @@ __metadata:
     uuid: "npm:11.1.0"
     vite: "npm:7.0.4"
     vitest: "npm:3.2.4"
+    vitest-sonar-reporter: "npm:2.0.4"
     webpack: "npm:5.100.1"
     winston: "npm:3.17.0"
   peerDependencies:
@@ -13164,6 +13166,7 @@ __metadata:
     typescript: "npm:5.8.3"
     vite: "npm:7.0.4"
     vitest: "npm:3.2.4"
+    vitest-sonar-reporter: "npm:2.0.4"
     webpack: "npm:5.100.1"
     webpack-cli: "npm:6.0.1"
     webpack-node-externals: "npm:3.0.0"
@@ -13342,6 +13345,7 @@ __metadata:
     vite-plugin-css-injected-by-js: "npm:3.5.2"
     vitest: "npm:3.2.4"
     vitest-axe: "npm:0.1.0"
+    vitest-sonar-reporter: "npm:2.0.4"
     waait: "npm:^1.0.5"
     webpack: "npm:5.100.1"
   languageName: unknown
@@ -15071,6 +15075,7 @@ __metadata:
     vite-plugin-css-injected-by-js: "npm:3.5.2"
     vitest: "npm:3.2.4"
     vitest-axe: "npm:0.1.0"
+    vitest-sonar-reporter: "npm:2.0.4"
     waait: "npm:^1.0.5"
     webpack: "npm:5.100.1"
   languageName: unknown
@@ -23089,6 +23094,7 @@ __metadata:
     vite-plugin-css-injected-by-js: "npm:3.5.2"
     vitest: "npm:3.2.4"
     vitest-axe: "npm:0.1.0"
+    vitest-sonar-reporter: "npm:2.0.4"
     waait: "npm:^1.0.5"
     webpack: "npm:5.100.1"
   languageName: unknown
@@ -25297,6 +25303,7 @@ __metadata:
     typescript: "npm:5.8.3"
     vite: "npm:7.0.4"
     vitest: "npm:3.2.4"
+    vitest-sonar-reporter: "npm:2.0.4"
     webpack: "npm:5.100.1"
     webpack-cli: "npm:6.0.1"
     webpack-node-externals: "npm:3.0.0"
@@ -25395,6 +25402,15 @@ __metadata:
   peerDependencies:
     vitest: ">=0.16.0"
   checksum: 26bba9eb2088b170220eb75138ee6865352b5c7821ce2a877935389cda03aa447cd4e508b17e3a86b7c23ec32126031170149182f8ea5514493d8021b361389b
+  languageName: node
+  linkType: hard
+
+"vitest-sonar-reporter@npm:2.0.4":
+  version: 2.0.4
+  resolution: "vitest-sonar-reporter@npm:2.0.4"
+  peerDependencies:
+    vitest: ">=1"
+  checksum: 68534956bc120a1a19f2ead565ebc4a16121912cbf19a9b38fb44a8bb79230314b5463fbfe02bcc8caa4383b471d26065af1b1f0a9d3ad3160fb0c702d750ec7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TH-1409.

The Vitest should make a coverage report for Sonarcloud. Therefore, this commit adds `vitest-sonar-reporter` as a dependency and configures the vitest coverage reporters.
