### PR TITLE
chore(sonar): configure sonar for packages/component

### DIFF
--- a/packages/components/sonar-project.properties
+++ b/packages/components/sonar-project.properties
@@ -1,0 +1,32 @@
+sonar.projectKey = City-of-Helsinki_events-components
+sonar.organization = city-of-helsinki
+sonar.exclusions = \
+  # Test files and directories
+  **/__tests__/**, \
+  **/__snapshots__/**, \
+  **/*.test.ts, \
+  **/*.spec.ts, \
+  **/*.test.tsx, \
+  **/*.spec.tsx, \
+  \
+  # Type definitions
+  **/*.d.ts, \
+  \
+  # Source code to exclude (assets, styles, types)
+  src/assets/**, \
+  src/styles/**, \
+  src/types/**, \
+  \
+  # Generated code, build artifacts, and dependencies
+  src/index.tsx, \
+  **/codegen.ts, \
+  **/query.ts, \
+  **/node_modules/**, \
+  **/build/**, \
+  **/browser-tests/**, \
+  **/*.config.*js, \
+  \
+  # Non-source files
+  **/*.json, **/*.xml, **/*.yaml, **/*.md, **/*.html, **/*.css, **/*.properties
+sonar.sources = src
+sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -32,7 +32,6 @@ export default defineConfig(({ mode }) => ({
       include: ['src/**/*.{ts,tsx,js,jsx}'],
       exclude: [
         'src/**/*.test.ts',
-        'src/.next/**',
         '**/*.d.ts',
         '**/*.json',
         '**/*.xml',
@@ -52,6 +51,9 @@ export default defineConfig(({ mode }) => ({
         '**/*.test.ts',
         '**/*.spec.ts',
         '**/query.ts',
+        'src/assets/**',
+        'src/styles/**',
+        'src/types/**',
       ],
     },
   },


### PR DESCRIPTION
TH-1409.

Add sonar-project.properties to packages/components. Update vitest test converage configuration and sync it with sonar.exclusions.

NOTE: The packages/components does not yet have a proejct in Sonarcloud.
