### PR TITLE
HH-440 | Show weekdays in event cards also for date ranges

### DIFF
--- a/packages/components/src/utils/__tests__/getDateRangeStr.test.ts
+++ b/packages/components/src/utils/__tests__/getDateRangeStr.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import getDateRangeStr from '../getDateRangeStr';
+
+type getDateRangeStrProps = Parameters<typeof getDateRangeStr>[0];
+
+describe('getDateRangeStr', () => {
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    // Set timezone to Europe/Helsinki for consistent test results
+    process.env.TZ = 'Europe/Helsinki';
+  });
+
+  afterEach(() => {
+    // Restore original timezone
+    process.env.TZ = originalTz;
+  });
+
+  const testCases = [
+    {
+      props: {
+        start: '2025-09-23T09:00:00Z',
+        end: '2025-09-23T10:00:00Z',
+        locale: 'fi',
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: 'Ti 23.9.2025, klo 12.00–13.00',
+    },
+    {
+      props: {
+        start: '2025-09-23T09:00:00Z',
+        end: '2025-09-23T10:00:00Z',
+        locale: 'fi',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: '23.9.2025, klo 12.00–13.00',
+    },
+    {
+      props: {
+        start: '2025-06-11T10:15:00Z',
+        end: '2025-06-12T11:15:00Z',
+        locale: 'fi',
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: 'Ke 11.6. – To 12.6.2025',
+    },
+    {
+      props: {
+        start: '2025-06-11T10:15:00Z',
+        end: '2025-06-12T11:15:00Z',
+        locale: 'fi',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: '11.6.–12.6.2025',
+    },
+    {
+      props: {
+        start: '2025-06-11T10:15:00Z',
+        end: '2026-06-12T11:15:00Z',
+        locale: 'fi',
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: 'Ke 11.6.2025 – Pe 12.6.2026',
+    },
+    {
+      props: {
+        start: '2025-06-11T10:15:00Z',
+        end: '2026-06-12T11:15:00Z',
+        locale: 'fi',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: '11.6.2025–12.6.2026',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2025-09-26T11:15:00Z',
+        locale: 'fi',
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: 'Ti 10.6. – Pe 26.9.2025',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2025-09-26T11:15:00Z',
+        locale: 'fi',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: '10.6.–26.9.2025',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2026-09-26T11:15:00Z',
+        locale: 'fi',
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: 'Ti 10.6.2025 – La 26.9.2026',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2026-09-26T11:15:00Z',
+        locale: 'fi',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'klo',
+      },
+      expected: '10.6.2025–26.9.2026',
+    },
+    {
+      props: {
+        start: '2025-09-23T09:00:00Z',
+        end: '2025-09-23T10:00:00Z',
+        locale: 'sv',
+        includeTime: true,
+        timeAbbreviation: 'kl.',
+      },
+      expected: 'Ti 23.9.2025, kl. 12:00–13:00',
+    },
+    {
+      props: {
+        start: '2025-09-23T09:00:00Z',
+        end: '2025-09-23T10:00:00Z',
+        locale: 'sv',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'kl.',
+      },
+      expected: '23.9.2025, kl. 12:00–13:00',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2025-09-28T11:15:00Z',
+        locale: 'sv',
+        includeTime: true,
+        timeAbbreviation: 'kl.',
+      },
+      expected: 'Ti 10.6. – Sö 28.9.2025',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2025-09-28T11:15:00Z',
+        locale: 'sv',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'kl.',
+      },
+      expected: '10.6.–28.9.2025',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2026-09-28T11:15:00Z',
+        locale: 'sv',
+        includeTime: true,
+        timeAbbreviation: 'kl.',
+      },
+      expected: 'Ti 10.6.2025 – Må 28.9.2026',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2026-09-28T11:15:00Z',
+        locale: 'sv',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'kl.',
+      },
+      expected: '10.6.2025–28.9.2026',
+    },
+    {
+      props: {
+        start: '2025-09-23T10:30:00Z',
+        end: '2025-09-23T11:15:00Z',
+        locale: 'en',
+        includeTime: true,
+        timeAbbreviation: 'at',
+      },
+      expected: 'Tue 23.9.2025, at 1:30 p.m.–2:15 p.m.',
+    },
+    {
+      props: {
+        start: '2025-09-23T10:30:00Z',
+        end: '2025-09-23T11:15:00Z',
+        locale: 'en',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'at',
+      },
+      expected: '23.9.2025, at 1:30 p.m.–2:15 p.m.',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2025-09-24T11:15:00Z',
+        locale: 'en',
+        includeTime: true,
+        timeAbbreviation: 'at',
+      },
+      expected: 'Tue 10.6. – Wed 24.9.2025',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2025-09-24T11:15:00Z',
+        locale: 'en',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'at',
+      },
+      expected: '10.6.–24.9.2025',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2026-09-24T11:15:00Z',
+        locale: 'en',
+        includeTime: true,
+        timeAbbreviation: 'at',
+      },
+      expected: 'Tue 10.6.2025 – Thu 24.9.2026',
+    },
+    {
+      props: {
+        start: '2025-06-10T10:15:00Z',
+        end: '2026-09-24T11:15:00Z',
+        locale: 'en',
+        includeWeekday: false,
+        includeTime: true,
+        timeAbbreviation: 'at',
+      },
+      expected: '10.6.2025–24.9.2026',
+    },
+  ] as const satisfies Array<
+    { props: getDateRangeStrProps } & { expected: string }
+  >;
+
+  it.each(testCases)(
+    'getDateRangeStr($props) == $expected',
+    ({ props, expected }) => {
+      expect(getDateRangeStr(props)).toStrictEqual(expected);
+    }
+  );
+});

--- a/packages/components/src/utils/getDateRangeStr.ts
+++ b/packages/components/src/utils/getDateRangeStr.ts
@@ -1,10 +1,4 @@
-import {
-  addDays,
-  isBefore,
-  isSameDay,
-  isSameMonth,
-  isSameYear,
-} from 'date-fns';
+import { addDays, isBefore, isSameDay, isSameYear } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import capitalize from 'lodash/capitalize';
 
@@ -38,7 +32,7 @@ const getDateRangeStr = ({
   const weekdayFormat = locale === 'en' ? 'eee' : 'eeeeee';
   const dateFormat = 'd.M.yyyy ';
   const timeFormat = getTimeFormat(language);
-  const weekdayStr = includeWeekday
+  const startWeekdayStr = includeWeekday
     ? `${capitalize(formatDate(startDate, weekdayFormat, language))} `
     : '';
   const timeAbbreviationStr = timeAbbreviation ? `${timeAbbreviation} ` : '';
@@ -49,14 +43,21 @@ const getDateRangeStr = ({
       ? `, ${timeAbbreviationStr}${formatDate(startDate, timeFormat, language)}`
       : '';
 
-    return [weekdayStr, dateStr, timeStr].join('');
+    return [startWeekdayStr, dateStr, timeStr].join('');
   } else {
     const endDate = toZonedTime(new Date(end), timeZone);
+    const endWeekdayStr = includeWeekday
+      ? `${capitalize(formatDate(endDate, weekdayFormat, language))} `
+      : '';
+
+    const formatDateRangeWithStartDateFormat = (startDateFormat: string) => {
+      const startDateStr = formatDate(startDate, startDateFormat);
+      const endDateStr = formatDate(endDate, 'd.M.yyyy');
+      const delimiter = startWeekdayStr || endWeekdayStr ? ' – ' : '–';
+      return `${startWeekdayStr}${startDateStr}${delimiter}${endWeekdayStr}${endDateStr}`;
+    };
 
     if (isSameDay(startDate, endDate) || isBefore(endDate, nextDay)) {
-      const weekdayStr = includeWeekday
-        ? `${capitalize(formatDate(startDate, weekdayFormat, language))} `
-        : '';
       const dateStr = formatDate(startDate, dateFormat, language);
       const startTimeStr = formatDate(startDate, timeFormat, language);
       const endTimeStr = formatDate(endDate, timeFormat, language);
@@ -64,22 +65,11 @@ const getDateRangeStr = ({
         ? `, ${timeAbbreviationStr}${startTimeStr}–${endTimeStr}`
         : '';
 
-      return [weekdayStr, dateStr, timeStr].join('');
-    } else if (isSameMonth(startDate, endDate)) {
-      const startDateStr = formatDate(startDate, 'd') + '.';
-      const endDateStr = formatDate(endDate, 'd.M.yyyy');
-
-      return `${startDateStr}–${endDateStr}`;
+      return [startWeekdayStr, dateStr, timeStr].join('');
     } else if (isSameYear(startDate, endDate)) {
-      const startDateStr = formatDate(startDate, 'd.M') + '.';
-      const endDateStr = formatDate(endDate, 'd.M.yyyy');
-
-      return `${startDateStr}–${endDateStr}`;
+      return formatDateRangeWithStartDateFormat('d.M.');
     } else {
-      const startDateStr = formatDate(startDate, 'd.M.yyyy');
-      const endDateStr = formatDate(endDate, 'd.M.yyyy');
-
-      return `${startDateStr}–${endDateStr}`;
+      return formatDateRangeWithStartDateFormat('d.M.yyyy');
     }
   }
 };


### PR DESCRIPTION
## Description

**Show weekdays** in event **cards** also for **date ranges**

Add tests for getDateRangeStr to document what is expected of its
output. Now the **month** is **always shown** in a date range regardless of
whether the start and end dates are in the same month or not, this is by
the **request** of hobbies-helsinki/events-helsinki **product owner**.

Related information in Finnish:
https://kielitoimistonohjepankki.fi/ohje/ajanilmaukset-aikavalit-1-1-31-1/
> Rajakohtailmauksessa voidaan esittää paitsi päivämäärät myös
> viikonpäivät. Koska ilmaus koostuu tällöin useammasta kuin yhdestä
> sanasta, ajatusviivan molemmin puolin jätetään selvyyden vuoksi väli.
> Samoin menetellään muissa vastaavissa tapauksissa:
>
>```
> ma 10.4. – pe 21.4.
> 100 eaa. – 50 eaa.
>```

### Related

[HH-440](https://helsinkisolutionoffice.atlassian.net/browse/HH-440)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-440]: https://helsinkisolutionoffice.atlassian.net/browse/HH-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ