### PR TITLE
Remove inconsistent and inaccessible clear and close buttons from search widgets

### DIFF
--- a/packages/components/src/components/dateSelector/DateSelectorMenu.tsx
+++ b/packages/components/src/components/dateSelector/DateSelectorMenu.tsx
@@ -25,9 +25,10 @@ interface Props {
   onChangeDateTypes: (value: string[]) => void;
   onChangeEndDate: (date: Date | null) => void;
   onChangeStartDate: (date: Date | null) => void;
-  onCloseMenu: () => void;
+  onCloseMenu?: () => void;
   startDate: Date | null;
   toggleIsCustomDate: () => void;
+  showCloseButton?: boolean;
 }
 
 const DateSelectorMenu: FunctionComponent<Props> = ({
@@ -45,6 +46,7 @@ const DateSelectorMenu: FunctionComponent<Props> = ({
   onCloseMenu,
   startDate,
   toggleIsCustomDate,
+  showCloseButton = false,
 }) => {
   const { t } = useCommonTranslation();
 
@@ -149,17 +151,20 @@ const DateSelectorMenu: FunctionComponent<Props> = ({
           />
         </div>
       )}
-      <button
-        className={classNames(styles.button, styles.btnClose, {
-          [styles.hidden]: !isCustomDate,
-        })}
-        onClick={onCloseMenu}
-        type="button"
-      >
-        <div className={styles.buttonText}>
-          {t('common:dateSelector.menu.buttonClose')}
-        </div>
-      </button>
+      {showCloseButton && (
+        // FIXME: accessibility issues are reported in close-button. Now not rendered by default. See ticket HH-376.
+        <button
+          className={classNames(styles.button, styles.btnClose, {
+            [styles.hidden]: !isCustomDate,
+          })}
+          onClick={onCloseMenu}
+          type="button"
+        >
+          <div className={styles.buttonText}>
+            {t('common:dateSelector.menu.buttonClose')}
+          </div>
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/components/src/components/dateSelector/__tests__/__snapshots__/DateSelectorMenu.test.tsx.snap
+++ b/packages/components/src/components/dateSelector/__tests__/__snapshots__/DateSelectorMenu.test.tsx.snap
@@ -146,15 +146,5 @@ exports[`matches snapshot 1`] = `
       Takaisin
     </div>
   </button>
-  <button
-    class="_button_bbd991 _btnClose_bbd991 _hidden_bbd991"
-    type="button"
-  >
-    <div
-      class="_buttonText_bbd991"
-    >
-      Sulje
-    </div>
-  </button>
 </div>
 `;

--- a/packages/components/src/components/dropdownMenu/DropdownMenu.tsx
+++ b/packages/components/src/components/dropdownMenu/DropdownMenu.tsx
@@ -5,7 +5,7 @@ import styles from './dropdownMenu.module.scss';
 interface Props {
   children?: React.ReactNode;
   isOpen: boolean;
-  onClear: () => void;
+  onClear?: () => void;
 }
 
 const DropdownMenu: React.FC<Props> = ({ children, isOpen, onClear }) => {
@@ -15,9 +15,11 @@ const DropdownMenu: React.FC<Props> = ({ children, isOpen, onClear }) => {
   return (
     <div className={styles.dropdownMenu}>
       <div className={styles.dropdownMenuWrapper}>{children}</div>
-      <button className={styles.btnClear} onClick={onClear} type="button">
-        {t('common:dropdown.menu.buttonClear')}
-      </button>
+      {onClear && (
+        <button className={styles.btnClear} onClick={onClear} type="button">
+          {t('common:dropdown.menu.buttonClear')}
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/components/src/components/multiSelectDropdown/MultiSelectDropdown.tsx
+++ b/packages/components/src/components/multiSelectDropdown/MultiSelectDropdown.tsx
@@ -52,6 +52,7 @@ const MultiSelectDropdown: React.FC<MultiselectDropdownProps> = ({
   helpText,
   filterByInput = true,
   buttonStyles,
+  showClearButton = false,
 }) => {
   const { t } = useCommonTranslation();
   const inputPlaceholderText =
@@ -357,7 +358,11 @@ const MultiSelectDropdown: React.FC<MultiselectDropdownProps> = ({
           {isMenuOpen ? <IconAngleUp /> : <IconAngleDown />}
         </div>
       </button>
-      <DropdownMenu isOpen={isMenuOpen} onClear={handleClear}>
+      <DropdownMenu
+        isOpen={isMenuOpen}
+        // FIXME: accessibility issues are reported in clear-button. Now not rendered by default. See ticket HH-376.
+        onClear={showClearButton ? handleClear : undefined}
+      >
         {showSearch && (
           <div className={styles.inputWrapper}>
             <IconSearch size="s" aria-hidden />

--- a/packages/components/src/components/multiSelectDropdown/types.ts
+++ b/packages/components/src/components/multiSelectDropdown/types.ts
@@ -20,4 +20,5 @@ export interface MultiselectDropdownProps {
   buttonStyles?: React.CSSProperties;
   helpText?: string;
   filterByInput?: boolean;
+  showClearButton?: boolean;
 }

--- a/packages/components/src/components/rangeDropdown/RangeDropdown.tsx
+++ b/packages/components/src/components/rangeDropdown/RangeDropdown.tsx
@@ -33,6 +33,7 @@ export interface RangeDropdownProps {
   header?: string;
   value: string[];
   withPlaceholders?: boolean;
+  showClearButton?: boolean;
 }
 
 const RangeDropdown: React.FC<RangeDropdownProps> = ({
@@ -54,6 +55,7 @@ const RangeDropdown: React.FC<RangeDropdownProps> = ({
   header = '',
   value,
   withPlaceholders = true,
+  showClearButton = false,
 }) => {
   const [internalIsFixedValues, setInternalIsFixedValues] =
     React.useState(false);
@@ -239,7 +241,10 @@ const RangeDropdown: React.FC<RangeDropdownProps> = ({
           )}
         </div>
       </button>
-      <DropdownMenu isOpen={isMenuOpen} onClear={handleClear}>
+      <DropdownMenu
+        isOpen={isMenuOpen}
+        onClear={showClearButton ? handleClear : undefined}
+      >
         {header && <div className={styles.header}>{header}</div>}
         <div className={styles.rangeInputsWrapper}>
           <TextInput


### PR DESCRIPTION
HH-376.

Make showing the clear and close buttons optional in advanced search form widgets.

1. Hide the clear buttons from filter dropdown used in advanced search by default. The clear button was not applied consistently and it had accessibility issues reported.

2. Hide the close button from date selector menu used in advanced search by default. The close button was not applied consistently and it had accessibility issues reported.

<img width="1350" height="838" alt="image" src="https://github.com/user-attachments/assets/72b00149-70d2-4ec2-af83-9833271b078a" />

<img width="1450" height="755" alt="image" src="https://github.com/user-attachments/assets/c13334f3-7d1b-4a7d-acef-5d7e9f97fab3" />

<img width="1409" height="563" alt="image" src="https://github.com/user-attachments/assets/1509d77f-b424-4a76-9e95-61bc6106f395" />

<img width="1417" height="923" alt="image" src="https://github.com/user-attachments/assets/335ffe91-e0a6-40e5-83c5-edd719cd8de8" />

<img width="1323" height="887" alt="image" src="https://github.com/user-attachments/assets/0c7bb143-06f0-4259-b00b-82747fa3704c" />

<img width="1349" height="747" alt="image" src="https://github.com/user-attachments/assets/2b0d0275-80c7-477e-9fff-94e20d287f9b" />

<img width="1481" height="716" alt="image" src="https://github.com/user-attachments/assets/cac0a03d-d194-4add-97ac-42e34b122e23" />
