### PR TITLE
HH-381 | Refine exact age translations used in age selector

### DIFF
--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -44,7 +44,7 @@
     "ageFilter": {
       "minAge": "{{age}} {{yearAbbr}}",
       "maxAge": "{{age}} {{yearAbbr}}",
-      "exactAge": "For a {{age}}-year-old"
+      "exactAge": "{{age}}-year-olds"
     },
     "labelAccessibilityProfile": "Accessibility",
     "ariaLabelClearAccessibilityProfile": "Remove the accessibility shortcoming selection",

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -57,7 +57,7 @@
     "ageFilter": {
       "minAge": "{{age}} {{yearAbbr}}",
       "maxAge": "{{age}} {{yearAbbr}}",
-      "exactAge": "{{age}}-vuotiaalle"
+      "exactAge": "{{age}}-vuotiaille"
     },
     "labelAccessibilityProfile": "Esteettömyys",
     "ariaLabelClearAccessibilityProfile": "Poista esteettömyysvalinta",

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -44,7 +44,7 @@
     "ageFilter": {
       "minAge": "{{age}} {{yearAbbr}}",
       "maxAge": "{{age}} {{yearAbbr}}",
-      "exactAge": "För en {{age}}-åring"
+      "exactAge": "{{age}}-åringar"
     },
     "labelAccessibilityProfile": "Tillgänglighet",
     "ariaLabelClearAccessibilityProfile": "Ta bort valet av tillgänglighet",

--- a/packages/components/src/components/filters/__tests__/AgeFilter.test.tsx
+++ b/packages/components/src/components/filters/__tests__/AgeFilter.test.tsx
@@ -20,7 +20,7 @@ it('calls onRemove callback when remove button is clicked', async () => {
   const onClickMock = vi.fn();
   render(<AgeFilter {...props} onRemove={onClickMock} />);
 
-  expect(screen.getByText(`${props.value}-vuotiaalle`)).toBeInTheDocument();
+  expect(screen.getByText(`${props.value}-vuotiaille`)).toBeInTheDocument();
 
   await userEvent.click(screen.getByRole('button'));
 

--- a/packages/components/src/components/filters/__tests__/__snapshots__/AgeFilter.test.tsx.snap
+++ b/packages/components/src/components/filters/__tests__/__snapshots__/AgeFilter.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`matches snapshot 1`] = `
     <span
       aria-hidden="true"
     >
-      10-vuotiaalle
+      10-vuotiaille
     </span>
   </span>
   <button
-    aria-label="Poista suodatin: 10-vuotiaalle"
+    aria-label="Poista suodatin: 10-vuotiaille"
     class="Tag-module_deleteButton__1diMR tag_hds-tag__delete-button__33Tgz"
     id="hds-tag-delete-button"
     type="button"


### PR DESCRIPTION
## Description

Refine exact age translations used in age selector.

These translations come from the hobbies-helsinki/events-helsinki
product owner who has gone over these with a professional translator.

## Related

[HH-381](https://helsinkisolutionoffice.atlassian.net/browse/HH-381)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-381]: https://helsinkisolutionoffice.atlassian.net/browse/HH-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ