### PR TITLE
fix(apps): root index page headers populated from nextjs configuration

### DIFF
--- a/next.base.config.mjs
+++ b/next.base.config.mjs
@@ -182,19 +182,12 @@ const nextBaseConfig = ({
 
       return [
         {
-          // Apply to all page routes (not API routes)
-          source: '/:path((?!api).*)*',
+          source: '/:path*',
           headers: [
             { key: 'X-Content-Type-Options', value: 'nosniff' },
             { key: 'X-XSS-Protection', value: '0' },
             { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
             { key: 'Cross-Origin-Embedder-Policy', value: 'same-origin' },
-          ],
-        },
-        {
-          // Apply CSP to all routes, including API (adjust if API needs different CSP)
-          source: '/(.*)',
-          headers: [
             {
               key: 'Content-Security-Policy',
               value: cspHeader,


### PR DESCRIPTION
HH-432.

The headers were set in nextjs configuration in a way that they were not applied in the root index page at all. All the rest of the pages did have the configured headers, but the root index did not. Now when the source has a different matcher, also the root index gets the configured headers.

<img width="1951" height="1196" alt="image" src="https://github.com/user-attachments/assets/4a9296e8-e328-455c-8e13-6e4ec799f1c8" />

This screenshot shows that also the root idnex now has the CSP configuration.
