### PR TITLE
TH-1437 | Clean up test output

### DIFF
--- a/apps/events-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/events-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -47,7 +47,7 @@ const keywords = [
   { name: 'Eläimet', id: 'keyword2' },
   { name: 'Grillaus', id: 'keyword3' },
 ];
-const superEventId = 'hel:123';
+const superEventId = 'hel:super-123';
 const otherEventTimesCount = 10;
 
 const event = fakeEvent({

--- a/apps/events-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/events-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -273,32 +273,13 @@ it('doesnt show similar events when SIMILAR_EVENTS flag is off', async () => {
   ).not.toBeInTheDocument();
 });
 
-it('doesnt show similar events when keywords are not mapped', async () => {
+it('hides similar events when event has no keywords', async () => {
   advanceTo('2020-10-01');
-  renderComponent({ event: event, loading: false, showSimilarEvents: true }, [
-    ...mocks,
-    createEventListRequestAndResultMocks({
-      variables: {
-        keywordOrSet2: [''],
-        language: undefined,
-        pageSize: 100,
-        publisherAncestor: null,
-        eventType: [EventTypeId.General],
-      },
-      response: {
-        data: [],
-        meta: {
-          __typename: 'Meta',
-          count: 0,
-          next: '',
-          previous: '',
-        },
-        __typename: 'EventListResponse',
-      },
-    }),
-  ]);
-  await waitFor(() => {
-    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  const eventNoKeywords = { ...event, keywords: [] };
+  renderComponent({
+    event: eventNoKeywords,
+    loading: false,
+    showSimilarEvents: true,
   });
   await waitForLoadingCompleted();
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx
@@ -4,6 +4,8 @@ import {
   NeighborhoodListDocument,
   PlaceListDocument,
 } from '@events-helsinki/components';
+import { configure, screen, act } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { advanceTo, clear } from 'jest-date-mock';
 import mockRouter from 'next-router-mock';
 import React from 'react';
@@ -13,13 +15,7 @@ import {
   fakeNeighborhoods,
   fakePlaces,
 } from '../../../../../../config/vitest/mockDataUtils';
-import {
-  actWait,
-  configure,
-  render,
-  screen,
-  userEvent,
-} from '../../../../../../config/vitest/test-utils';
+import { render } from '../../../../../../config/vitest/test-utils';
 
 import Search from '../AdvancedSearch';
 
@@ -85,16 +81,20 @@ beforeEach(() => {
 
 afterAll(() => {
   clear();
+  vi.restoreAllMocks();
 });
 
 it('for accessibility violations', async () => {
+  // Mock canvas related methods as jest-axe says color contrast checks don't work
+  // (vitest-axe, which is used here, is based on jest-axe so this should apply)
+  //
+  // See https://github.com/NickColley/jest-axe/tree/v10.0.0?tab=readme-ov-file
+  // "Color contrast checks do not work in JSDOM so are turned off in jest-axe."
+  HTMLCanvasElement.prototype.getContext = vi.fn();
   const { container } = renderComponent();
-
-  await actWait();
-
-  const results = await axe(container);
+  const results = await act(async () => await axe(container));
   expect(results).toHaveNoViolations();
-}, 50000); // FIXME: Why does this take so long?
+});
 
 it('should clear all filters and search field', async () => {
   const { router } = renderComponent();

--- a/apps/events-helsinki/vitest-setup.ts
+++ b/apps/events-helsinki/vitest-setup.ts
@@ -1,4 +1,5 @@
 import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
+import { hideConsoleMessages } from '@events-helsinki/common-tests';
 import { loadEnvConfig } from '@next/env';
 
 import { expect } from 'vitest';
@@ -88,3 +89,19 @@ vi.mock('next-i18next', async () => {
 });
 
 loadEnvConfig(process.cwd());
+
+hideConsoleMessages({
+  error: [
+    // Hide error message caused by hds-react v3:
+    // eslint-disable-next-line @stylistic/max-len
+    // https://github.com/City-of-Helsinki/helsinki-design-system/blob/v3.11.0/packages/react/src/components/dropdown/select/Select.tsx#L669
+    //
+    // Example use case:
+    // TargetAgeGroupSelector (apps/events-helsinki) → Select (hds-react)
+    // Removing this hiding & running TargetAgeGroupSelector tests should show this error if HDS v3.11.0 is still used.
+    //
+    // Related issue:
+    // https://github.com/facebook/react/issues/29233
+    /Support for defaultProps will be removed.*Use JavaScript default parameters instead.*hds-react/s,
+  ],
+});

--- a/apps/events-helsinki/vitest-setup.ts
+++ b/apps/events-helsinki/vitest-setup.ts
@@ -1,3 +1,4 @@
+import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
 import { loadEnvConfig } from '@next/env';
 
 import { expect } from 'vitest';
@@ -5,6 +6,10 @@ import * as matchers from 'vitest-axe/matchers';
 import { initializeI18nWithConfig } from './config/vitest/initI18n';
 
 import '@testing-library/jest-dom/vitest';
+
+// Load error messages for Apollo client so it's easier to debug errors
+loadDevMessages();
+loadErrorMessages();
 
 expect.extend(matchers);
 

--- a/apps/events-helsinki/vitest.config.ts
+++ b/apps/events-helsinki/vitest.config.ts
@@ -54,7 +54,28 @@ const aliasPaths = paths
 
 export default defineConfig({
   cacheDir: '../../.cache/events-helsinki',
-  plugins: [react(), cssInjectedByJsPlugin()],
+  plugins: [
+    react(),
+    cssInjectedByJsPlugin(),
+    {
+      // Suppress sourcemap warnings that can't be suppressed at console/stdout/stderr level
+      //
+      // See:
+      // - https://github.com/vitejs/rolldown-vite/blob/v7.0.4/packages/vite/src/node/server/sourcemap.ts#L81
+      // - https://github.com/vitest-dev/vitest/issues/7976
+      name: 'suppress-sourcemap-warnings',
+      configureServer(server) {
+        const originalWarnOnce = server.config.logger.warnOnce;
+
+        server.config.logger.warnOnce = (msg, options) => {
+          if (/^Sourcemap for .* points to missing source files$/.test(msg)) {
+            return;
+          }
+          originalWarnOnce(msg, options);
+        };
+      },
+    },
+  ],
   test: {
     environment: 'jsdom',
     globals: true, // Makes test, expect, vi global


### PR DESCRIPTION
## Description

Clean up events-helsinki app's tests' output.

Only remaining errors/warnings in events-helsinki app's tests' output are:
1. `Warning: Each child in a list should have a unique "key" prop.`
   - Check the render method of `CarouselSlider`. See https://reactjs.org/link/warning-keys for more information.
2. `Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.`

Fixing these errors/warning may need fixes to [RHHC](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/)

This PR is **quite similar** to **PR #870** and **PR #871**.

## Related

[TH-1437](https://helsinkisolutionoffice.atlassian.net/browse/TH-1437)

[TH-1437]: https://helsinkisolutionoffice.atlassian.net/browse/TH-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ