### PR TITLE
feat(apps): respond with not found when event is closed or cancelled

### DIFF
--- a/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
+++ b/apps/events-helsinki/src/pages/events/[eventId]/index.tsx
@@ -8,6 +8,8 @@ import {
   PageBreadcrumbTitleDocument,
   getFilteredBreadcrumbs,
   getEventFields,
+  isEventClosed,
+  isEventCancelled,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -85,6 +87,37 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     const event = eventData?.eventDetails;
 
     if (!event) {
+      // eslint-disable-next-line no-console
+      console.debug('Event could not be found.', 'Responding with not found!', {
+        id,
+      });
+      return {
+        notFound: true,
+      };
+    }
+
+    /**
+     * If the event is already closed (ended or cancelled), respond with `notFound`.
+     *
+     * NOTE: HTTP 410 Gone would be a better response, but it's not available when SSG / ISR is used
+     * and implementing that feature with a middleware would require fetching the event multiple times.
+     *
+     * INFO: Since SSG / ISR is in use _without revalidate-feature_, a closed event can also be rendered,
+     * (in shape of a "warning page", not as event detail page). The `getStaticProps` will rerun only after
+     * the statically generated page has been deleted or revalidated on demand.
+     * For auto clean, there is a cleaner cronjob. Ondemand revalidation can be triggered by calling `/api/revalidate`.
+     */
+    if (isEventClosed(event) || isEventCancelled(event)) {
+      // eslint-disable-next-line no-console
+      console.info(
+        'Event closed (or cancelled).',
+        'Responding with not found!',
+        {
+          id,
+          eventEndTime: event.endTime,
+          eventStatus: event.eventStatus,
+        }
+      );
       return {
         notFound: true,
       };

--- a/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
+++ b/apps/sports-helsinki/src/pages/courses/[eventId]/index.tsx
@@ -8,6 +8,8 @@ import {
   PageBreadcrumbTitleDocument,
   getFilteredBreadcrumbs,
   getEventFields,
+  isEventClosed,
+  isEventCancelled,
 } from '@events-helsinki/components';
 import type {
   EventFields,
@@ -101,6 +103,37 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     const event = eventData?.eventDetails;
 
     if (!event) {
+      // eslint-disable-next-line no-console
+      console.debug('Event could not be found.', 'Responding with not found!', {
+        id,
+      });
+      return {
+        notFound: true,
+      };
+    }
+
+    /**
+     * If the event is already closed (ended or cancelled), respond with `notFound`.
+     *
+     * NOTE: HTTP 410 Gone would be a better response, but it's not available when SSG / ISR is used
+     * and implementing that feature with a middleware would require fetching the event multiple times.
+     *
+     * INFO: Since SSG / ISR is in use _without revalidate-feature_, a closed event can also be rendered,
+     * (in shape of a "warning page", not as event detail page). The `getStaticProps` will rerun only after
+     * the statically generated page has been deleted or revalidated on demand.
+     * For auto clean, there is a cleaner cronjob. Ondemand revalidation can be triggered by calling `/api/revalidate`.
+     */
+    if (isEventClosed(event) || isEventCancelled(event)) {
+      // eslint-disable-next-line no-console
+      console.info(
+        'Event closed (or cancelled).',
+        'Responding with not found!',
+        {
+          id,
+          eventEndTime: event.endTime,
+          eventStatus: event.eventStatus,
+        }
+      );
       return {
         notFound: true,
       };


### PR DESCRIPTION
HH-442.

If the event is already closed (ended or cancelled), respond with `notFound`.

HTTP 410 Gone would be a better response, but it's not available when SSG / ISR is used and implementing that feature with a middleware would require fetching the event multiple times.

Since SSG / ISR is in use _without revalidate-feature_, a closed event can also be rendered, (in shape of a "warning page", not as event detail page). The `getStaticProps` will rerun only after the statically generated page has been deleted or revalidated on demand. For auto clean, there is a cleaner cronjob. Ondemand revalidation can be triggered by calling `/api/revalidate`.

----

### How to test

An example of closed event: https://tapahtumat.hel.fi/fi/tapahtumat/kulke:66385. 

In production where the changes are not yet applied, the respond is this:

<img width="1623" height="1096" alt="image" src="https://github.com/user-attachments/assets/47998e66-8901-4753-8781-871861be2df6" />

The status code is HTTP200 and the message says that the event has ended.

In this PR's server https://tapahtumat-pr859.dev.hel.ninja/fi/tapahtumat/kulke:66385, the respond is this:

<img width="1690" height="1156" alt="image" src="https://github.com/user-attachments/assets/e0ef7ce4-1397-4150-b3a7-6f55698e5978" />

The status code is HTTP404 and a not found page is rendered.

