### PR TITLE
fix: remove remainingAttendeeCapacity field from event details root

### DIFF
--- a/apps/events-helsinki/config/vitest/mockDataUtils.ts
+++ b/apps/events-helsinki/config/vitest/mockDataUtils.ts
@@ -81,7 +81,6 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       enrolmentStartTime: '',
       maximumAttendeeCapacity: 10,
       minimumAttendeeCapacity: 1,
-      remainingAttendeeCapacity: 5,
       audienceMinAge: '5',
       audienceMaxAge: '15',
       typeId: EventTypeId.General,

--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.1.3",
+    "react-helsinki-headless-cms": "1.1.4-canary-c2b489c",
     "react-i18next": "15.6.0",
     "react-scroll": "^1.9.3",
     "react-toastify": "^11.0.5",

--- a/apps/hobbies-helsinki/config/vitest/mockDataUtils.ts
+++ b/apps/hobbies-helsinki/config/vitest/mockDataUtils.ts
@@ -81,7 +81,6 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       enrolmentStartTime: '',
       maximumAttendeeCapacity: 10,
       minimumAttendeeCapacity: 1,
-      remainingAttendeeCapacity: 5,
       audienceMinAge: '5',
       audienceMaxAge: '15',
       typeId: EventTypeId.Course,

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.1.3",
+    "react-helsinki-headless-cms": "1.1.4-canary-c2b489c",
     "react-i18next": "15.6.0",
     "react-scroll": "^1.9.3",
     "react-toastify": "^11.0.5",

--- a/apps/sports-helsinki/config/vitest/mockDataUtils.ts
+++ b/apps/sports-helsinki/config/vitest/mockDataUtils.ts
@@ -82,7 +82,6 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       enrolmentStartTime: '',
       maximumAttendeeCapacity: 10,
       minimumAttendeeCapacity: 1,
-      remainingAttendeeCapacity: 5,
       audienceMinAge: '5',
       audienceMaxAge: '15',
       typeId: EventTypeId.Course,

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -85,7 +85,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.1.3",
+    "react-helsinki-headless-cms": "1.1.4-canary-c2b489c",
     "react-i18next": "15.6.0",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.9.3",

--- a/packages/components/config/tests/mockDataUtils.ts
+++ b/packages/components/config/tests/mockDataUtils.ts
@@ -79,7 +79,6 @@ export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
       enrolmentStartTime: '',
       maximumAttendeeCapacity: 10,
       minimumAttendeeCapacity: 1,
-      remainingAttendeeCapacity: 5,
       audienceMinAge: '5',
       audienceMaxAge: '15',
       typeId: EventTypeId.General,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.1.3",
+    "react-helsinki-headless-cms": "1.1.4-canary-c2b489c",
     "react-i18next": "15.6.0",
     "react-leaflet": "4.2.1",
     "react-toastify": "^11.0.5",

--- a/packages/components/src/components/domain/event/eventInfo/mocks/EventInfo.mocks.ts
+++ b/packages/components/src/components/domain/event/eventInfo/mocks/EventInfo.mocks.ts
@@ -52,7 +52,6 @@ export const price = '12 €';
 export const targetGroups = ['lapset', 'aikuiset'];
 export const maximumAttendeeCapacity = 20;
 export const minimumAttendeeCapacity = 10;
-export const remainingAttendeeCapacity = 5;
 export const audienceMinAge = '5';
 export const audienceMaxAge = '15';
 export const organizerName = 'provider organisation';
@@ -75,7 +74,6 @@ export const event: EventFieldsFragment = fakeEvent({
   },
   maximumAttendeeCapacity: maximumAttendeeCapacity,
   minimumAttendeeCapacity: minimumAttendeeCapacity,
-  remainingAttendeeCapacity: remainingAttendeeCapacity,
   offers: [fakeOffer({ isFree: false, price: { fi: price } })],
   audience: targetGroups.map((targetGroup) =>
     fakeTargetGroup({ name: fakeLocalizedObject(targetGroup) })

--- a/packages/components/src/components/domain/event/query.ts
+++ b/packages/components/src/components/domain/event/query.ts
@@ -88,7 +88,6 @@ export const QUERY_EVENT_DETAILS = gql`
     }
     enrolmentStartTime
     enrolmentEndTime
-    remainingAttendeeCapacity
   }
 
   query EventDetails($id: ID!, $include: [String]) {

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -3314,7 +3314,6 @@ export type EventDetails = {
   provider?: Maybe<LocalizedObject>;
   providerContactInfo?: Maybe<LocalizedObject>;
   publisher?: Maybe<Scalars['ID']['output']>;
-  remainingAttendeeCapacity?: Maybe<Scalars['Int']['output']>;
   shortDescription?: Maybe<LocalizedObject>;
   startTime?: Maybe<Scalars['String']['output']>;
   subEvents: Array<InternalIdObject>;
@@ -14260,7 +14259,6 @@ export type EventFieldsFragment = {
   publisher?: string | null;
   enrolmentStartTime?: string | null;
   enrolmentEndTime?: string | null;
-  remainingAttendeeCapacity?: number | null;
   externalLinks: Array<{
     __typename?: 'ExternalLink';
     name?: string | null;
@@ -14453,7 +14451,6 @@ export type EventDetailsQuery = {
     publisher?: string | null;
     enrolmentStartTime?: string | null;
     enrolmentEndTime?: string | null;
-    remainingAttendeeCapacity?: number | null;
     externalLinks: Array<{
       __typename?: 'ExternalLink';
       name?: string | null;
@@ -14728,7 +14725,6 @@ export type EventListQuery = {
       publisher?: string | null;
       enrolmentStartTime?: string | null;
       enrolmentEndTime?: string | null;
-      remainingAttendeeCapacity?: number | null;
       externalLinks: Array<{
         __typename?: 'ExternalLink';
         name?: string | null;
@@ -14933,7 +14929,6 @@ export type EventsByIdsQuery = {
       publisher?: string | null;
       enrolmentStartTime?: string | null;
       enrolmentEndTime?: string | null;
-      remainingAttendeeCapacity?: number | null;
       externalLinks: Array<{
         __typename?: 'ExternalLink';
         name?: string | null;
@@ -16070,7 +16065,6 @@ export const EventFieldsFragmentDoc = gql`
     }
     enrolmentStartTime
     enrolmentEndTime
-    remainingAttendeeCapacity
   }
   ${LocalizedFieldsFragmentDoc}
   ${KeywordFieldsFragmentDoc}

--- a/packages/components/src/utils/eventUtils.ts
+++ b/packages/components/src/utils/eventUtils.ts
@@ -355,7 +355,6 @@ export const getEventFields = (event: EventFields, locale: AppLanguage) => {
     photographerName: event.images?.[0]?.photographerName,
     ...getEventLocationFields(event, locale),
     locationExtraInfo: getLocalizedString(event.locationExtraInfo, locale),
-    remainingAttendeeCapacity: event.remainingAttendeeCapacity,
     enrolmentStartTime: event.enrolmentStartTime,
     enrolmentEndTime: event.enrolmentEndTime,
     providerContactInfo: getLocalizedString(event.providerContactInfo, locale),

--- a/packages/components/src/utils/getEventEnrolmentStatus.ts
+++ b/packages/components/src/utils/getEventEnrolmentStatus.ts
@@ -3,8 +3,10 @@ import type { EventFields } from '../types/event-types';
 
 export function getEnrolmentStatus(event: EventFields): EnrolmentStatusLabel {
   const now = new Date();
-  const { remainingAttendeeCapacity, enrolmentStartTime, enrolmentEndTime } =
-    event;
+  const { remainingAttendeeCapacity, enrolmentStartTime, enrolmentEndTime } = {
+    ...event,
+    remainingAttendeeCapacity: null,
+  };
 
   // TODO: Add EnrolmentStatusLabel.queueable when we can resolve it
   if (remainingAttendeeCapacity === 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3171,7 +3171,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.1.3"
+    react-helsinki-headless-cms: "npm:1.1.4-canary-c2b489c"
     react-i18next: "npm:15.6.0"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^11.0.5"
@@ -13434,7 +13434,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.1.3"
+    react-helsinki-headless-cms: "npm:1.1.4-canary-c2b489c"
     react-i18next: "npm:15.6.0"
     react-scroll: "npm:^1.9.3"
     react-toastify: "npm:^11.0.5"
@@ -15176,7 +15176,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.1.3"
+    react-helsinki-headless-cms: "npm:1.1.4-canary-c2b489c"
     react-i18next: "npm:15.6.0"
     react-scroll: "npm:^1.9.3"
     react-toastify: "npm:^11.0.5"
@@ -21367,9 +21367,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.1.3":
-  version: 1.1.3
-  resolution: "react-helsinki-headless-cms@npm:1.1.3"
+"react-helsinki-headless-cms@npm:1.1.4-canary-c2b489c":
+  version: 1.1.4-canary-c2b489c
+  resolution: "react-helsinki-headless-cms@npm:1.1.4-canary-c2b489c"
   dependencies:
     classnames: "npm:^2.5.1"
     hds-design-tokens: "npm:^3.11.0"
@@ -21387,7 +21387,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: e89a66acbb1a0a26937eef6cad04ca0575b2fad6d4c9ea1b606140c0526253cf984250987aa6724104af6b0a01c75cf4b8ef125fa05ab8ac1fba27e8efdf5bb1
+  checksum: 2aa6a2c6544d3217d3bc2c9a3f6f90a6ef95ce76da3454d2c52dfe1d350ce6d8572cd01eff504ab995f8a33fea05510dd063a886ab02971264101c9ceb549efa
   languageName: node
   linkType: hard
 
@@ -23512,7 +23512,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.1.3"
+    react-helsinki-headless-cms: "npm:1.1.4-canary-c2b489c"
     react-i18next: "npm:15.6.0"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.9.3"


### PR DESCRIPTION
HH-449.

Hot fix event queries by removing the `remainingAttendeeCapacity` field. It's now removed from Events-federation-router and Events-graphql-proxy, so it cannot no longer be queried (from the event details root).
