### PR TITLE
TH-1334 | Use browser's back button, not custom back button in detail pages

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueHero/__tests__/VenueHero.test.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/__tests__/VenueHero.test.tsx
@@ -1,9 +1,10 @@
 import type { Venue } from '@events-helsinki/components';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
 import { clear } from 'jest-date-mock';
 import capitalize from 'lodash/capitalize';
 import * as React from 'react';
-import { render, screen, userEvent } from '@/test-utils';
-import { translations } from '@/test-utils/initI18n';
+import { render } from '@/test-utils';
 import { fakeOntology, fakeVenue } from '@/test-utils/mockDataUtils';
 import VenueHero from '../VenueHero';
 import type { Props as VenueHeroProps } from '../VenueHero';
@@ -49,12 +50,12 @@ it('should go to venue list', async () => {
   const { router } = render(<VenueHero venue={venue} />, {
     routes: [`/paikat/${venue.id}?returnPath=/haku`],
   });
-  await userEvent.click(
-    screen.getByRole('link', {
-      name: translations.venue.hero.ariaLabelBackButton,
-    })
-  );
-  expect(router.pathname).toBe('/haku');
+  // Simulating browser back button event:
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event
+  fireEvent(window, new PopStateEvent('popstate'));
+  await waitFor(() => {
+    expect(router.pathname).toBe('/haku');
+  });
 });
 
 it('should render ontologywords', () => {

--- a/apps/sports-helsinki/src/domain/venue/venueHero/venueHero.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/venueHero.module.scss
@@ -36,20 +36,13 @@ $logoWidth: 5.5rem;
       grid-template-rows: unset;
     }
 
-    .backButtonWrapper {
-      padding: var(--spacing-m) var(--spacing-4-xl) var(--spacing-m) 0;
+    .leftEmpty {
+      padding: var(--spacing-m) calc(var(--spacing-4-xl) + 40px)
+        var(--spacing-m) 0;
 
       @include breakpoints.respond-below(xl) {
         position: absolute;
-        padding: var(--spacing-s) 0 0 var(--spacing-s);
-      }
-
-      button:hover {
-        outline: 2px solid var(--color-coat-of-arms);
-      }
-
-      svg {
-        color: var(--color-primary-black);
+        padding: 0;
       }
     }
 

--- a/packages/common-i18n/src/locales/en/event.json
+++ b/packages/common-i18n/src/locales/en/event.json
@@ -18,7 +18,6 @@
     "isFree": "Free"
   },
   "hero": {
-    "ariaLabelBackButton": "Go back to previous page",
     "ariaLabelBuyTickets": "Buy tickets - The link will open in a new window",
     "ariaLabelEnrol": "Enrol - The link will open in a new window",
     "buttonBuyTickets": "Buy tickets",

--- a/packages/common-i18n/src/locales/en/venue.json
+++ b/packages/common-i18n/src/locales/en/venue.json
@@ -27,7 +27,6 @@
     }
   },
   "hero": {
-    "ariaLabelBackButton": "Back to the sports location page",
     "ariaLabelKeywords": "Keywords"
   },
   "venueCard": {

--- a/packages/common-i18n/src/locales/fi/event.json
+++ b/packages/common-i18n/src/locales/fi/event.json
@@ -18,7 +18,6 @@
     "isFree": "Maksuton"
   },
   "hero": {
-    "ariaLabelBackButton": "Palaa takaisin edelliselle sivulle",
     "ariaLabelBuyTickets": "Osta liput - Linkki avautuu uudessa ikkunassa",
     "ariaLabelEnrol": "Ilmoittaudu - Linkki avautuu uudessa ikkunassa",
     "buttonBuyTickets": "Osta liput",

--- a/packages/common-i18n/src/locales/fi/venue.json
+++ b/packages/common-i18n/src/locales/fi/venue.json
@@ -27,7 +27,6 @@
     }
   },
   "hero": {
-    "ariaLabelBackButton": "Takaisin liikuntapaikkasivulle",
     "ariaLabelKeywords": "Asiasanat"
   },
   "venueCard": {

--- a/packages/common-i18n/src/locales/sv/event.json
+++ b/packages/common-i18n/src/locales/sv/event.json
@@ -18,7 +18,6 @@
     "isFree": "Gratis"
   },
   "hero": {
-    "ariaLabelBackButton": "Gå tillbaka till föregående sida",
     "ariaLabelBuyTickets": "Köp biljetter - Länken öppnas i ett annat fönster",
     "ariaLabelEnrol": "Registrera - Länken öppnas i ett annat fönster",
     "buttonBuyTickets": "Köp biljetter",

--- a/packages/common-i18n/src/locales/sv/venue.json
+++ b/packages/common-i18n/src/locales/sv/venue.json
@@ -27,7 +27,6 @@
     }
   },
   "hero": {
-    "ariaLabelBackButton": "Tillbaka till motionsplatssidan",
     "ariaLabelKeywords": "Ämnesord"
   },
   "venueCard": {

--- a/packages/common-tests/browser-tests/eventSearch/search-page.testcafe.utils.ts
+++ b/packages/common-tests/browser-tests/eventSearch/search-page.testcafe.utils.ts
@@ -23,18 +23,17 @@ export async function isOnEventClosedPage() {
 /**
  * Sometimes the event card comes from the cache but the event is already "closed".
  * Check whether the user is on closed event page or event details page
- * and return back to search page, by clicking the return back -button.
+ * and return back to search page, by using window.history.back().
  * */
 export async function useClosedPageAwareGoBackFeature() {
   const detailsPage = new EventDetailsPage();
   if (await isOnEventClosedPage()) {
     // eslint-disable-next-line no-console
     console.info('The event was already closed!');
-    await goBack();
   } else {
     await detailsPage.verifyBasicContent();
-    await detailsPage.clickReturnButton();
   }
+  await goBack();
 }
 
 async function isCardInScreen(name: string) {

--- a/packages/common-tests/browser-tests/page-model/eventDetailsPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventDetailsPage.ts
@@ -7,13 +7,6 @@ class EventDetailsPage {
     return screen.getByTestId('event-name');
   }
 
-  private get returnButton() {
-    const returnButtonText = i18n.t('event:hero.ariaLabelBackButton');
-    return screen.findByRole('link', {
-      name: returnButtonText,
-    });
-  }
-
   private get description() {
     const descriptionHeading = i18n.t('event:description.title');
     return screen.findByRole('heading', {
@@ -105,14 +98,9 @@ class EventDetailsPage {
     });
   }
 
-  public async clickReturnButton() {
-    await t.click(this.returnButton);
-  }
-
   public async verifyBasicContent() {
     // eslint-disable-next-line no-console
     console.info('EventDetailsPage: verify');
-    await t.expect(this.returnButton.exists).ok();
     await t.expect(this.title.exists).ok();
     await t.expect(this.description.exists).ok();
     await t.expect(this.dateInfo.exists).ok();

--- a/packages/components/src/components/eventHero/__tests__/EventHero.test.tsx
+++ b/packages/components/src/components/eventHero/__tests__/EventHero.test.tsx
@@ -1,7 +1,11 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
 import { advanceTo, clear } from 'jest-date-mock';
 import capitalize from 'lodash/capitalize';
 import * as React from 'react';
-import { render, screen, userEvent } from '@/test-utils';
+import { render } from '@/test-utils';
+
 import { translations } from '@/test-utils/initI18n';
 import {
   fakeEvent,
@@ -76,12 +80,12 @@ it('should render event name, description and location', () => {
 it('should go to event list', async () => {
   const { router } = renderComponent();
 
-  await userEvent.click(
-    screen.getByRole('link', {
-      name: translations.event.hero.ariaLabelBackButton,
-    })
-  );
-  expect(router.pathname).toBe('/haku');
+  // Simulating browser back button event:
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event
+  fireEvent(window, new PopStateEvent('popstate'));
+  await waitFor(() => {
+    expect(router.pathname).toBe('/haku');
+  });
 });
 
 it('should render keywords', () => {

--- a/packages/components/src/components/eventHero/eventHero.module.scss
+++ b/packages/components/src/components/eventHero/eventHero.module.scss
@@ -27,20 +27,13 @@ $logoWidth: 5.5rem;
       grid-template-rows: unset;
     }
 
-    .backButtonWrapper {
-      padding: var(--spacing-m) var(--spacing-4-xl) var(--spacing-m) 0;
+    .leftEmpty {
+      padding: var(--spacing-m) calc(var(--spacing-4-xl) + 40px)
+        var(--spacing-m) 0;
 
       @include breakpoints.respond-below(xl) {
         position: absolute;
-        padding: var(--spacing-s) 0 0 var(--spacing-s);
-      }
-
-      button:hover {
-        outline: 2px solid var(--color-coat-of-arms);
-      }
-
-      svg {
-        color: var(--color-primary-black);
+        padding: 0;
       }
     }
 


### PR DESCRIPTION
## Description

TODO:
 - [ ] Browser's back button hijacking needs some work / unconditional hijacking is not good UX

NOTE:
- **Pipelines seem to be broken** somehow, should not be related to this PR.

Use browser's back button, not custom back button in detail pages

Remove the custom back button from detail pages (event/venue/hobby)
and simply do the same effect with the browser's back button.

### Related

[TH-1334](https://helsinkisolutionoffice.atlassian.net/browse/TH-1334)

## Testing

### Automated tests

### Manual testing

**Tested locally** with **all apps** (using "yarn dev"):
- sports-helsinki with venues, events and hobbies (on first page & loaded more too with each option)
- events-helsinki with events (on first page & loaded more too with each option)
- hobbies-helsinki with hobbies (on first page & loaded more too with each option)

Used keyboard shortcut for back button and clicked on browser's back button in the UI, both worked.
**Scrolling worked** in all tested cases i.e. the scroll position was correctly set on the search page
after coming back to it from the detail page using browser's back button.

And also tested in PR environment with harrastukset, scrolling worked.

**Tapahtumat in PR environment didn't always work**. It seemed to reload the
search page, or two versions of the page changed. Let's discuss.

## Screenshots

## Additional notes


[TH-1334]: https://helsinkisolutionoffice.atlassian.net/browse/TH-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ