### PR TITLE
fix(csp): askem uses multiple src-endpoints

### DIFF
--- a/next.base.config.mjs
+++ b/next.base.config.mjs
@@ -159,7 +159,7 @@ const nextBaseConfig = ({
       // Base CSP directives
       const cspDirectives = [
         "default-src 'self'",
-        `script-src 'self' ${isDevelopment ? "'unsafe-eval'" : ''} https://webanalytics.digiaiiris.com https://cdn.reactandshare.com *.youtube.com *.googlesyndication.com *.google-analytics.com *.googletagmanager.com *.gstatic.com`,
+        `script-src 'self' ${isDevelopment ? "'unsafe-eval'" : ''} https://webanalytics.digiaiiris.com *.reactandshare.com *.youtube.com *.googlesyndication.com *.google-analytics.com *.googletagmanager.com *.gstatic.com`,
         "style-src 'self' 'unsafe-inline' https://cdn.reactandshare.com",
         "img-src * 'self' data: https:",
         "font-src 'self' *.hel.fi *.hel.ninja fonts.gstatic.com https://cdn.reactandshare.com",


### PR DESCRIPTION
LIIKUNTA-757.

(At least in prod mode), it seems the Askem is also using https://data.reactandshare.com to download scripts.

<img width="712" height="320" alt="image" src="https://github.com/user-attachments/assets/66e38714-36b3-4e39-8456-d7ded228357a" />

When it's allowed (with wrong keys):
<img width="697" height="278" alt="image" src="https://github.com/user-attachments/assets/f4df692a-f825-4347-b187-4a30b9c5c3aa" />
