### PR TITLE
feat: remove price info from other event info details in right panel

### DIFF
--- a/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/packages/components/src/components/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -49,7 +49,6 @@ it('should render event content fields', async () => {
     { role: 'heading', name: translations.event.info.labelLanguages },
     { role: 'heading', name: translations.event.info.labelOtherInfo },
     { role: 'heading', name: translations.event.info.labelDirections },
-    { role: 'heading', name: translations.event.info.labelPrice },
     { role: 'heading', name: translations.event.description.title },
     { role: 'heading', name: translations.event.shareLinks.title },
     { role: 'button', name: translations.common.shareLinks.buttonCopyLink },

--- a/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/EventInfo.tsx
@@ -1,14 +1,12 @@
 import * as Sentry from '@sentry/browser';
 import FileSaver from 'file-saver';
 import {
-  Button,
   IconAngleRight,
   IconCalendarClock,
   IconGlobe,
   IconGroup,
   IconInfoCircle,
   IconLocation,
-  IconTicket,
 } from 'hds-react';
 import type { EventAttributes } from 'ics';
 import { createEvent } from 'ics';
@@ -22,7 +20,6 @@ import Visible from '../../../../components/visible/Visible';
 import useLocale from '../../../../hooks/useLocale';
 import useTabFocusStyle from '../../../../hooks/useTabFocusStyle';
 import { useAppRoutingContext } from '../../../../routingUrlProvider';
-import { useAppThemeContext } from '../../../../themeProvider';
 import type {
   EventFields,
   KeywordOption,
@@ -31,7 +28,6 @@ import type {
 import {
   getAudienceAgeText,
   getEventFields,
-  getEventPrice,
   getServiceMapUrl,
 } from '../../../../utils/eventUtils';
 import getDateArray from '../../../../utils/getDateArray';
@@ -93,7 +89,6 @@ const EventInfo: React.FC<EventInfoProps> = ({ event, superEvent }) => {
         {showOtherInfo && <OtherInfo event={event} />}
         <Directions event={event} />
         <OrganizationInfo event={event} />
-        <PriceInfo event={event} />
       </div>
     </div>
   );
@@ -326,47 +321,6 @@ const Directions: React.FC<{
         {t('info.directionsHSL')}
       </SecondaryLink>
     </InfoWithIcon>
-  );
-};
-
-const PriceInfo: React.FC<{
-  event: EventFields;
-}> = ({ event }) => {
-  const { t } = useTranslation('event');
-  const { defaultButtonTheme: theme, defaultButtonVariant: variant } =
-    useAppThemeContext();
-  const locale = useLocale();
-  const eventPriceText = getEventPrice(event, locale, t('info.offers.isFree'));
-  const { offerInfoUrl } = getEventFields(event, locale);
-  const moveToBuyTicketsPage = () => {
-    window.open(offerInfoUrl);
-  };
-  return (
-    <>
-      {/* Price info */}
-      <Visible below="s">
-        <InfoWithIcon
-          icon={<IconTicket aria-hidden />}
-          title={t('info.labelPrice')}
-        >
-          {eventPriceText || '-'}
-        </InfoWithIcon>
-      </Visible>
-
-      {offerInfoUrl && (
-        <Visible below="s" className={styles.buyButtonWrapper}>
-          <Button
-            theme={theme}
-            variant={variant}
-            aria-label={t('info.ariaLabelBuyTickets')}
-            fullWidth={true}
-            onClick={moveToBuyTicketsPage}
-          >
-            {t('info.buttonBuyTickets')}
-          </Button>
-        </Visible>
-      )}
-    </>
   );
 };
 

--- a/packages/components/src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx
@@ -217,22 +217,6 @@ it('should hide the map link from location info if location is internet', () => 
   ).not.toBeInTheDocument();
 });
 
-it('should open ticket buy page', async () => {
-  global.open = vi.fn();
-  render(<EventInfo event={event} />, { mocks });
-
-  // Event info fields
-  await userEvent.click(
-    screen.getByRole('button', {
-      name: translations.event.info.ariaLabelBuyTickets,
-    })
-  );
-
-  await waitFor(() => {
-    expect(global.open).toHaveBeenCalled();
-  });
-});
-
 it.skip('should create ics file succesfully', async () => {
   const saveAsSpy = vi.spyOn(FileSaver, 'saveAs');
   render(<EventInfo event={event} />, { mocks });


### PR DESCRIPTION
HH-444.

<img width="586" height="387" alt="image" src="https://github.com/user-attachments/assets/d5163e95-82c5-4b44-ba38-b078ade4e3dd" />

Remove the price information section from the right panel of small screens in event details page.