### PR TITLE
Consistent styles for search filter elements

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
@@ -156,6 +156,11 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
               clearButtonAriaLabel={tAppEvents(
                 'appEvents:search.search.clearButtonAriaLabel'
               )}
+              style={
+                {
+                  '--placeholder-color': 'var(--color-black)',
+                } as React.CSSProperties
+              }
             />
           </div>
         </div>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
@@ -146,6 +146,11 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
               clearButtonAriaLabel={tAppHobbies(
                 'appHobbies:search.search.clearButtonAriaLabel'
               )}
+              style={
+                {
+                  '--placeholder-color': 'var(--color-black)',
+                } as React.CSSProperties
+              }
             />
           </div>
         </div>
@@ -163,6 +168,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
                 showSearch={false}
                 title={t('search.titleDropdownCategory')}
                 value={selectedCategories}
+                buttonStyles={{ fontSize: 'var(--fontsize-body-m)' }}
               />
             </div>
             <div className={styles.dateSelectorWrapper}>
@@ -191,6 +197,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
                 showSelectAll={true}
                 title={t('search.titleDropdownPlace')}
                 value={selectedPlaces}
+                buttonStyles={{ fontSize: 'var(--fontsize-body-m)' }}
               />
             </div>
             <div>
@@ -209,6 +216,11 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
                 }
                 placeholder={t('search.placeholderAge')}
                 value={ageInput}
+                style={
+                  {
+                    '--placeholder-color': 'var(--color-black)',
+                  } as React.CSSProperties
+                }
               />
             </div>
           </div>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
@@ -88,7 +88,9 @@ $buttonWidth: 180px;
   }
 
   .dateSelectorWrapper {
-    align-self: flex-end;
+    & > div {
+      height: -webkit-fill-available; // Fill 2px of available space under dropdown
+    }
   }
 }
 

--- a/packages/components/src/components/advancedSearch/advancedSearchInput.module.scss
+++ b/packages/components/src/components/advancedSearch/advancedSearchInput.module.scss
@@ -6,7 +6,6 @@
   padding: 0 1rem;
   align-items: center;
   box-sizing: border-box;
-  border: 2px solid var(--color-white);
   &.focused {
     outline: 3px solid var(--color-coat-of-arms);
     outline-offset: 2px;

--- a/packages/components/src/components/advancedSearch/advancedSearchTextInput.module.scss
+++ b/packages/components/src/components/advancedSearch/advancedSearchTextInput.module.scss
@@ -6,7 +6,7 @@
   padding: 0 1rem;
   align-items: center;
   box-sizing: border-box;
-  border: 2px solid var(--color-white);
+
   &.focused {
     outline: 3px solid var(--color-coat-of-arms);
     outline-offset: 2px;


### PR DESCRIPTION
HH-448.

Fix the font sizes and svg-icon sizes of the Hobbies-Helsinki search form filters.

Reference:
https://github.com/City-of-Helsinki/events-helsinki-monorepo/commit/ dc83040082827d16eaa82c181dc2d9d2fe522bc7 for changes in events app.

<img width="1094" height="580" alt="image" src="https://github.com/user-attachments/assets/57fd6f60-ceab-414a-b4dc-d0fd6f1c707b" />
