### PR TITLE
fix(search): target age group menu should always open downwards

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/TargetAgeGroupSelector.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/TargetAgeGroupSelector.tsx
@@ -1,7 +1,9 @@
 import { SrOnly, useSearchTranslation } from '@events-helsinki/components';
+import classNames from 'classnames';
 import type { SingleSelectProps } from 'hds-react';
 import { IconGroup, Select } from 'hds-react';
 import { TARGET_GROUP_AGE_GROUPS_IN_ORDER } from '../../../../constants';
+import styles from './targetAgeGroup.module.scss';
 
 /**
  * Get select component options for target group age selection.
@@ -64,6 +66,7 @@ function TargetAgeGroupSelector({
   label,
   value,
   defaultValue = '',
+  className,
   ...rest
 }: TargetAgeGroupSelectorProps) {
   const { t: tSearch } = useSearchTranslation();
@@ -84,6 +87,9 @@ function TargetAgeGroupSelector({
       // Prevent reading the label / placeholder twice by screen reader
       placeholder={!value ? placeholder : undefined}
       {...rest}
+      className={classNames(styles.targetAgeGroupSelector, {
+        [String(className)]: !!className,
+      })}
       multiselect={false}
       options={options}
       optionLabelField="label"

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/targetAgeGroup.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/targetAgeGroup.module.scss
@@ -1,0 +1,6 @@
+.targetAgeGroupSelector {
+  ul {
+    /* Fix the menu should always open downwards. */
+    bottom: auto;
+  }
+}


### PR DESCRIPTION
TH-1327.

<img width="1099" height="814" alt="image" src="https://github.com/user-attachments/assets/776da1a0-74aa-4b39-adcf-6af8085cc55c" />
