### PR TITLE
fix(csp): add Askem to CSP headers

### DIFF
--- a/next.base.config.mjs
+++ b/next.base.config.mjs
@@ -159,10 +159,10 @@ const nextBaseConfig = ({
       // Base CSP directives
       const cspDirectives = [
         "default-src 'self'",
-        `script-src 'self' ${isDevelopment ? "'unsafe-eval'" : ''} https://webanalytics.digiaiiris.com *.youtube.com *.googlesyndication.com *.google-analytics.com *.googletagmanager.com *.gstatic.com`,
-        "style-src 'self' 'unsafe-inline'",
+        `script-src 'self' ${isDevelopment ? "'unsafe-eval'" : ''} https://webanalytics.digiaiiris.com https://cdn.reactandshare.com *.youtube.com *.googlesyndication.com *.google-analytics.com *.googletagmanager.com *.gstatic.com`,
+        "style-src 'self' 'unsafe-inline' https://cdn.reactandshare.com",
         "img-src * 'self' data: https:",
-        "font-src 'self' *.hel.fi *.hel.ninja fonts.gstatic.com",
+        "font-src 'self' *.hel.fi *.hel.ninja fonts.gstatic.com https://cdn.reactandshare.com",
         "connect-src 'self' localhost:* 127.0.0.1:* *.hel.fi *.hel.ninja *.hkih.hion.dev *.digiaiiris.com",
         "object-src 'none'",
         "media-src 'self' *.hel.fi *.hel.ninja *.hkih.hion.dev",


### PR DESCRIPTION
LIIKUNTA-757.

Askem / React and share -component loads element-scripts, styles and fonts from https://cdn.reactandshare.com. These rules were not applied in our CSP policy.

NOTE: Askem has been in use in production only (by default configuration). To test this locally, the Askem needs to be enabled.

```
NEXT_PUBLIC_ASKEM_ENABLED=1
NEXT_PUBLIC_ASKEM_API_KEY_FI=asdasdas
NEXT_PUBLIC_ASKEM_API_KEY_EN=asdasdas
NEXT_PUBLIC_ASKEM_API_KEY_SV=asdasdas
```