### PR TITLE
TH-1441 | Make use of AppLanguage more in a typesafe way

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -1,4 +1,3 @@
-import type { AppLanguage } from '@events-helsinki/components';
 import {
   DATE_TYPES,
   DEFAULT_EVENT_SORT_OPTION,
@@ -51,7 +50,7 @@ describe('getSearchQuery function', () => {
 describe('getEventSearchVariables function', () => {
   const defaultParams = {
     include: [],
-    language: 'fi' as AppLanguage,
+    language: 'fi' as const,
     pageSize: AppConfig.pageSize,
     sortOrder: DEFAULT_EVENT_SORT_OPTION,
     superEventType: [],

--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -171,7 +171,7 @@ export async function getStaticPaths(): Promise<
       if (slug && slug.length > 0) {
         acc.push({
           params: { slug },
-          locale: pageInfo.locale as AppLanguage,
+          locale: pageInfo.locale,
         });
       }
       return acc;

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -121,7 +121,7 @@ export async function getStaticPaths(): Promise<
       if (slug && slug.length > 0) {
         acc.push({
           params: { slug },
-          locale: pageInfo.locale as AppLanguage,
+          locale: pageInfo.locale,
         });
       }
       return acc;

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -1,4 +1,3 @@
-import type { AppLanguage } from '@events-helsinki/components';
 import {
   DATE_TYPES,
   EVENT_SEARCH_FILTERS,
@@ -50,7 +49,7 @@ describe('getSearchQuery function', () => {
 describe('getEventSearchVariables function', () => {
   const defaultParams = {
     include: [],
-    language: 'fi' as AppLanguage,
+    language: 'fi' as const,
     pageSize: 10,
     sortOrder: EVENT_SORT_OPTIONS.END_TIME,
     superEventType: [],

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -171,7 +171,7 @@ export async function getStaticPaths(): Promise<
       if (slug && slug.length > 0) {
         acc.push({
           params: { slug },
-          locale: pageInfo.locale as AppLanguage,
+          locale: pageInfo.locale,
         });
       }
       return acc;

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -121,7 +121,7 @@ export async function getStaticPaths(): Promise<
       if (slug && slug.length > 0) {
         acc.push({
           params: { slug },
-          locale: pageInfo.locale as AppLanguage,
+          locale: pageInfo.locale,
         });
       }
       return acc;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/CombinedSearchFormAdapter.ts
@@ -1,12 +1,10 @@
 import type { ParsedUrlQuery } from 'querystring';
+import type { AppLanguage } from '@events-helsinki/components';
 // eslint-disable-next-line @stylistic/max-len
 import type { UnifiedSearchOrderByType } from '@events-helsinki/components/components/domain/unifiedSearch/unifiedSearchConstants';
 // eslint-disable-next-line @stylistic/max-len
 import { UnifiedSearchOrderBy } from '@events-helsinki/components/components/domain/unifiedSearch/unifiedSearchConstants';
-import type {
-  AppLanguage,
-  Coordinates,
-} from '@events-helsinki/components/types';
+import type { Coordinates } from '@events-helsinki/components/types';
 import { EventTypeId } from '@events-helsinki/components/types';
 import upperFirst from 'lodash/upperFirst';
 import qs from 'query-string';
@@ -66,7 +64,7 @@ class CombinedSearchFormAdapter
    * Note that these properties should have some general level name.
    * These values can be mapped to event, course and venue queries.
    */
-  language: string;
+  language: AppLanguage;
   geolocation?: Coordinates | null;
   text: string;
   venueOrderBy?: string | null;
@@ -89,7 +87,7 @@ class CombinedSearchFormAdapter
    * state of the search form.
    */
   constructor(
-    locale: string,
+    locale: AppLanguage,
     input: URLSearchParams,
     geolocation?: Coordinates | null
   ) {
@@ -231,7 +229,7 @@ class CombinedSearchFormAdapter
   public getSearchVariables(): SearchVariablesType {
     const venueSearchQueryVariables = new VenueSearchAdapter(
       this.getFormValues(),
-      this.language as AppLanguage,
+      this.language,
       this.geolocation
     ).getQueryVariables();
     const eventSearchQueryVariables = new EventSearchAdapter(

--- a/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -1,4 +1,3 @@
-import type { AppLanguage } from '@events-helsinki/components';
 import {
   DATE_TYPES,
   EVENT_SORT_OPTIONS,
@@ -41,7 +40,7 @@ describe('getSearchQuery function', () => {
 describe('getEventSearchVariables function', () => {
   const defaultParams = {
     include: [],
-    language: 'fi' as AppLanguage,
+    language: 'fi' as const,
     pageSize: AppConfig.pageSize,
     sortOrder: EVENT_SORT_OPTIONS.END_TIME,
     superEventType: [],

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -170,7 +170,7 @@ export async function getStaticPaths(): Promise<
       if (slug && slug.length > 0) {
         acc.push({
           params: { slug },
-          locale: pageInfo.locale as AppLanguage,
+          locale: pageInfo.locale,
         });
       }
       return acc;

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -121,7 +121,7 @@ export async function getStaticPaths(): Promise<
       if (slug && slug.length > 0) {
         acc.push({
           params: { slug },
-          locale: pageInfo.locale as AppLanguage,
+          locale: pageInfo.locale,
         });
       }
       return acc;

--- a/packages/components/src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/test-utils';
 import { translations } from '@/test-utils/initI18n';
 import { fakeEvent } from '@/test-utils/mockDataUtils';
-import type { AppLanguage } from '../../../../../types';
 import type {
   EventFields,
   SuperEventResponse,
@@ -48,7 +47,7 @@ configure({ defaultHidden: true });
 const getDateRangeStrProps = (event: EventDetails) => ({
   start: event.startTime!,
   end: event.endTime,
-  locale: 'fi' as AppLanguage,
+  locale: 'fi' as const,
   includeTime: true,
   timeAbbreviation: translations.common.timeAbbreviation,
 });

--- a/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/packages/components/src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -16,7 +16,6 @@ import {
 } from '@/test-utils/mocks/eventListMocks';
 import { EventTypeId } from '../../../../../types';
 import type {
-  AppLanguage,
   EventDetails,
   EventFieldsFragment,
   EventListQueryVariables,
@@ -123,7 +122,7 @@ const renderComponent = ({
 const getDateRangeStrProps = (event: EventDetails) => ({
   start: event.startTime!,
   end: event.endTime,
-  locale: 'fi' as AppLanguage,
+  locale: 'fi' as const,
   includeTime: true,
   timeAbbreviation: translations.common.timeAbbreviation,
 });

--- a/packages/components/src/components/navigation/useGetPathnameForLanguage.tsx
+++ b/packages/components/src/components/navigation/useGetPathnameForLanguage.tsx
@@ -6,6 +6,8 @@ import type {
   PageType,
 } from 'react-helsinki-headless-cms';
 import { useCmsHelper, useCmsRoutedAppHelper } from '../../cmsHelperProvider';
+import { DEFAULT_LANGUAGE } from '../../constants';
+import isAppLanguage from '../../type-guards/is-app-language';
 import type { AppLanguage } from '../../types';
 
 export default function useGetPathnameForLanguage(
@@ -31,6 +33,9 @@ export default function useGetPathnameForLanguage(
   );
 
   return ({ slug }) => {
+    const appLanguage: AppLanguage = isAppLanguage(slug)
+      ? slug
+      : DEFAULT_LANGUAGE;
     const translatedPage = (page?.translations as PageType[])?.find(
       (translation) => translation?.language?.slug === slug
     );
@@ -44,7 +49,7 @@ export default function useGetPathnameForLanguage(
               ) ?? '',
           }
         : getCurrentParsedUrlQuery(),
-      slug as AppLanguage
+      appLanguage
     );
   };
 }

--- a/packages/components/src/hooks/__tests__/useLocale.test.tsx
+++ b/packages/components/src/hooks/__tests__/useLocale.test.tsx
@@ -6,7 +6,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { render, screen } from '../../../config/tests/test-utils';
 import { APP_LANGUAGES } from '../../constants';
-import type { AppLanguage } from '../../types';
 import * as useLocale from '../useLocale';
 
 const TestComponent = () => {
@@ -39,7 +38,7 @@ describe('useLocale', () => {
 
     render(<TestComponent />);
     expect(initTestI18n.language).toBe(lang);
-    expect(mockUseLocale).toHaveReturnedWith(lang as AppLanguage);
+    expect(mockUseLocale).toHaveReturnedWith(lang);
   });
 
   it.each(unsupportedLanguages)(
@@ -49,7 +48,7 @@ describe('useLocale', () => {
       await initTestI18n.changeLanguage(lang);
       render(<TestComponent />);
       expect(initTestI18n.language).toBe(lang);
-      expect(mockUseLocale).toHaveReturnedWith('fi' as AppLanguage);
+      expect(mockUseLocale).toHaveReturnedWith('fi');
       expect(await screen.findByTestId('translation')).toHaveTextContent(
         translations.common.supriseMe
       );

--- a/packages/components/src/type-guards/is-app-language.ts
+++ b/packages/components/src/type-guards/is-app-language.ts
@@ -2,7 +2,10 @@ import { APP_LANGUAGES } from '../constants';
 import type { AppLanguage } from '../types';
 
 const isAppLanguage = (value: unknown): value is AppLanguage => {
-  return APP_LANGUAGES.includes(value as AppLanguage);
+  return (
+    typeof value === 'string' &&
+    (APP_LANGUAGES as readonly string[]).includes(value)
+  );
 };
 
 export default isAppLanguage;

--- a/packages/components/src/types/types.ts
+++ b/packages/components/src/types/types.ts
@@ -50,7 +50,7 @@ export type AppCategory = {
   value: string;
 };
 
-export type PageUriInfo = { uri: string; slug: string; locale: string };
+export type PageUriInfo = { uri: string; slug: string; locale: AppLanguage };
 
 export type TimeResourceState =
   | 'open'

--- a/packages/components/src/utils/headless-cms/HeadlessCmsRoutedAppHelper.tsx
+++ b/packages/components/src/utils/headless-cms/HeadlessCmsRoutedAppHelper.tsx
@@ -95,10 +95,15 @@ export class CmsRoutedAppHelper {
       // Remove all
       Object.keys(queryObject).forEach((param) => delete queryObject[param]);
     }
+    const locale = router.locale || router.defaultLocale;
+    const appLanguage: AppLanguage = isAppLanguage(locale)
+      ? locale
+      : DEFAULT_LANGUAGE;
+
     const cleanedUrl = this.getLocalizedCmsItemUrl(
       forwardPath, // FIXME: Could this be taken from the router.asPath?
       queryObject,
-      (router.locale || router.defaultLocale) as AppLanguage
+      appLanguage
     );
     router.replace(
       cleanedUrl,

--- a/packages/components/src/utils/headless-cms/service.tsx
+++ b/packages/components/src/utils/headless-cms/service.tsx
@@ -6,9 +6,10 @@ import type {
 } from '@apollo/client/core/index.js';
 import type { NextApiResponse } from 'next';
 
-import { APP_LANGUAGES } from '../../constants';
+import { APP_LANGUAGES, DEFAULT_LANGUAGE } from '../../constants';
 import type { Logger } from '../../loggers/logger';
-import type { PageUriInfo } from '../../types';
+import isAppLanguage from '../../type-guards/is-app-language';
+import type { AppLanguage, PageUriInfo } from '../../types';
 import type { GetAllItemsUriInfoResponseType } from './queries';
 import {
   GET_ALL_PAGES_URI_INFO_QUERY,
@@ -46,11 +47,18 @@ export function uniqBySetWithArrayFrom<T>(array: T[]): T[] {
  */
 const _getPageUriInfo = ({
   node,
-}: GetAllItemsUriInfoResponseType['items']['edges'][number]): PageUriInfo => ({
-  uri: node.uri,
-  slug: node.slug,
-  locale: node.language.code.toLowerCase(),
-});
+}: GetAllItemsUriInfoResponseType['items']['edges'][number]): PageUriInfo => {
+  const locale = node.language.code.toLowerCase();
+  const appLanguage: AppLanguage = isAppLanguage(locale)
+    ? locale
+    : DEFAULT_LANGUAGE;
+
+  return {
+    uri: node.uri,
+    slug: node.slug,
+    locale: appLanguage,
+  };
+};
 
 /**
  * Fetches all article (post) URI information from the CMS.

--- a/packages/graphql-proxy-server/src/utils/acceptLanguage.ts
+++ b/packages/graphql-proxy-server/src/utils/acceptLanguage.ts
@@ -4,7 +4,10 @@ import type ContextValue from '../context/ContextValue.js';
 import { appLanguages, type AppLanguage } from '../types.js';
 
 const isAppLanguage = (value: unknown): value is AppLanguage => {
-  return appLanguages.includes(value as AppLanguage);
+  return (
+    typeof value === 'string' &&
+    (appLanguages as readonly string[]).includes(value)
+  );
 };
 
 /**


### PR DESCRIPTION
## Description

Make use of AppLanguage more in a typesafe way:

done:
- remove all "as AppLanguage" typecasts from codebase
- use AppLanguage instead of string as a type where applicable
- if locale/language is string, make sure it actually is an AppLanguage by using isAppLanguage typeguard first, and only after that use it as an AppLanguage
- use DEFAULT_LANGUAGE (i.e. "fi") as a fallback for AppLanguage values
- make slightly better use of typescript's type system in isAppLanguage typeguards by instead of downcasting unknown to AppLanguage upcast `('fi' | 'en' | 'sv')[]` to `readonly string[]` and narrow `unknown` to `string` first

## Related

- Based on PR #877 
- [TH-1441](https://helsinkisolutionoffice.atlassian.net/browse/TH-1441)

## Testing

<details>

<summary>
Ran `yarn g:lint && yarn g:typecheck && yarn g:test` locally and they all passed (Click to see output)
</summary>

```
$ yarn g:lint && yarn g:typecheck && yarn g:test

➤ YN0000: [@events-helsinki/common-i18n]: Process started
➤ YN0000: [@events-helsinki/common-tests]: Process started
➤ YN0000: [@events-helsinki/components]: Process started
➤ YN0000: [@events-helsinki/eslint-config-bases]: Process started
➤ YN0000: [@events-helsinki/graphql-proxy-server]: Process started
➤ YN0000: [@events-helsinki/graphql-proxy-server]: Process exited (exit code 0), completed in 4s 514ms
➤ YN0000: [@events-helsinki/eslint-config-bases]: Process exited (exit code 0), completed in 4s 854ms
➤ YN0000: [@events-helsinki/common-i18n]: Process exited (exit code 0), completed in 6s 74ms
➤ YN0000: [@events-helsinki/common-tests]: Process exited (exit code 0), completed in 6s 660ms
➤ YN0000: [@events-helsinki/components]: Process exited (exit code 0), completed in 15s 435ms
➤ YN0000: [events-helsinki]: Process started
➤ YN0000: [hobbies-helsinki]: Process started
➤ YN0000: [sports-helsinki]: Process started
➤ YN0000: [events-graphql-proxy]: Process started
➤ YN0000: [venue-graphql-proxy]: Process started
➤ YN0000: [events-graphql-proxy]: Process exited (exit code 0), completed in 6s 194ms
➤ YN0000: [venue-graphql-proxy]: Process exited (exit code 0), completed in 9s 223ms
➤ YN0000: [hobbies-helsinki]: Process exited (exit code 0), completed in 12s 372ms
➤ YN0000: [events-helsinki]: Process exited (exit code 0), completed in 16s 557ms
➤ YN0000: [sports-helsinki]: Process exited (exit code 0), completed in 19s 409ms
➤ YN0000: Done in 34s 893ms

➤ YN0000: [@events-helsinki/common-i18n]: Process started
➤ YN0000: [@events-helsinki/common-tests]: Process started
➤ YN0000: [@events-helsinki/components]: Process started
➤ YN0000: [@events-helsinki/eslint-config-bases]: Process started
➤ YN0000: [@events-helsinki/graphql-proxy-server]: Process started
➤ YN0000: [@events-helsinki/common-i18n]: Process exited (exit code 0), completed in 3s 20ms
➤ YN0000: [@events-helsinki/eslint-config-bases]: Process exited (exit code 0), completed in 3s 837ms
➤ YN0000: [@events-helsinki/common-tests]: Process exited (exit code 0), completed in 4s 22ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]: Process exited (exit code 0), completed in 4s 214ms
➤ YN0000: [@events-helsinki/components]: Process exited (exit code 0), completed in 5s 916ms
➤ YN0000: [events-helsinki]: Process started
➤ YN0000: [hobbies-helsinki]: Process started
➤ YN0000: [sports-helsinki]: Process started
➤ YN0000: [events-graphql-proxy]: Process started
➤ YN0000: [venue-graphql-proxy]: Process started
➤ YN0000: [events-graphql-proxy]: Process exited (exit code 0), completed in 3s 656ms
➤ YN0000: [venue-graphql-proxy]: Process exited (exit code 0), completed in 3s 839ms
➤ YN0000: [events-helsinki]: Process exited (exit code 0), completed in 5s 941ms
➤ YN0000: [sports-helsinki]: Process exited (exit code 0), completed in 5s 974ms
➤ YN0000: [hobbies-helsinki]: Process exited (exit code 0), completed in 6s 8ms
➤ YN0000: Done in 11s 966ms

➤ YN0000: [@events-helsinki/components]: Process started
➤ YN0000: [@events-helsinki/graphql-proxy-server]: Process started
➤ YN0000: [@events-helsinki/graphql-proxy-server]:
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  RUN  v3.2.4 events-helsinki-monorepo/packages/graphql-proxy-server
➤ YN0000: [@events-helsinki/graphql-proxy-server]:
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/composeQuery.test.ts > composeQuery function > should compose new search query 2ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/normalizeLocalizedObject.test.ts > normalizeLocalizedObject function > should normalize certain localized object 4ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/normalizeKeys.test.ts > normalizeKeys function > should normalize entered object 3ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/queryBuilder.test.ts > queryBuilder function > returns correct query string with arrays 3ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/queryBuilder.test.ts > queryBuilder function > returns correct query string with booleans 1ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/queryBuilder.test.ts > queryBuilder function > returns correct query string with strings 0ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/queryBuilder.test.ts > queryBuilder function > returns correct query string with numbers 0ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/queryBuilder.test.ts > queryBuilder function > returns correct query from mixed types 0ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  ✓ src/utils/__tests__/normalizeKey.test.ts > normalizeKey function > should normalize entered key 2ms
➤ YN0000: [@events-helsinki/graphql-proxy-server]:
➤ YN0000: [@events-helsinki/graphql-proxy-server]:  Test Files  5 passed (5)
➤ YN0000: [@events-helsinki/graphql-proxy-server]:       Tests  9 passed (9)
➤ YN0000: [@events-helsinki/graphql-proxy-server]:    Start at  13:23:21
➤ YN0000: [@events-helsinki/graphql-proxy-server]:    Duration  2.57s (transform 381ms, setup 75ms, collect 736ms, tests 27ms, environment 9.22s, prepare 834ms)
➤ YN0000: [@events-helsinki/graphql-proxy-server]:
➤ YN0000: [@events-helsinki/graphql-proxy-server]: SonarQube report written to events-helsinki-monorepo\packages\graphql-proxy-server\sonar-report.xml
➤ YN0000: [@events-helsinki/graphql-proxy-server]: JSON report written to events-helsinki-monorepo/packages/graphql-proxy-server/sonar-report.json
➤ YN0000: [@events-helsinki/graphql-proxy-server]: Process exited (exit code 0), completed in 4s 203ms
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]:  RUN  v3.2.4 events-helsinki-monorepo/packages/components
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchTextInput.test.tsx > AdvancedSearchTextInput > renders an input field 845ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchTextInput.test.tsx > AdvancedSearchTextInput > passes placeholder to the input 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchTextInput.test.tsx > AdvancedSearchTextInput > allows user to type in the input 448ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchTextInput.test.tsx > AdvancedSearchTextInput > calls onChange handler when input value changes 217ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchTextInput.test.tsx > AdvancedSearchTextInput > focuses input on container click 124ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchTextInput.test.tsx > AdvancedSearchTextInput > renders a search icon 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/select/__tests__/SearchSelect.test.tsx > SearchSelect > successful cases > renders properly 867ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/select/__tests__/SearchSelect.test.tsx > SearchSelect > successful cases > lists the values when it's clicked 525ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/select/__tests__/SearchSelect.test.tsx > SearchSelect > error cases > does not allow array as a value 49ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/select/__tests__/SearchSelect.test.tsx > SearchSelect > error cases > does not allow array as a defaultValue 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/select/__tests__/SearchSelect.test.tsx > SearchSelect > error cases > does not allow multiselect 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelector.test.tsx > should render selected date types when single option is selected 67ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelector.test.tsx > should render selected date types when multiple options are selected 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > should have correct date types selected 791ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventKeywords/__tests__/EventKeywords.test.tsx > should render keywords and handle click 810ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventKeywords/__tests__/EventKeywords.test.tsx > should not show keywords 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventCard/__tests__/LargeEventCard.test.tsx > large event card > should go to event page by clicking event card 1020ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should set focus to input after clicking toggle button 839ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/ApolloErrorNotification.test.tsx > ApolloErrorNotification > renders properly 852ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx > similar events > should render similar event cards 924ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx > similar events > should hide the whole page section when there are no cards 72ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventCard/__tests__/EventCard.test.tsx > event card > should go to event page by clicking event card 965ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > should call onChangeDateTypes and unselect option 208ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should render event name, description and location 789ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventKeywords/__tests__/EventKeywords.test.tsx > should render today tag and handle click 150ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventCard/__tests__/EventCard.test.tsx > event card > should go to event page by clicking button 182ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventKeywords/__tests__/EventKeywords.test.tsx > should render this week tag and handle click 76ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventKeywords/__tests__/EventKeywords.test.tsx > should hide buy button for free events 79ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > should call onChangeDateTypes and select option 151ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/ApolloErrorNotification.test.tsx > ApolloErrorNotification > calls onClose callback when closed 314ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelector.test.tsx > should add date type 1005ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > Escape > should close range dropdown with escape 1067ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > should not open dropdown when user focuses toggle button 51ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > custom date type should be selected when startDate is selected 88ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > custom date type should be selected when endDate is selected 85ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should go to event list 282ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should render keywords 33ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > should open dropdown when user clicks on toggle button 210ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > should close date selector menu with escape 176ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should filter results based on user search and options[].text field 477ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateRangePicker/__tests/DateRangePicker.test.tsx > date range input > should call onChangeEndDate 1507ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelector.test.tsx > should call toggleIsCustomDate function 275ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should render today tag 285ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > should open dropdown when toggle button is active and user presses ArrowDown 176ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > should close dropdown when toggle button is active and user presses ArrowUp 66ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelector.test.tsx > should remove date type 295ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/place/placeSelector/__tests__/PlaceSelector.test.tsx > should filter place options 1687ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/place/placeSelector/__tests__/PlaceSelector.test.tsx > should render selected value correctly 45ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should render this week tag 216ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should hide buy/enrol button if no offer url 29ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelector.test.tsx > should open menu with > ArrowDown 121ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelector.test.tsx > should open menu with > ArrowUp 118ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should show buy/enrol button 167ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > should close date selector menu with close button 417ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should show always show fixed options also before search 223ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should show buy/enrol button 163ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx > events > should render other event times 1894ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > when menu has been closed, it should reopen with > ArrowDown 206ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/mobileDateSelector/__tests__/MobileDateSelector.test.tsx > when menu has been closed, it should reopen with > ArrowUp 124ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > can be navigated with tab 340ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should show buy/enrol button 148ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should show buy/enrol button 126ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/EventHero.test.tsx > should show event dates if super event is defined 26ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should reset keyboard navigation position after a new search 452ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventContent/__tests__/EventContent.test.tsx > should render event content fields 2261ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventContent/__tests__/EventContent.test.tsx > should hide map if internet event 61ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > should call onChange correctly when setting fixed values with checkbox 313ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx > events > should show toastr when loading next event page fails 378ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventContent/__tests__/EventContent.test.tsx > should show location extra info when available 57ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventContent/__tests__/EventContent.test.tsx > should not show location extra info title when location extra info not available 72ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > ArrowUp, ArrowDown > should allow navigation with up and down arrows 379ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > ArrowUp, ArrowDown > should select last item if the first keyboard navigation is button up 226ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > Validation > should fix min value and max value if initial values are negative 448ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/rangeDropdown/__tests__/RangeDropdown.test.tsx > Validation > should fix min value and max value if min > max 352ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > ArrowUp, ArrowDown > should reset to start position when user goes up in the first member of the list 371ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateRangePicker/__tests/DateRangePicker.test.tsx > date range input > should call onChangeEndDate with clicking date 1799ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx > events > should go to event page of other event time 1085ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > ArrowUp, ArrowDown > should reset to start position when user goes down from the last member of the list 204ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > Escape > should close suggestions with escape 255ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should not open dropdown when user focuses toggle button 68ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateRangePicker/__tests/DateRangePicker.test.tsx > date range input > should call onChangeStartDate 642ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should open dropdown when user clicks on toggle button 255ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should render event info fields 3721ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should call onChange when clicking checkbox 281ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should hide the organizer section when the organizer name is not given 346ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should uncheck option 323ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should hide other info section if no provider contact info, external links or info url 255ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should hide other info section registration url from external links 153ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should call onChange with empty array when clicking select all checkbox 396ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should show selected text for single value 10ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > should show selected text for single value 2 14ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should hide the map link from location info if location is internet 113ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > when dropdown has been closed, it should reopen with > Enter 270ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > add to calendar > should call ics.createEvent 542ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > when dropdown has been closed, it should reopen with > ArrowDown 259ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/multiSelectDropdown/__tests__/MultiSelectDropdown.test.tsx > when dropdown has been closed, it should reopen with > ArrowUp 249ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > add to calendar > should call ics.createEvent when end time is not defined 404ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should show formatted audience age info on single event page if min and max ages are specified 161ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateRangePicker/__tests/DateRangePicker.test.tsx > date range input > should call onChangeStartDate with clicking date 1921ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should show formatted audience age info on single event page if max age is not specified 161ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should hide audience age info on single event page if min and max ages are not specified 161ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchInput.test.tsx > AdvancedSearchInput > should render the icon and the input 68ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > OrganizationInfo > should show correct provider link text on event/hobby detail page 200ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchInput.test.tsx > AdvancedSearchInput > should focus the input when the container is clicked 763ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > OrganizationInfo > should show correct provider link text on event/hobby detail page 167ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/advancedSearch/__tests__/AdvancedSearchInput.test.tsx > AdvancedSearchInput > should apply and remove focus styles 248ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > OrganizationInfo > should show correct provider link on event/hobby detail page 408ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateRangePicker/__tests/DateRangePicker.test.tsx > date range input > should show error start date must be before end date 1147ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/AskemFeedbackContainer.test.tsx > AskemFeedbackContainer > should render null when disabled 25ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/AskemFeedbackContainer.test.tsx > AskemFeedbackContainer > should render CookiesRequired when consent is not given 40ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/AskemFeedbackContainer.test.tsx > AskemFeedbackContainer > should render the feedback container when consent is given 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/AskemFeedbackContainer.test.tsx > AskemFeedbackContainer > should handle consent page redirect when button is clicked 687ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/AskemFeedbackContainer.test.tsx > AskemFeedbackContainer > should not redirect if consentUrl is not provided 103ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/AskemFeedbackContainer.test.tsx > AskemFeedbackContainer > should apply withPadding style when withPadding prop is true 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > OrganizationInfo > should show correct provider link on event/hobby detail page 345ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateRangePicker/__tests/DateRangePicker.test.tsx > date range input > should show formatting error 774ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > superEvent > should render super event title and link when super event is given 640ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > superEvent > should should not render super event title when super event is not given 381ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > subEvents > should render sub events title and content when sub events are given 1185ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > subEvents > should navigate to sub events page when it is clicked 359ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > subEvents > should render subEvents with other times title when the event is a middle level event in event hierarchy 722ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/shareLinks/__tests__/ShareLinks.test.tsx > should have discoverable link address copy button as well as Facebook, Twitter and LinkedIn share link buttons 975ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/TextFilter.test.tsx > matches snapshot 59ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/PublisherFilter.test.tsx > matches snapshot 126ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/TextFilter.test.tsx > calls onRemove callback when remove button is clicked 833ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/PublisherFilter.test.tsx > calls onRemove callback when remove button is clicked 878ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/PublisherFilter.test.tsx > should return null if place doesn't exist 31ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/PlaceFilter.test.tsx > matches snapshot 133ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx > should render 1 mapLink and 2 directionsLink 959ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx > should render event name 34ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx > should render location address 24ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx > cookie consents > when disabled > should not render service map 14ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx > cookie consents > when only required consents accepted > should not render service map 15ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventLocation/__tests__/EventLocation.test.tsx > cookie consents > when service map consents accepted > renders service map 38ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/PlaceFilter.test.tsx > calls onRemove callback when remove button is clicked 759ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/PlaceFilter.test.tsx > should return null if place doesn't exist 44ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/AgeFilter.test.tsx > matches snapshot 82ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/AgeFilter.test.tsx > calls onRemove callback when remove button is clicked 853ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/DateFilter.test.tsx > matches snapshot 105ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filters/__tests__/DateFilter.test.tsx > calls onRemove callback when remove button is clicked 892ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventClosedHero/__tests__/EventClosedHero.test.tsx > should render all text fields 899ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventClosedHero/__tests__/EventClosedHero.test.tsx > should go to home page when clicking button 174ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/iconButton/__tests__/IconButton.test.tsx > should render icon button 824ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/keyword/__tests__/KeywordButton.test.tsx > matches snapshot 72ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/keyword/__tests__/KeywordButton.test.tsx > calls onClick callback when clicking 801ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/RouteMeta.test.tsx > RouteMeta > without page prop > should render canonical and alternate links based on router path 80ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/RouteMeta.test.tsx > RouteMeta > without page prop > should handle root path correctly 10ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should render the list of items 154ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the default variant class when no variant is provided 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct class for variant "default" 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct class for variant "collection-grid" 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct class for variant "searchResult" 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct class for variant "grid-3" 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct class for variant "grid-2" 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct class for variant "fixed-grid-4" 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct class for variant "column" 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct gap class for gap "xs" 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct gap class for gap "s" 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct gap class for gap "m" 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should apply the correct gap class for gap "l" 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should use a custom component for list items when provided 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should attach the ref to the ul element 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should pass className to custom li component 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/list/__tests__/List.test.tsx > <List /> > should render an empty list if items is an empty array 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/RouteMeta.test.tsx > RouteMeta > without page prop > should handle path with trailing slash and query params 12ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/RouteMeta.test.tsx > RouteMeta > with page prop > should render alternate links based on page translations 12ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/PageMeta.test.tsx > PageMeta > should render basic title and description 71ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/PageMeta.test.tsx > PageMeta > should render Open Graph meta tags 14ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/PageMeta.test.tsx > PageMeta > should render Twitter card meta tags 12ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should not render any meta tags when no props are provided 65ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should render title meta tag 18ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should render description meta tag 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should render favicon link tag 10ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should render SVG favicon link tag 11ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should render apple touch icon link tag 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should render manifest link tag 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/BasicMeta.test.tsx > BasicMeta > should render all tags when all props are provided 8ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/toggleButton/__tests__/ToggleButton.test.tsx > matches snapshot 63ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/toggleButton/__tests__/ToggleButton.test.tsx > should call onClick 885ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/shareLinks/__tests__/FacebookShareLink.test.tsx > should apply aria label 925ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/cmsHelperProvider/__tests__/useCmsRoutedAppHelper.test.tsx > useCmsRoutedAppHelper > should throw an error when used outside of CmsRoutedApiHelperProvider 47ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/cmsHelperProvider/__tests__/useCmsRoutedAppHelper.test.tsx > useCmsRoutedAppHelper > should throw an error if routerHelper is not provided in the context 11ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/cmsHelperProvider/__tests__/useCmsRoutedAppHelper.test.tsx > useCmsRoutedAppHelper > should return the routerHelper when it is provided in the context 8ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/shareLinks/__tests__/LinkedInShareLink.test.tsx > should apply aria label 829ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/shareLinks/__tests__/TwitterShareLink.test.tsx > should apply aria label 928ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return false if event is not defined 29ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return false if registration is not defined 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return true if remainingAttendeeCapacity is greater than 0 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return true event with waiting list capacity and remainingWaitingListCapacity is greater than 0 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return false if both remaining capacities are 0 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return false if both remaining capacities are null 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return true if enrolment has not started yet and enrolmentFormAvailableBeforeHand is true 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > useIsEnrolmentOpen > should return false if enrolment has not started yet and enrolmentFormAvailableBeforeHand is false 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > OfferButton > should render if offerInfoUrl exists and enrolment is open 815ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > OfferButton > should not render if offerInfoUrl exists but enrolment is not open 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > OfferButton > should not render if enrolment is open but offerInfoUrl does not exist 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > OfferButton > should not render if offerInfoUrl does not exist and enrolment is not open 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should not render if enrolmentStartTime is missing 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should not render if enrolmentEndTime is missing 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should render if enrolment times are present and status is "full" 10ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should render if enrolment times are present and status is "enrolmentNotStartedYet" 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should render if enrolment times are present and status is "enrolmentEnded" 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should not render if status is "noEnrolmentTimes" even if enrolment times are present 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should not render if status is "enrollable" even if enrolment times are present 13ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should not render if status is "queueable" even if enrolment times are present 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EnrolmentStatusInfo > should apply alert class when enrolment status is "full" 11ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EventHero's enrolment features > Status: enrollable => { showOfferButton: true, showEnrolmentStatus: false } 198ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EventHero's enrolment features > Status: enrolmentEnded => { showOfferButton: false, showEnrolmentStatus: true } 13ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EventHero's enrolment features > Status: enrolmentNotStartedYet => { showOfferButton: true, showEnrolmentStatus: true } 127ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EventHero's enrolment features > Status: full => { showOfferButton: false, showEnrolmentStatus: true } 14ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EventHero's enrolment features > Status: noEnrolmentTimes => { showOfferButton: false, showEnrolmentStatus: false } 12ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventHero/__tests__/enrolment.test.tsx > EventHero's enrolment features > Status: queueable => { showOfferButton: true, showEnrolmentStatus: false } 119ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/cmsHelperProvider/__tests__/useCmsHelper.test.tsx > useCmsHelper > should throw an error when used outside of CmsHelperProvider 53ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/cmsHelperProvider/__tests__/useCmsHelper.test.tsx > useCmsHelper > should throw an error if cmsHelper is not provided in the context 11ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/cmsHelperProvider/__tests__/useCmsHelper.test.tsx > useCmsHelper > should return the cmsHelper when it is provided in the context 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > uniqBySetWithArrayFrom > should remove duplicate numbers from an array 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > uniqBySetWithArrayFrom > should remove duplicate strings from an array 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > uniqBySetWithArrayFrom > should handle an empty array 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > uniqBySetWithArrayFrom > should not remove duplicate objects unless they are the same reference 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > CMS URI Info Fetchers > getAllCmsArticlesPageUriInfos should fetch a single page of articles 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > CMS URI Info Fetchers > getAllCmsArticlesPageUriInfos should handle pagination 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > CMS URI Info Fetchers > getAllCmsPagesPageUriInfos should fetch pages 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > revalidate > should revalidate a simple path and return null on success 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > revalidate > should normalize path with trailing slash 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > revalidate > should handle root path 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > revalidate > should handle empty string as root path 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > revalidate > should log an error and return the path on failure 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > revalidateAll > should call revalidate for each unique page 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > revalidateAll > should log failures correctly 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > NextPageLister functionality > listGeneratedPages should list, deduplicate, and sort files recursively 21ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > NextPageLister functionality > listGeneratedPages should throw if directory does not exist 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > triggerAllCmsPagesRevalidation > should fetch all CMS pages and revalidate them 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > triggerAllCmsPagesRevalidation > should handle errors during fetching 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > triggerAllPathnamesPagesRevalidation > should list pages from multiple pathnames and revalidate them 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > triggerAllPathnamesPagesRevalidation > should continue even if one pathname fails to list 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/service.test.ts > NextPageRevalidateService > triggerAllPathnamesPagesRevalidation > should not revalidate if no pages are found 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/use-promise.test.tsx > usePromise hook > should load, return the promise response and rerender 61ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/use-promise.test.tsx > usePromise hook > should set error when promise fails 21ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/useLocale.test.tsx > useLocale > supports the "en" as a language 57ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/useLocale.test.tsx > useLocale > supports the "fi" as a language 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/useLocale.test.tsx > useLocale > supports the "sv" as a language 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/useLocale.test.tsx > useLocale > returns default language "fi" for unsupported language "fr" 17ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/use-promise.test.tsx > usePromise hook > should call the promise when forceReload is called 20ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/use-promise.test.tsx > usePromise component > should conditionally call the promise based on deps changes 43ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/use-promise.test.tsx > usePromise component > should call the promise if changed 13ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/useLocale.test.tsx > useLocale > returns default language "fi" for unsupported language "test" 20ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/place/__tests__/PlaceText.test.tsx > matches snapshot 115ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventPageMeta/__tests__/EventPageMeta.test.tsx > applies expected metadata 113ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/copyButton/__tests__/CopyButton.test.tsx > should show success message when copying succeeds that displays for 4 seconds 103ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/copyButton/__tests__/CopyButton.test.tsx > should add success class for 4s after a successful copy 17ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/shareLinks/__tests__/ShareLinkBase.test.tsx > should apply an aria label 56ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/shareLinks/__tests__/ShareLinkBase.test.tsx > should have button attribute 13ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/shareLinks/__tests__/ShareLinkBase.test.tsx > should launch sharing link in a pop up window with encoded uri components 24ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/dateSelector/__tests__/DateSelectorMenu.test.tsx > matches snapshot 100ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/useCanonicalUrl.test.tsx > useCanonicalUrl > should return the canonical URL with a simple path 25ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/useCanonicalUrl.test.tsx > useCanonicalUrl > should remove trailing slashes from the path 10ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/useCanonicalUrl.test.tsx > useCanonicalUrl > should handle the root path correctly 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/useCanonicalUrl.test.tsx > useCanonicalUrl > should strip query parameters from the path 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/useCanonicalUrl.test.tsx > useCanonicalUrl > should handle path with trailing slash and query parameters 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/seo/meta/__tests__/useCanonicalUrl.test.tsx > useCanonicalUrl > should handle root path with query parameters 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/spinner/__tests__/LoadingSpinner.test.tsx > matches snapshot 70ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/spinner/__tests__/LoadingSpinner.test.tsx > render spinner if isLoading is true 17ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/spinner/__tests__/LoadingSpinner.test.tsx > render child component if isLoading is false 11ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventName/__tests__/EventName.test.tsx > should render event name 70ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/eventName/__tests__/EventName.test.tsx > should tell that event has cancelled 31ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/useAskemContext.test.tsx > useAskemContext > should initialize with no consent if cookies are not set 34ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/useAskemContext.test.tsx > useAskemContext > should initialize with consent if cookies are set 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/useAskemContext.test.tsx > useAskemContext > should update askem instance when consent is given via handleConsentGiven 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/useAskemContext.test.tsx > useAskemContext > should recreate instance when askemConfigurationInput changes 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/scrollIntoViewWithFocus/__tests__/ScrollIntoViewWithFocus.test.tsx > should scroll to component when focused 58ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-09-23T09:00:00Z', …(4) }) == 'Ti 23.9.2025, klo 12.00–13.00' 9ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-09-23T09:00:00Z', …(5) }) == '23.9.2025, klo 12.00–13.00' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-11T10:15:00Z', …(4) }) == 'Ke 11.6. – To 12.6.2025' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-11T10:15:00Z', …(5) }) == '11.6.–12.6.2025' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-11T10:15:00Z', …(4) }) == 'Ke 11.6.2025 – Pe 12.6.2026' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-11T10:15:00Z', …(5) }) == '11.6.2025–12.6.2026' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(4) }) == 'Ti 10.6. – Pe 26.9.2025' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(5) }) == '10.6.–26.9.2025' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(4) }) == 'Ti 10.6.2025 – La 26.9.2026' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(5) }) == '10.6.2025–26.9.2026' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-09-23T09:00:00Z', …(4) }) == 'Ti 23.9.2025, kl. 12:00–13:00' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-09-23T09:00:00Z', …(5) }) == '23.9.2025, kl. 12:00–13:00' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(4) }) == 'Ti 10.6. – Sö 28.9.2025' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(5) }) == '10.6.–28.9.2025' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(4) }) == 'Ti 10.6.2025 – Må 28.9.2026' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(5) }) == '10.6.2025–28.9.2026' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-09-23T10:30:00Z', …(4) }) == 'Tue 23.9.2025, at 1:30 p.m.–2:15 p.m.' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-09-23T10:30:00Z', …(5) }) == '23.9.2025, at 1:30 p.m.–2:15 p.m.' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(4) }) == 'Tue 10.6. – Wed 24.9.2025' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(5) }) == '10.6.–24.9.2025' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(4) }) == 'Tue 10.6.2025 – Thu 24.9.2026' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateRangeStr.test.ts > getDateRangeStr > getDateRangeStr({ start: '2025-06-10T10:15:00Z', …(5) }) == '10.6.2025–24.9.2026' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/useApolloErrorHandler.test.tsx > useApolloErrorHandler > should have a correct initial state 31ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/useApolloErrorHandler.test.tsx > useApolloErrorHandler > should show notification when an error is added 8ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/useApolloErrorHandler.test.tsx > useApolloErrorHandler > should hide notification when errors are cleared via onCloseErrorHandler 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/useApolloErrorHandler.test.tsx > useApolloErrorHandler > should keep the notification visible when multiple unique errors are added 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/filterButton/__tests__/FilterButton.test.tsx > matches snapshot 92ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/srOnly/__tests__/SrOnly.test.tsx > matches snapshot 88ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/useAskem.test.tsx > useAskem > should return undefined values when used outside of AskemProvider 30ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/useAskem.test.tsx > useAskem > should return values from the context 6ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/askem/__tests__/useAskem.test.tsx > useAskem > should call setRnsConfigValue from the context instance 8ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/app/__tests__/BaseApp.test.tsx > BaseApp > renders children 73ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/hooks/__tests__/use-deep-compare-memoize.test.ts > useDeepCompareMemoize > should not mutate references 28ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects(null, "'fi'") == {} with expected warnings 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects(undefined, "'fi'") == {} with expected warnings 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('null', "'fi'") == {} with expected warnings 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[]', "'fi'") == {} with expected warnings 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[{"/a": "/b"}]', "'fi'") == { '/a': '/b', '/fi/a': '/b' } with expected warnings 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[{"/a": "/b"},{"": ""},{"invalid-from…', "'fi'") == { '/a': '/b', '/fi/a': '/b', …(2) } with expected warnings 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[{"/a": "/b"}]', "'sv'") == { '/a': '/b', '/sv/a': '/b' } with expected warnings 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[{"/a": "/b"}]', "'en'") == { '/a': '/b', '/en/a': '/b' } with expected warnings 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[{"/wiki/ακ#Απ": "/中-cn/to_go/2020年?s…', "'en'") == { …(2) } with expected warnings 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[{"/a": "/b"}, {"/c": "/d"}]', "'fi'") == { '/a': '/b', '/c': '/d', …(2) } with expected warnings 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('{"/a": "/b", "/c": "/d"}', "'en'") == { '/a': '/b', '/c': '/d', …(2) } with expected warnings 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/parseRedirects.test.tsx > parseRedirects > parseRedirects('[{"/a/b/c": "/d"}, {"/e/f/": "/g/h/"}]', "'sv'") == { '/a/b/c': '/d', …(3) } with expected warnings 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is configured > should return the proxied URL for 'an http URL' 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is configured > should return the proxied URL for 'an https URL' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is configured > should return the proxied URL for 'a protocol-relative URL' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is configured > should return the proxied URL for 'an empty string' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is configured > should return the proxied URL for 'null' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is configured > should return the proxied URL for 'undefined' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is configured > should return the proxied URL for 'an invalid URL' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is NOT configured > should handle URLs gracefully for 'an http URL' 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is NOT configured > should handle URLs gracefully for 'an https URL' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getSecureImage.test.ts > getSecureImage > when image proxy URL is NOT configured > should handle URLs gracefully for 'a protocol-relative URL' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/hash.test.ts > hash > Should create a stable hashed value from a string 15ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > MutableReference > should initialize with undefined reference 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > MutableReference > should allow setting and getting reference 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > initializeApolloClient > should mutate references used for caching the client 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > initializeApolloClient > should return the cached client if already set 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > initializeApolloClient > should create and cache a new client if not cached 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getQlLanguage > should return fi as FI 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getQlLanguage > should return sv as SV 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getQlLanguage > should return en as EN 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getQlLanguage > should return de as FI 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getQlLanguage > should return  as FI 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getQlLanguage > should return undefined as FI 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getUnifiedSearchLanguage > should return "fi" as "FINNISH" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getUnifiedSearchLanguage > should return "sv" as "SWEDISH" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getUnifiedSearchLanguage > should return "en" as "ENGLISH" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getUnifiedSearchLanguage > should return "de" as "undefined" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getUnifiedSearchLanguage > should return "" as "undefined" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getUnifiedSearchLanguage > should return "undefined" as "undefined" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getMenuLocationFromLanguage > should return "fi" as "PRIMARY" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getMenuLocationFromLanguage > should return "sv" as "PRIMARY___SV" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getMenuLocationFromLanguage > should return "en" as "PRIMARY___EN" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getMenuLocationFromLanguage > should return "de" as "PRIMARY" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getMenuLocationFromLanguage > should return "" as "PRIMARY" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/utils.test.ts > client utils > getMenuLocationFromLanguage > should return "undefined" as "PRIMARY" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > / 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > /questions/198606/can-i-use-commas-in-a-url 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > /fi/search?searchType=Venue&text=test+a+text+search&venueOrderBy=wheelchair 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > /wiki/File:Artistic_swimming_women%27s_team_medal_ceremony_at_Tokyo_2020.jpg 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > /wiki/2020年夏季奧林匹克運動會團體韻律泳比賽 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > /wiki/Καλλιτεχνική_κολύμβηση_στους_Θερινούς_Ολυμπιακούς_Αγώνες_2020_–_Ομαδικό_γυναικών#Αποτελέσματα 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > /auth/realms/helsinki-tunnistus/protocol/openid-connect/auth?client_id=kukkuu-ui&redirect_uri=https%3A%2F%2Fkummilapset.hel.fi%2Fcallback&response_type=code&scope=openid+profile+email&state=5df5f78691853f7ef4f5db2d02fb0e20&code_challenge=ZbOcQqOA-lLNB93o_OnaCJo7QcINCfx-cfVbMrZwDFD&code_challenge_method=S256&response_mode=query 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns true > /fi/أطفال-الثقافة/ 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false >  1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false >   0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false >  / 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false > /  0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false >  /  0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false >
➤ YN0000: [@events-helsinki/components]: / 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false > // 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false > /` 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false > https://example.org/ 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isValidRedirectAddress.test.tsx > isValidRedirectAddress returns false > https://liikunta.hel.fi/search 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx > defaultExcludedBreadcrumbPaths > contains /pages 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx > defaultExcludedBreadcrumbPaths > contains /fi/pages 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx > defaultExcludedBreadcrumbPaths > contains /sv/pages 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx > defaultExcludedBreadcrumbPaths > contains /en/pages 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx > getFilteredBreadcrumbs > uses defaultExcludedBreadcrumbPaths as default list of excluded paths > removes the defaultExcludedBreadcrumbPaths from the given breadcrumbs - 0 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx > getFilteredBreadcrumbs > uses defaultExcludedBreadcrumbPaths as default list of excluded paths > removes the defaultExcludedBreadcrumbPaths from the given breadcrumbs - 1 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/headless-cms/__tests__/getFilteredBreadcrumbs.test.tsx > getFilteredBreadcrumbs > uses defaultExcludedBreadcrumbPaths as default list of excluded paths > removes the defaultExcludedBreadcrumbPaths from the given breadcrumbs - 2 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidUrl.test.ts > yields true for %p http://google.fi 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidUrl.test.ts > yields true for %p https://google.fi 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidUrl.test.ts > yields true for %p http://localhost:3000/fi/article-title?param=1 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidUrl.test.ts > yields false for %p / 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidUrl.test.ts > yields false for %p /fi/article-title?param=1 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidUrl.test.ts > yields false for %p mailto:test@hel.fi 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidUrl.test.ts > yields false for %p https:|/malformed.fi 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > addError action > adds errors to the list of errors when the errors is not there yet (0) 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > addError action > adds errors to the list of errors when the errors is not there yet (1) 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > removeError action > removes the error from the list of errors (0) 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > removeError action > removes the error from the list of errors (1) 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > removeError action > removes the error from the list of errors (2) 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > clearErrors action > removes all the existing errors (0) 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > clearErrors action > removes all the existing errors (1) 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/apolloErrorNotification/__tests__/apolloErrorsReducer.test.tsx > apolloErrorsReducer > clearErrors action > removes all the existing errors (2) 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/time/__tests__/humanizeOpeningHoursForWeek.test.js > humanizeOpeningHoursForWeek > should return the condensed format when the weekdays have matching opening hours 30ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/time/__tests__/humanizeOpeningHoursForWeek.test.js > humanizeOpeningHoursForWeek > should return all dates on separate lines when some weekday does not match 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/time/__tests__/humanizeOpeningHoursForWeek.test.js > humanizeOpeningHoursForWeek > should work with various special cases 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/time/__tests__/humanizeOpeningHoursForWeek.test.js > humanizeOpeningHoursForWeek > should not return information for dates that don't have any opening times 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/time/__tests__/humanizeOpeningHoursForWeek.test.js > humanizeOpeningHoursForWeek > should work with Swedish 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/time/__tests__/humanizeOpeningHoursForWeek.test.js > humanizeOpeningHoursForWeek > should work with Finnish 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/time/__tests__/format.test.js > format > formatIntoDateTime > returns correctly formatted date 15ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > returns null when times can not be found 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > renders correct result when venue is closed 15ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > renders correct result when venue is open 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > renders resource state 8ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > ignores closed times 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/layout/__tests__/Container.test.tsx > matches snapshot 66ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns true >  2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns true >   1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns true > test 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns true > 匹 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns true > null 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > {} 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > undefined 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > NaN 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > 0 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > 1 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > 123 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > 123.5 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > { '1': undefined } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > { key: 'value' } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > { key: 'value', anotherKey: 'another value' } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > { a: { '2': { '3': [ 4, 5, 6 ] }, b: 1 } } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > %s 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > non-empty array 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > 1 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > Set{} 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > Set{ 1, 2, 3 } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > Map{} 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > Map{ 'key' => 'value' } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > Symbol(symbol) 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isStringOrNull.test.tsx > isStringOrNull returns false > 123n 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns true > {} 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns true > { '1': undefined } 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns true > { key: 'value' } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns true > { key: 'value', anotherKey: 'another value' } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns true > { a: { '2': { '3': [ 4, 5, 6 ] }, b: 1 } } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > null 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > undefined 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > NaN 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > 0 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false >  0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false >   0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > test 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > 1 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > 123 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > 123.5 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > %s 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > non-empty array 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > 1 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > Set{} 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > Set{ 1, 2, 3 } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > Map{} 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > Map{ 'key' => 'value' } 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > Symbol(symbol) 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/edge-runtime-compatible/middlewares/shortUrls/dynamicUrls/__tests__/isObject.test.tsx > isObject returns false > 123n 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getEnvOrError.test.ts > getEnvOrError > should return the value when the environment variable is set 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getEnvOrError.test.ts > getEnvOrError > should throw an error when the environment variable 'is not defined' 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getEnvOrError.test.ts > getEnvOrError > should throw an error when the environment variable 'is an empty string' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/arrayUtils.test.ts > appendUnique > appends a list with the objects that does not exist there yet and has the compared property - 0 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/arrayUtils.test.ts > appendUnique > appends a list with the objects that does not exist there yet and has the compared property - 1 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/arrayUtils.test.ts > appendUnique > appends a list with the objects that does not exist there yet and has the compared property - 2 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getUrlParamAsArray.test.ts > getUrlParamAsArray function > should return url param as an array 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDomain.test.ts > getDomain > should return "'http://example.com'" for location "{ protocol: 'http:', …(2) }" 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDomain.test.ts > getDomain > should return "'https://sub.example.com:8080'" for location "{ protocol: 'https:', …(2) }" 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDomain.test.ts > getDomain > should return "'http://localhost:3000'" for location "{ protocol: 'http:', …(2) }" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDomain.test.ts > getDomain > should return "'https://hel.fi'" for location "{ protocol: 'https:', …(2) }" 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidDate.test.ts > getIsValidDate > returns true for valid dates 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getIsValidDate.test.ts > getIsValidDate > returns false for invalid dates 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/season/__tests__/getCurrentSeason.test.js > Should return summer when it is the first day of summer season 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/season/__tests__/getCurrentSeason.test.js > Should return summer when it is the last day of summer season 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/season/__tests__/getCurrentSeason.test.js > Should return winter when it is the first day of winter season 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/season/__tests__/getCurrentSeason.test.js > Should return winter when it is the last day of winter season 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/translateUtils.test.ts > Translation utils > Translate value 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/translateUtils.test.ts > Translation utils > Translates lists 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/components/domain/event/eventLocation/__tests__/EventLocationText.test.tsx > should render event location text 27ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/dateUtils.test.ts > formatDate function > format date value 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/dateUtils.test.ts > convertFinnishDateStrToDate function > covert string to date 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/EventsFederationApolloClient.test.ts > EventsFederationApolloClient > should use custom headers if provided 7ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/EventsFederationApolloClient.test.ts > EventsFederationApolloClient > should allow unauthorized requests if configured 8ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/apollo/__tests__/EventsFederationApolloClient.test.ts > EventsFederationApolloClient > should call handleError on GraphQL error 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/formatToSingleTag.test.ts > formatToSingleTag > should format html string to a single tag string with predefined wrapping tag 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/capitalize.test.ts > capitalize > should capitalize the first letter 3ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/formatDateTimeIntoLocaleString.test.ts > formatDateTimeIntoLocaleString > should format 2023-10-27T07:00:00.000Z correctly to '27.10.2023 10:00' 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/formatDateTimeIntoLocaleString.test.ts > formatDateTimeIntoLocaleString > should format 2023-01-05T06:05:00.000Z correctly to '5.1.2023 08:05' 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/formatDateTimeIntoLocaleString.test.ts > formatDateTimeIntoLocaleString > should format 2024-12-31T21:59:00.000Z correctly to '31.12.2024 23:59' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/formatDateTimeIntoLocaleString.test.ts > formatDateTimeIntoLocaleString > should format 2024-12-31T22:00:00.000Z correctly to '1.1.2025 00:00' 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getLocalizedString.test.ts > getLocalizedString function > should return localised string 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getLocalizedString.test.ts > getLocalizedString function > should return string in first prioritized language when localised string is not found 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/geolocation/__tests__/GeolocationService.test.ts > GeolocationService > should resolve with position on successful geolocation fetch 4ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/geolocation/__tests__/GeolocationService.test.ts > GeolocationService > should reject with an error on failed geolocation fetch 5ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/geolocation/__tests__/GeolocationService.test.ts > GeolocationService > should reject if geolocation is not available on navigator 1ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getLanguageCodeFilter.test.ts > getLanguageCodeFilter function > should map En/Fi/Sv to same language 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getLanguageCode.test.ts > getLanguageCode function > should map En/Fi/Sv to same language 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateArray.test.ts > getDateArray > should convert date string '2023-10-27T10:30:00.000Z' to DateArray [ 2023, 10, 27, 10, 30 ] in UTC 2ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateArray.test.ts > getDateArray > should convert date string '2024-01-01T00:00:00.000Z' to DateArray [ 2024, 1, 1, +0, +0 ] in UTC 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateArray.test.ts > getDateArray > should convert date string '2022-12-31T23:59:00.000Z' to DateArray [ 2022, 12, 31, 23, 59 ] in UTC 0ms
➤ YN0000: [@events-helsinki/components]:  ✓ src/utils/__tests__/getDateArray.test.ts > getDateArray > should convert date string '2023-02-28T05:01:00.000Z' to DateArray [ 2023, 2, 28, 5, 1 ] in UTC 0ms
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/" when current location is "/"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi" when current location is "/"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi" when current location is "/fi"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/sv" when current location is "/sv"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/en" when current location is "/en"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/search" when current location is "/fi/search"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/search" when current location is "/fi/haku"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/search" when current location is "/haku"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/search" when current location is "/haku"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/sv/search" when current location is "/sv/search"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/sv/search" when current location is "/sv/sok"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/en/search" when current location is "/en/search"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/search" when current location is "/search"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/search" when current location is "/haku"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/search" when current location is "/search"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/search" when current location is "/haku"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/search" when current location is "/search?searchType=Venue"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/articles" when current location is "/fi/artikkelit"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/fi/articles" when current location is "/fi/articles"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/sv/articles" when current location is "/sv/articles"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/sv/articles" when current location is "/sv/artiklar"
➤ YN0000: [@events-helsinki/components]:  ↓ src/components/navigation/__tests__/useGetIsItemActive.test.tsx > useGetIsItemActive hook for Navigation-component > getIsItemActive function > returns true for menu item with URL "/en/articles" when current location is "/en/articles"
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]:  Test Files  92 passed | 1 skipped (93)
➤ YN0000: [@events-helsinki/components]:       Tests  493 passed | 22 skipped (515)
➤ YN0000: [@events-helsinki/components]:    Start at  13:23:21
➤ YN0000: [@events-helsinki/components]:    Duration  70.50s (transform 6.10s, setup 91.77s, collect 633.20s, tests 68.88s, environment 148.48s, prepare 26.16s)
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]: SonarQube report written to events-helsinki-monorepo\packages\components\sonar-report.xml
➤ YN0000: [@events-helsinki/components]: JSON report written to events-helsinki-monorepo/packages/components/sonar-report.json
➤ YN0000: [@events-helsinki/components]: stderr | src/components/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx > events > should render other event times
➤ YN0000: [@events-helsinki/components]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:102:16)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [@events-helsinki/components]:     at li
➤ YN0000: [@events-helsinki/components]:     at ul
➤ YN0000: [@events-helsinki/components]:     at EventList (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\eventList\EventList.tsx:22:22)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at InfoWithIcon (events-helsinki-monorepo\packages\components\src\components\infoWithIcon\InfoWithIcon.tsx:6:25)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at OtherEventTimes (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\OtherEventTimes.tsx:25:28)
➤ YN0000: [@events-helsinki/components]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [@events-helsinki/components]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [@events-helsinki/components]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:69:53)
➤ YN0000: [@events-helsinki/components]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [@events-helsinki/components]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [@events-helsinki/components]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [@events-helsinki/components]:     at I18nextTestStubProvider (events-helsinki-monorepo\packages\components\config\tests\I18nextTestStubProvider.tsx:9:3)
➤ YN0000: [@events-helsinki/components]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [@events-helsinki/components]:     at TestProviders (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:42:26)
➤ YN0000: [@events-helsinki/components]:     at wrapper (events-helsinki-monorepo\packages\components\config\tests\test-utils.tsx:40:17)
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]: stderr | src/components/domain/event/eventInfo/__tests__/EventInfo.test.tsx > should render event info fields
➤ YN0000: [@events-helsinki/components]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:102:16)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [@events-helsinki/components]:     at li
➤ YN0000: [@events-helsinki/components]:     at ul
➤ YN0000: [@events-helsinki/components]:     at EventList (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\eventList\EventList.tsx:22:22)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at InfoWithIcon (events-helsinki-monorepo\packages\components\src\components\infoWithIcon\InfoWithIcon.tsx:6:25)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at SubEvents (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventsHierarchy.tsx:28:22)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at EventInfo (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventInfo.tsx:48:22)
➤ YN0000: [@events-helsinki/components]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [@events-helsinki/components]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [@events-helsinki/components]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:69:53)
➤ YN0000: [@events-helsinki/components]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [@events-helsinki/components]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [@events-helsinki/components]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [@events-helsinki/components]:     at I18nextTestStubProvider (events-helsinki-monorepo\packages\components\config\tests\I18nextTestStubProvider.tsx:9:3)
➤ YN0000: [@events-helsinki/components]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [@events-helsinki/components]:     at TestProviders (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:42:26)
➤ YN0000: [@events-helsinki/components]:     at wrapper (events-helsinki-monorepo\packages\components\config\tests\test-utils.tsx:40:17)
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]: stderr | src/components/eventCard/__tests__/EventCard.test.tsx > event card > should go to event page by clicking event card
➤ YN0000: [@events-helsinki/components]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:102:16)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at LinkBox (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:19010:23)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at EventCard (events-helsinki-monorepo\packages\components\src\components\eventCard\EventCard.tsx:32:22)
➤ YN0000: [@events-helsinki/components]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [@events-helsinki/components]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [@events-helsinki/components]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:69:53)
➤ YN0000: [@events-helsinki/components]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [@events-helsinki/components]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [@events-helsinki/components]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [@events-helsinki/components]:     at I18nextTestStubProvider (events-helsinki-monorepo\packages\components\config\tests\I18nextTestStubProvider.tsx:9:3)
➤ YN0000: [@events-helsinki/components]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [@events-helsinki/components]:     at TestProviders (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:42:26)
➤ YN0000: [@events-helsinki/components]:     at wrapper (events-helsinki-monorepo\packages\components\config\tests\test-utils.tsx:40:17)
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]: stderr | src/components/eventCard/__tests__/LargeEventCard.test.tsx > large event card > should go to event page by clicking event card
➤ YN0000: [@events-helsinki/components]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:102:16)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at LinkBox (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:19010:23)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at LargeEventCard (events-helsinki-monorepo\packages\components\src\components\eventCard\LargeEventCard.tsx:35:3)
➤ YN0000: [@events-helsinki/components]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [@events-helsinki/components]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [@events-helsinki/components]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:69:53)
➤ YN0000: [@events-helsinki/components]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [@events-helsinki/components]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [@events-helsinki/components]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [@events-helsinki/components]:     at I18nextTestStubProvider (events-helsinki-monorepo\packages\components\config\tests\I18nextTestStubProvider.tsx:9:3)
➤ YN0000: [@events-helsinki/components]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [@events-helsinki/components]:     at TestProviders (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:42:26)
➤ YN0000: [@events-helsinki/components]:     at wrapper (events-helsinki-monorepo\packages\components\config\tests\test-utils.tsx:40:17)
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]: stderr | src/components/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx > similar events > should render similar event cards
➤ YN0000: [@events-helsinki/components]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:102:16)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at LinkBox (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:19010:23)
➤ YN0000: [@events-helsinki/components]:     at Card (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21055:17)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at li
➤ YN0000: [@events-helsinki/components]:     at CarouselSliderPage (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20788:22)
➤ YN0000: [@events-helsinki/components]:     at ul
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at CarouselSlider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20840:23)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at CarouselWithContext (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20989:20)
➤ YN0000: [@events-helsinki/components]:     at CarouselContextProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20721:23)
➤ YN0000: [@events-helsinki/components]:     at Carousel (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21033:21)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at CollectionCarousel (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21490:21)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at Collection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21511:21)
➤ YN0000: [@events-helsinki/components]:     at LoadingSpinner (events-helsinki-monorepo\packages\components\src\components\spinner\LoadingSpinner.tsx:18:3)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [@events-helsinki/components]:     at SimilarEvents (events-helsinki-monorepo\packages\components\src\components\domain\event\similarEvents\SimilarEvents.tsx:25:3)
➤ YN0000: [@events-helsinki/components]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [@events-helsinki/components]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [@events-helsinki/components]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:69:53)
➤ YN0000: [@events-helsinki/components]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [@events-helsinki/components]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [@events-helsinki/components]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [@events-helsinki/components]:     at I18nextTestStubProvider (events-helsinki-monorepo\packages\components\config\tests\I18nextTestStubProvider.tsx:9:3)
➤ YN0000: [@events-helsinki/components]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [@events-helsinki/components]:     at TestProviders (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:42:26)
➤ YN0000: [@events-helsinki/components]:     at wrapper (events-helsinki-monorepo\packages\components\config\tests\test-utils.tsx:40:17)
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]: stderr | src/components/domain/event/eventContent/__tests__/EventContent.test.tsx > should render event content fields
➤ YN0000: [@events-helsinki/components]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [@events-helsinki/components]:     at a
➤ YN0000: [@events-helsinki/components]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:102:16)
➤ YN0000: [@events-helsinki/components]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [@events-helsinki/components]:     at li
➤ YN0000: [@events-helsinki/components]:     at ul
➤ YN0000: [@events-helsinki/components]:     at EventList (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\eventList\EventList.tsx:22:22)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at InfoWithIcon (events-helsinki-monorepo\packages\components\src\components\infoWithIcon\InfoWithIcon.tsx:6:25)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at SubEvents (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventsHierarchy.tsx:28:22)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at EventInfo (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventInfo.tsx:48:22)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [@events-helsinki/components]:     at div
➤ YN0000: [@events-helsinki/components]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [@events-helsinki/components]:     at EventContent (events-helsinki-monorepo\packages\components\src\components\domain\event\eventContent\EventContent.tsx:25:3)
➤ YN0000: [@events-helsinki/components]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [@events-helsinki/components]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [@events-helsinki/components]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:69:53)
➤ YN0000: [@events-helsinki/components]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [@events-helsinki/components]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [@events-helsinki/components]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [@events-helsinki/components]:     at I18nextTestStubProvider (events-helsinki-monorepo\packages\components\config\tests\I18nextTestStubProvider.tsx:9:3)
➤ YN0000: [@events-helsinki/components]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [@events-helsinki/components]:     at TestProviders (events-helsinki-monorepo\packages\components\config\tests\app-test-providers.tsx:42:26)
➤ YN0000: [@events-helsinki/components]:     at wrapper (events-helsinki-monorepo\packages\components\config\tests\test-utils.tsx:40:17)
➤ YN0000: [@events-helsinki/components]:
➤ YN0000: [@events-helsinki/components]: Process exited (exit code 0), completed in 1m 13s
➤ YN0000: [events-helsinki]: Process started
➤ YN0000: [hobbies-helsinki]: Process started
➤ YN0000: [sports-helsinki]: Process started
➤ YN0000: [events-graphql-proxy]: Process started
➤ YN0000: [venue-graphql-proxy]: Process started
➤ YN0000: [venue-graphql-proxy]:
➤ YN0000: [venue-graphql-proxy]:  RUN  v3.2.4 events-helsinki-monorepo/proxies/venue-graphql-proxy
➤ YN0000: [venue-graphql-proxy]:
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > pickLocaleWithFallback > uses "sv" as first fallback locale to fetch the details when the default locale "en" is not available in object { sv: 'text på svenska' } 3ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > pickLocaleWithFallback > uses "fi" as first fallback locale to fetch the details when the default locale "en" is not available in object { fi: 'tekstiä suomeksi', sv: 'text på svenska' } 1ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > pickLocaleWithFallback > uses "en" as first fallback locale to fetch the details when the default locale "sv" is not available in object { fi: 'tekstiä suomeksi', en: 'text in English' } 0ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > pickLocaleWithFallback > uses "fi" as first fallback locale to fetch the details when the default locale "sv" is not available in object { fi: 'tekstiä suomeksi' } 0ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > translateUnenrichedVenue > returns the details in given language fi 1ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > translateUnenrichedVenue > returns the details in given language en 0ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > translateUnenrichedVenue > returns the details in given language sv 0ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > translateUnenrichedVenue > uses a fallback language when the requested details are not available in given language fi 1ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > translateUnenrichedVenue > uses a fallback language when the requested details are not available in given language en 1ms
➤ YN0000: [venue-graphql-proxy]:  ✓ src/utils/__tests__/utils.test.ts > translateUnenrichedVenue > uses a fallback language when the requested details are not available in given language sv 0ms
➤ YN0000: [venue-graphql-proxy]:
➤ YN0000: [venue-graphql-proxy]:  Test Files  1 passed (1)
➤ YN0000: [venue-graphql-proxy]:       Tests  10 passed (10)
➤ YN0000: [venue-graphql-proxy]:    Start at  13:24:34
➤ YN0000: [venue-graphql-proxy]:    Duration  6.79s (transform 263ms, setup 112ms, collect 453ms, tests 10ms, environment 4.29s, prepare 1.18s)
➤ YN0000: [venue-graphql-proxy]:
➤ YN0000: [venue-graphql-proxy]: SonarQube report written to events-helsinki-monorepo\proxies\venue-graphql-proxy\sonar-report.xml
➤ YN0000: [venue-graphql-proxy]: JSON report written to events-helsinki-monorepo/proxies/venue-graphql-proxy/sonar-report.json
➤ YN0000: [venue-graphql-proxy]: Process exited (exit code 0), completed in 12s 99ms
➤ YN0000: [events-graphql-proxy]:
➤ YN0000: [events-graphql-proxy]:  RUN  v3.2.4 events-helsinki-monorepo/proxies/events-graphql-proxy
➤ YN0000: [events-graphql-proxy]:
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > resolves eventList correctly 412ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > resolves eventDetails correctly 7ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > resolves eventsByIds correctly 70ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > handles error correctly in eventsByIds 90ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > sends REST requests correctly > sends General event type by default 88ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > sends REST requests correctly > sends Course event type with event type param 21ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > sends REST requests correctly > sends all params in query string correctly 9ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/eventIntegration.test.ts > sends REST request correctly with query params (course) 41ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/keywordIntegration.test.ts > sends REST request correctly with params 432ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/keywordIntegration.test.ts > resolves keywordList correctly 13ms
➤ YN0000: [events-graphql-proxy]:  ✓ src/__tests__/keywordIntegration.test.ts > uses correct path when source is provided 11ms
➤ YN0000: [events-graphql-proxy]:
➤ YN0000: [events-graphql-proxy]:  Test Files  2 passed (2)
➤ YN0000: [events-graphql-proxy]:       Tests  11 passed (11)
➤ YN0000: [events-graphql-proxy]:    Start at  13:24:34
➤ YN0000: [events-graphql-proxy]:    Duration  18.53s (transform 3.28s, setup 94ms, collect 19.61s, tests 1.20s, environment 9.61s, prepare 2.35s)
➤ YN0000: [events-graphql-proxy]:
➤ YN0000: [events-graphql-proxy]: SonarQube report written to events-helsinki-monorepo\proxies\events-graphql-proxy\sonar-report.xml
➤ YN0000: [events-graphql-proxy]: JSON report written to events-helsinki-monorepo/proxies/events-graphql-proxy/sonar-report.json
➤ YN0000: [events-graphql-proxy]: Process exited (exit code 0), completed in 23s 137ms
➤ YN0000: [hobbies-helsinki]:
➤ YN0000: [hobbies-helsinki]:  RUN  v3.2.4 events-helsinki-monorepo/apps/hobbies-helsinki
➤ YN0000: [hobbies-helsinki]:
➤ YN0000: [hobbies-helsinki]:  ✓ src/__tests__/criticalHdsRules.test.tsx > Critical HDS rules file generation > critical-hds-styles are up to date 808ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'http://localhost:8080' 6ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.example.org/' 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.example.org' 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.b.c:8080/1/2/3?a=1&b=2' 2ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides required config 'origin' 2ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'debug' 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'allowUnauthorizedRequests' 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'showSimilarEvents' 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides number config 'defaultRevalidate' 7ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides configuration for Matomo 21ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > gives access to misc configs 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getSearchQuery function > get search query 6ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return start=now if start time is in past/today 4ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct start and end time 6ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getNextPage function > should return next page 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getNextPage function > should return null 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('') == undefined 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(null) == undefined 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(undefined) == undefined 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput([]) == undefined 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput({}) == undefined 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(1) == 1 1ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(9) == 9 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(12) == 12 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(99) == 99 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(115) == 115 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('1') == 1 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('9') == 9 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('12') == 12 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('99') == 99 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('115') == 115 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('00012') == 12 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('+12') == 12 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(-1) == +0 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('-1') == +0 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('-0001') == +0 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(131) == 130 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('131') == 130 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('000131') == 130 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput('+131') == 130 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput(12.5) == undefined 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput([ 1, 9, 12, 99, 115 ]) == undefined 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > clampAgeInput function > clampAgeInput({ age: 12 }) == undefined 0ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 0 Valitsemillasi hakuehdoilla ei löytynyt yhtään harrastusta. results are found 110ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 1 Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia. results are found 18ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 4 Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia. results are found 12ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should not return any results info if more than 5 or more results are found 10ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > events with 0 results matches snapshot for no results 140ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders no events found text 19ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders few events found text when event count is 1 9ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders few events found text when event count is 4 11ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/common-events/components/category/__tests__/CategoryFilter.test.tsx > matches snapshot 362ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/common-events/components/category/__tests__/CategoryFilter.test.tsx > calls onClick callback when category filter button is clicked 1584ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/HobbiesApolloProvider.test.tsx > HobbiesApolloProvider > ApolloErrorNotification > does not render when there are no errors 114ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx > calls onClear callback when clear button is clicked 2184ms
➤ YN0000: [hobbies-helsinki]:  ↓ src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx > routes to correct url after deleting filters
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/app/__tests__/HobbiesApolloProvider.test.tsx > HobbiesApolloProvider > ApolloErrorNotification > renders ApolloErrorNotification on Apollo-Client errors 2117ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking submit button 2689ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page with correct search query after clicking submit button 1162ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page with correct search query after pressing enter to submit form 537ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should render info and load other events + similar events 5187ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should show error info when event is closed 190ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking category 596ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should show error info when event doesn't exist 103ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > for accessibility violations 2924ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should clear all filters and search field 639ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > shows similar events when SIMILAR_EVENTS flag is on 1404ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after selecting today date type and pressing submit button 1367ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after checking is free checkbox and submitting form 820ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > doesnt show similar events when SIMILAR_EVENTS flag is off 997ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > hides similar events when event has no keywords 930ms
➤ YN0000: [hobbies-helsinki]:  ↓ src/domain/event/__tests__/EventPageContainer.test.tsx > should link to events search when clicking tags
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after selecting today date type and pressing submit button 1618ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after selecting start date and pressing submit button 2592ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after selecting start date and pressing submit button 3708ms
➤ YN0000: [hobbies-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after clicking category menu item 2740ms
➤ YN0000: [hobbies-helsinki]:
➤ YN0000: [hobbies-helsinki]:  Test Files  11 passed (11)
➤ YN0000: [hobbies-helsinki]:       Tests  75 passed | 1 skipped | 1 todo (77)
➤ YN0000: [hobbies-helsinki]:    Start at  13:24:34
➤ YN0000: [hobbies-helsinki]:    Duration  62.53s (transform 20.55s, setup 24.38s, collect 375.96s, tests 37.81s, environment 51.08s, prepare 11.55s)
➤ YN0000: [hobbies-helsinki]:
➤ YN0000: [hobbies-helsinki]: SonarQube report written to events-helsinki-monorepo\apps\hobbies-helsinki\sonar-report.xml
➤ YN0000: [hobbies-helsinki]: JSON report written to events-helsinki-monorepo/apps/hobbies-helsinki/sonar-report.json
➤ YN0000: [hobbies-helsinki]: stderr | src/common-events/components/category/__tests__/CategoryFilter.test.tsx > matches snapshot
➤ YN0000: [hobbies-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [hobbies-helsinki]:     at a
➤ YN0000: [hobbies-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [hobbies-helsinki]:     at a
➤ YN0000: [hobbies-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [hobbies-helsinki]:     at Link (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:152:16)
➤ YN0000: [hobbies-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at CategoryFilter (events-helsinki-monorepo\apps\hobbies-helsinki\src\common-events\components\category\CategoryFilter.tsx:13:3)
➤ YN0000: [hobbies-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [hobbies-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [hobbies-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [hobbies-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [hobbies-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [hobbies-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [hobbies-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [hobbies-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [hobbies-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [hobbies-helsinki]:     at wrapper (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [hobbies-helsinki]:
➤ YN0000: [hobbies-helsinki]: stderr | src/domain/event/__tests__/EventPageContainer.test.tsx > should render info and load other events + similar events
➤ YN0000: [hobbies-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [hobbies-helsinki]:     at a
➤ YN0000: [hobbies-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [hobbies-helsinki]:     at a
➤ YN0000: [hobbies-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [hobbies-helsinki]:     at Link (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:152:16)
➤ YN0000: [hobbies-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [hobbies-helsinki]:     at li
➤ YN0000: [hobbies-helsinki]:     at ul
➤ YN0000: [hobbies-helsinki]:     at EventList (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\eventList\EventList.tsx:22:22)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at InfoWithIcon (events-helsinki-monorepo\packages\components\src\components\infoWithIcon\InfoWithIcon.tsx:6:25)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at SubEvents (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventsHierarchy.tsx:28:22)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at EventInfo (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventInfo.tsx:48:22)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [hobbies-helsinki]:     at EventContent (events-helsinki-monorepo\packages\components\src\components\domain\event\eventContent\EventContent.tsx:25:3)
➤ YN0000: [hobbies-helsinki]:     at LoadableComponent (events-helsinki-monorepo\node_modules\next\dist\shared\lib\loadable.shared-runtime.js:111:9)
➤ YN0000: [hobbies-helsinki]:     at LoadingSpinner (events-helsinki-monorepo\packages\components\src\components\spinner\LoadingSpinner.tsx:18:3)
➤ YN0000: [hobbies-helsinki]:     at main
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at EventPageContainer (events-helsinki-monorepo\apps\hobbies-helsinki\src\domain\event\EventPageContainer.tsx:41:3)
➤ YN0000: [hobbies-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [hobbies-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [hobbies-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [hobbies-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [hobbies-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [hobbies-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [hobbies-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [hobbies-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [hobbies-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [hobbies-helsinki]:     at wrapper (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [hobbies-helsinki]:
➤ YN0000: [hobbies-helsinki]: stderr | src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking submit button
➤ YN0000: [hobbies-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [hobbies-helsinki]:     at a
➤ YN0000: [hobbies-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [hobbies-helsinki]:     at a
➤ YN0000: [hobbies-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [hobbies-helsinki]:     at Link (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:152:16)
➤ YN0000: [hobbies-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [hobbies-helsinki]:     at SecondaryLink (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:122:24)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at form
➤ YN0000: [hobbies-helsinki]:     at LandingPageSearchForm (events-helsinki-monorepo\apps\hobbies-helsinki\src\domain\search\landingPageSearch\LandingPageSearchForm.tsx:19:3)
➤ YN0000: [hobbies-helsinki]:     at div
➤ YN0000: [hobbies-helsinki]:     at Search (events-helsinki-monorepo\apps\hobbies-helsinki\src\domain\search\landingPageSearch\LandingPageSearch.tsx:27:67)
➤ YN0000: [hobbies-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [hobbies-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [hobbies-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [hobbies-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [hobbies-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [hobbies-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [hobbies-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [hobbies-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [hobbies-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [hobbies-helsinki]:     at wrapper (events-helsinki-monorepo\apps\hobbies-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [hobbies-helsinki]:
➤ YN0000: [hobbies-helsinki]: Process exited (exit code 0), completed in 1m 5s
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]:  RUN  v3.2.4 events-helsinki-monorepo/apps/sports-helsinki
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]:  ✓ src/__tests__/criticalHdsRules.test.tsx > Critical HDS rules file generation > critical-hds-styles are up to date 591ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders no events found text 137ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders no events found text 13ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders no events found text 25ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 0 Valitsemillasi hakuehdoilla ei löytynyt yhtään paikkaa. results are found 166ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 1 Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia. results are found 19ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 4 Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia. results are found 17ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should not return any results info if more than 5 or more results are found 19ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > events with 0 results matches snapshot for no results 49ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders few events found text when event count is 1 9ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders few events found text when event count is 4 22ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueCard/__tests__/LargeVenueCard.test.tsx > large venue card > should go to venue page by clicking venue card 1566ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/hooks/__tests__/useCombinedSearchController.test.tsx > updateRouteToSearchPage > pushes the user to a desired url 112ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/hooks/__tests__/useCombinedSearchController.test.tsx > updateRouteToSearchPage > pushes the user to a desired url 35ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/hooks/__tests__/useCombinedSearchController.test.tsx > updateRouteToSearchPage > pushes the user to a desired url 11ms
➤ YN0000: [sports-helsinki]:  ✓ src/common-events/components/category/__tests__/CategoryFilter.test.tsx > matches snapshot 189ms
➤ YN0000: [sports-helsinki]:  ✓ src/common-events/components/category/__tests__/CategoryFilter.test.tsx > calls onClick callback when category filter button is clicked 1370ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/SportsApolloProvider.test.tsx > SportsApolloProvider > ApolloErrorNotification > does not render when there are no errors 129ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchProvider.test.tsx > CombinedSearchProvider > reads the context properly 128ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchProvider.test.tsx > CombinedSearchProvider > reads the context properly 38ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchProvider.test.tsx > CombinedSearchProvider > reads the context properly 33ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx > upcoming events of a venue > should render upcoming event cards 2192ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx > upcoming events of a venue > should hide the whole page section when there are no cards 90ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx > calls onClear callback when clear button is clicked 1636ms
➤ YN0000: [sports-helsinki]:  ↓ src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx > routes to correct url after deleting filters
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/SportsApolloProvider.test.tsx > SportsApolloProvider > ApolloErrorNotification > renders ApolloErrorNotification on Apollo-Client errors 1828ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueHero/__tests__/VenueHero.test.tsx > should render venue name, description and location 1961ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueHero/__tests__/VenueHero.test.tsx > should go to venue list 694ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueHero/__tests__/VenueHero.test.tsx > should render ontologywords 60ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking submit button 2181ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/similarVenues/__tests__/SimilarVenuesSection.test.tsx > similar venues > should render similar venues cards 2012ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/similarVenues/__tests__/SimilarVenuesSection.test.tsx > similar venues > should hide the whole page section when there are no cards 67ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page with correct search query after clicking submit button 751ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueContent/__tests__/VenueContent.test.tsx > should render event content fields 2954ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > should render Venue tab inside the search tabs when the tabs context is empty 2112ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > should render Course tab inside the search tabs when the tabs context is empty 389ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page with correct search query after pressing enter to submit form 440ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking category 572ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > should render General tab inside the search tabs when the tabs context is empty 341ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > should show the search result count as part of the Venue tab label 325ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > should show the search result count as part of the Course tab label 292ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > should show the search result count as part of the General tab label 251ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > clicking the Venue tab should set the active tab id 564ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should render info and load other events + similar events 5651ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should show error info when event is closed 184ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > clicking the Course tab should set the active tab id 457ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx > SearchTabs search utilities > clicking the General tab should set the active tab id 391ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should show error info when event doesn't exist 126ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > shows similar events when SIMILAR_EVENTS flag is on 1312ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > hides similar events when SIMILAR_EVENTS flag is off 882ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > hides similar events when event has no keywords 623ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueHighlights/__tests__/venueHighlights.test.tsx > venueHighlightKey({ name: '', sectionType: 'HIGHLIGHT' }) == 'venue-highlight-e3b0c44298fc1c149afbf…' 4ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueHighlights/__tests__/venueHighlights.test.tsx > venueHighlightKey({ name: 'Test venue name', …(1) }) == 'venue-highlight-e4bad7384d70322d1622c…' 0ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueHighlights/__tests__/venueHighlights.test.tsx > venueHighlightKey({ name: 'Ääkköspaikanimi', …(1) }) == 'venue-highlight-ee0f86913a89f0e6c8e55…' 0ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > clean > field specific clean functions are found in CombinedSearchFormAdapter 14ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > clean > field specific clean functions should have unique names 5ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > clean > field specific clean functions take no parameters 7ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > clean > field specific clean functions return nothing 4ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > clean > clean function calls all field specific clean functions 7ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > clean > CombinedSearchFormAdapter constructor calls clean function 3ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > getURLQuery > collects the form values from the URL but does not exclude the extra params 5ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > getFormValues > returns only the form values without any possible extra params given in a URL 7ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > getSearchVariables > includes the transformed venue query variables 4ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts > CombinedSearchFormAdapter > getSearchVariables > includes the transformed event query variables 3ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'http://localhost:8080' 4ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.example.org/' 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.example.org' 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.b.c:8080/1/2/3?a=1&b=2' 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides required config 'origin' 2ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'debug' 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'allowUnauthorizedRequests' 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'showSimilarEvents' 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides number config 'defaultRevalidate' 6ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides configuration for Matomo 17ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > returns null when times can not be found 8ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > renders correct result when venue is closed 19ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > renders correct result when venue is open 2ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > renders resource state 2ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/utils/__tests__/getVenueOpeningTimeDescription.test.ts > ignores closed times 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/VenueSearchAdapter.test.ts > VenueSearchAdapter > getQueryVariables > converts the form values input to a desired search variables as an output 15ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getSearchQuery function > get search query 6ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return start=now if start time is in past/today 5ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct start and end time 6ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getNextPage function > should return next page 1ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getNextPage function > should return null 1ms
➤ YN0000: [sports-helsinki]:  ↓ src/domain/venue/venueKeywords/__tests__/VenueKeywords.test.tsx > should render keywords and handle click
➤ YN0000: [sports-helsinki]:  ✓ src/domain/venue/venueKeywords/__tests__/VenueKeywords.test.tsx > should not show keywords 38ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/constants.test.ts > eventSearch constants > mappings of target groups to keywords > ADAPTED_GROUPS keyword list should not contain duplicates 3ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/constants.test.ts > eventSearch constants > mappings of target groups to keywords > ADULTS keyword list should not contain duplicates 0ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/constants.test.ts > eventSearch constants > mappings of target groups to keywords > CHILDREN_AND_FAMILIES keyword list should not contain duplicates 0ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/constants.test.ts > eventSearch constants > mappings of target groups to keywords > PARTNERS keyword list should not contain duplicates 0ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/constants.test.ts > eventSearch constants > mappings of target groups to keywords > SENIORS keyword list should not contain duplicates 0ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/constants.test.ts > eventSearch constants > mappings of target groups to keywords > YOUTH keyword list should not contain duplicates 0ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts > EventSearchAdapter > getQueryVariables > converts the form values input to General search variables as an output 4ms
➤ YN0000: [sports-helsinki]:  ✓ src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts > EventSearchAdapter > getQueryVariables > converts the form values input to Course search variables as an output 1ms
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]:  Test Files  25 passed (25)
➤ YN0000: [sports-helsinki]:       Tests  93 passed | 1 skipped | 1 todo (95)
➤ YN0000: [sports-helsinki]:    Start at  13:24:34
➤ YN0000: [sports-helsinki]:    Duration  63.90s (transform 25.65s, setup 61.73s, collect 635.47s, tests 36.31s, environment 92.38s, prepare 24.05s)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: SonarQube report written to events-helsinki-monorepo\apps\sports-helsinki\sonar-report.xml
➤ YN0000: [sports-helsinki]: JSON report written to events-helsinki-monorepo/apps/sports-helsinki/sonar-report.json
➤ YN0000: [sports-helsinki]: stderr | src/common-events/components/category/__tests__/CategoryFilter.test.tsx > matches snapshot
➤ YN0000: [sports-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:154:16)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at CategoryFilter (events-helsinki-monorepo\apps\sports-helsinki\src\common-events\components\category\CategoryFilter.tsx:13:3)
➤ YN0000: [sports-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [sports-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [sports-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [sports-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [sports-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [sports-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [sports-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [sports-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [sports-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [sports-helsinki]:     at wrapper (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: stderr | src/domain/venue/venueCard/__tests__/LargeVenueCard.test.tsx > large venue card > should go to venue page by clicking venue card
➤ YN0000: [sports-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:154:16)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at LinkBox (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:19010:23)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at LargeVenueCard (events-helsinki-monorepo\apps\sports-helsinki\src\domain\venue\venueCard\LargeVenueCard.tsx:19:3)
➤ YN0000: [sports-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [sports-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [sports-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [sports-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [sports-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [sports-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [sports-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [sports-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [sports-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [sports-helsinki]:     at wrapper (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: stderr | src/domain/venue/upcomingEvents/__tests__/upcomingEventsSection.test.tsx > upcoming events of a venue > should render upcoming event cards
➤ YN0000: [sports-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:154:16)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at LinkBox (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:19010:23)
➤ YN0000: [sports-helsinki]:     at Card (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21055:17)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at li
➤ YN0000: [sports-helsinki]:     at CarouselSliderPage (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20788:22)
➤ YN0000: [sports-helsinki]:     at ul
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at CarouselSlider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20840:23)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at CarouselWithContext (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20989:20)
➤ YN0000: [sports-helsinki]:     at CarouselContextProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20721:23)
➤ YN0000: [sports-helsinki]:     at Carousel (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21033:21)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at CollectionCarousel (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21490:21)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at Collection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21511:21)
➤ YN0000: [sports-helsinki]:     at LoadingSpinner (events-helsinki-monorepo\packages\components\src\components\spinner\LoadingSpinner.tsx:18:3)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [sports-helsinki]:     at VenueUpcomingEvents (events-helsinki-monorepo\apps\sports-helsinki\src\domain\venue\upcomingEvents\UpcomingEventsSection.tsx:23:3)
➤ YN0000: [sports-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [sports-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [sports-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [sports-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [sports-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [sports-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [sports-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [sports-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [sports-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [sports-helsinki]:     at wrapper (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: stderr | src/domain/event/__tests__/EventPageContainer.test.tsx > should render info and load other events + similar events
➤ YN0000: [sports-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:154:16)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [sports-helsinki]:     at li
➤ YN0000: [sports-helsinki]:     at ul
➤ YN0000: [sports-helsinki]:     at EventList (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\eventList\EventList.tsx:22:22)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at InfoWithIcon (events-helsinki-monorepo\packages\components\src\components\infoWithIcon\InfoWithIcon.tsx:6:25)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at SubEvents (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventsHierarchy.tsx:28:22)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at EventInfo (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventInfo.tsx:48:22)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [sports-helsinki]:     at EventContent (events-helsinki-monorepo\packages\components\src\components\domain\event\eventContent\EventContent.tsx:25:3)
➤ YN0000: [sports-helsinki]:     at LoadableComponent (events-helsinki-monorepo\node_modules\next\dist\shared\lib\loadable.shared-runtime.js:111:9)
➤ YN0000: [sports-helsinki]:     at LoadingSpinner (events-helsinki-monorepo\packages\components\src\components\spinner\LoadingSpinner.tsx:18:3)
➤ YN0000: [sports-helsinki]:     at main
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at EventPageContainer (events-helsinki-monorepo\apps\sports-helsinki\src\domain\event\EventPageContainer.tsx:41:3)
➤ YN0000: [sports-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [sports-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [sports-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [sports-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [sports-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [sports-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [sports-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [sports-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [sports-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [sports-helsinki]:     at wrapper (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: stderr | src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking submit button
➤ YN0000: [sports-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:154:16)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [sports-helsinki]:     at SecondaryLink (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:122:24)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at form
➤ YN0000: [sports-helsinki]:     at LandingPageSearchForm (events-helsinki-monorepo\apps\sports-helsinki\src\domain\search\landingPageSearch\LandingPageSearchForm.tsx:19:3)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at Search (events-helsinki-monorepo\apps\sports-helsinki\src\domain\search\landingPageSearch\LandingPageSearch.tsx:26:79)
➤ YN0000: [sports-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [sports-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [sports-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [sports-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [sports-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [sports-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [sports-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [sports-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [sports-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [sports-helsinki]:     at wrapper (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: stderr | src/domain/venue/venueContent/__tests__/VenueContent.test.tsx > should render event content fields
➤ YN0000: [sports-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:154:16)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [sports-helsinki]:     at li
➤ YN0000: [sports-helsinki]:     at ul
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at InfoWithIcon (events-helsinki-monorepo\packages\components\src\components\infoWithIcon\InfoWithIcon.tsx:6:25)
➤ YN0000: [sports-helsinki]:     at ContactDetailsInfo (events-helsinki-monorepo\apps\sports-helsinki\src\domain\venue\venueInfo\VenueInfo.tsx:64:10)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at VenueInfo (events-helsinki-monorepo\apps\sports-helsinki\src\domain\venue\venueInfo\VenueInfo.tsx:387:22)
➤ YN0000: [sports-helsinki]:     at aside
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [sports-helsinki]:     at VenueContent (events-helsinki-monorepo\apps\sports-helsinki\src\domain\venue\venueContent\VenueContent.tsx:20:25)
➤ YN0000: [sports-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [sports-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [sports-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [sports-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [sports-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [sports-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [sports-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [sports-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [sports-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [sports-helsinki]:     at wrapper (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: stderr | src/domain/venue/similarVenues/__tests__/SimilarVenuesSection.test.tsx > similar venues > should render similar venues cards
➤ YN0000: [sports-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [sports-helsinki]:     at a
➤ YN0000: [sports-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:154:16)
➤ YN0000: [sports-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at LinkBox (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:19010:23)
➤ YN0000: [sports-helsinki]:     at Card (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21055:17)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at li
➤ YN0000: [sports-helsinki]:     at CarouselSliderPage (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20788:22)
➤ YN0000: [sports-helsinki]:     at ul
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at CarouselSlider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20840:23)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at CarouselWithContext (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20989:20)
➤ YN0000: [sports-helsinki]:     at CarouselContextProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20721:23)
➤ YN0000: [sports-helsinki]:     at Carousel (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21033:21)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at CollectionCarousel (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21490:21)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at Collection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:21511:21)
➤ YN0000: [sports-helsinki]:     at LoadingSpinner (events-helsinki-monorepo\packages\components\src\components\spinner\LoadingSpinner.tsx:18:3)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [sports-helsinki]:     at div
➤ YN0000: [sports-helsinki]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [sports-helsinki]:     at SimilarVenuesSection (events-helsinki-monorepo\apps\sports-helsinki\src\domain\venue\similarVenues\SimilarVenuesSection.tsx:25:3)
➤ YN0000: [sports-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [sports-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [sports-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [sports-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [sports-helsinki]:     at ApolloProvider (events-helsinki-monorepo\node_modules\@apollo\client\react\context\context.cjs:50:21)
➤ YN0000: [sports-helsinki]:     at MockedProvider (events-helsinki-monorepo\node_modules\@apollo\client\testing\testing.cjs:30:28)
➤ YN0000: [sports-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [sports-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [sports-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [sports-helsinki]:     at wrapper (events-helsinki-monorepo\apps\sports-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [sports-helsinki]:
➤ YN0000: [sports-helsinki]: Process exited (exit code 0), completed in 1m 7s
➤ YN0000: [events-helsinki]:
➤ YN0000: [events-helsinki]:  RUN  v3.2.4 events-helsinki-monorepo/apps/events-helsinki
➤ YN0000: [events-helsinki]:
➤ YN0000: [events-helsinki]:  ✓ src/__tests__/criticalHdsRules.test.tsx > Critical HDS rules file generation > critical-hds-styles are up to date 333ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'http://localhost:8080' 4ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.example.org/' 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.example.org' 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides hostname from 'https://a.b.c:8080/1/2/3?a=1&b=2' 2ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides required config 'origin' 3ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'debug' 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'allowUnauthorizedRequests' 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides flag config 'showSimilarEvents' 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides number config 'defaultRevalidate' 5ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > provides configuration for Matomo 32ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/AppConfig.test.tsx > gives access to misc configs 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getSearchQuery function > get search query 7ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 5ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct keywords per category 10ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should not return any keywords for an undefined category 2ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return start=now if start time is in past/today 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getEventSearchVariables function > should return correct start and end time 112ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getNextPage function > should return next page 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/__tests__/utils.test.ts > getNextPage function > should return null 0ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getKeywordList function > should sort and capitalize keywords 8ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getKeywordList function > should remove duplicate keywords (not case sensitive) 3ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getKeywordList function > should not return keyword if id or name is not defined 4ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getEventSomeImageUrl function > should return default placeholder image if image is not defined 2ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getLocationId function > should return Palvelukartta compatible location id 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getServiceMapUrl function > get service map url 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getEventIdFromUrl function > get event id 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getEventIdsFromUrls function > gets event idsfrom urls 1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > getEventFields function > should return false to today and thisWeek fields if startTime is not defined 3ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > formatPrice function > format correctly with separator:  1ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > formatPrice function > format correctly with separator: - 0ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > formatPrice function > format correctly with separator: , 0ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > formatPrice function > format correctly with separator: . 0ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > formatPrice function > format correctly with separator: / 0ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > formatPrice function > adds € with one or more numbers 0ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventUtils.test.ts > formatPrice function > doesn't add € when not needed 1ms
➤ YN0000: [events-helsinki]:  ↓ src/__tests__/redirectRoutes.test.tsx > NextJS redirects > should redirect the requests of the old app-version path (/fi/home) to the new path (/fi)
➤ YN0000: [events-helsinki]:  ↓ src/__tests__/redirectRoutes.test.tsx > NextJS redirects > should redirect the requests of the old app-version path (/sv/home) to the new path (/sv)
➤ YN0000: [events-helsinki]:  ↓ src/__tests__/redirectRoutes.test.tsx > NextJS redirects > should redirect the requests of the old app-version path (/en/home) to the new path (/en)
➤ YN0000: [events-helsinki]:  ↓ src/__tests__/redirectRoutes.test.tsx > NextJS redirects > should redirect the requests of the old app-version path (/fi/events) to the new path (/fi/haku)
➤ YN0000: [events-helsinki]:  ↓ src/__tests__/redirectRoutes.test.tsx > NextJS redirects > should redirect the requests of the old app-version path (/sv/events) to the new path (/sv/sok)
➤ YN0000: [events-helsinki]:  ↓ src/__tests__/redirectRoutes.test.tsx > NextJS redirects > should redirect the requests of the old app-version path (/en/events) to the new path (/en/search)
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > events with 0 results matches snapshot for no results 132ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders no events found text 45ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders few events found text when event count is 1 30ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/ResultsInfo.test.tsx > renders few events found text when event count is 4 14ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/TargetAgeGroupSelector.test.tsx > <TargetAgeGroupSelector /> > renders without crashing 1951ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/TargetAgeGroupSelector.test.tsx > <TargetAgeGroupSelector /> > renders with correct placeholder 27ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/TargetAgeGroupSelector.test.tsx > <TargetAgeGroupSelector /> > renders with correct placeholder without label 322ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 0 Valitsemillasi hakuehdoilla ei löytynyt yhtään tapahtumaa. results are found 144ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 1 Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia. results are found 37ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should return the proper results info text if 4 Valitsemillasi hakuehdoilla löytyi vain vähän hakutuloksia. results are found 32ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/searchResultList/__tests__/SearchResultsContainer.test.tsx > should not return any results info if more than 5 or more results are found 50ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/TargetAgeGroupSelector.test.tsx > <TargetAgeGroupSelector /> > shows all age group options when opened 417ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/TargetAgeGroupSelector.test.tsx > <TargetAgeGroupSelector /> > calls onChange with the correct value when an option is selected 642ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/TargetAgeGroupSelector.test.tsx > <TargetAgeGroupSelector /> > displays the selected value 42ms
➤ YN0000: [events-helsinki]:  ✓ src/common-events/components/category/__tests__/CategoryFilter.test.tsx > matches snapshot 332ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/TargetAgeGroupSelector.test.tsx > <TargetAgeGroupSelector /> > can be cleared 352ms
➤ YN0000: [events-helsinki]:  ✓ src/common-events/components/category/__tests__/CategoryFilter.test.tsx > calls onClick callback when category filter button is clicked 1488ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx > calls onClear callback when clear button is clicked 2188ms
➤ YN0000: [events-helsinki]:  ↓ src/domain/search/eventSearch/filterSummary/__tests__/FilterSummary.test.tsx > routes to correct url after deleting filters
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/EventsApolloProvider.test.tsx > EventsApolloProvider > ApolloErrorNotification > does not render when there are no errors 109ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/app/__tests__/EventsApolloProvider.test.tsx > EventsApolloProvider > ApolloErrorNotification > renders ApolloErrorNotification on Apollo-Client errors 2065ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking submit button 2622ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page with correct search query after clicking submit button 1253ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page with correct search query after pressing enter to submit form 452ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should render info and load other events + similar events 4816ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should show error info when event is closed 163ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking category 632ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > for accessibility violations 3621ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > should show error info when event doesn't exist 113ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should clear all filters and search field 772ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after selecting today date type and pressing submit button 1359ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after checking only evening events checkbox and submitting form 959ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > shows similar events when SIMILAR_EVENTS flag is on 1382ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > doesnt show similar events when SIMILAR_EVENTS flag is off 1049ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after checking is free checkbox and submitting form 1028ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/event/__tests__/EventPageContainer.test.tsx > hides similar events when event has no keywords 970ms
➤ YN0000: [events-helsinki]:  ↓ src/domain/event/__tests__/EventPageContainer.test.tsx > should link to events search when clicking tags
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after selecting start date and pressing submit button 2432ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after selecting today date type and pressing submit button 1720ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after selecting start date and pressing submit button 3829ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query after clicking category menu item 3091ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query 'babies' after clicking target age group menu item /vauvat/i 733ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query 'children' after clicking target age group menu item /lapset/i 390ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query 'youth' after clicking target age group menu item /nuoret/i 355ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query 'seniors' after clicking target age group menu item /ikääntyneet/i 375ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query 'adults' after clicking target age group menu item /aikuiset/i 360ms
➤ YN0000: [events-helsinki]:  ✓ src/domain/search/eventSearch/advancedSearch/__tests__/Search.test.tsx > should change search query with remote events checkbox and submitting form 234ms
➤ YN0000: [events-helsinki]:
➤ YN0000: [events-helsinki]:  Test Files  13 passed | 1 skipped (14)
➤ YN0000: [events-helsinki]:       Tests  89 passed | 7 skipped | 1 todo (97)
➤ YN0000: [events-helsinki]:    Start at  13:24:34
➤ YN0000: [events-helsinki]:    Duration  66.09s (transform 12.97s, setup 44.63s, collect 475.85s, tests 45.78s, environment 66.14s, prepare 13.82s)
➤ YN0000: [events-helsinki]:
➤ YN0000: [events-helsinki]: SonarQube report written to events-helsinki-monorepo\apps\events-helsinki\sonar-report.xml
➤ YN0000: [events-helsinki]: JSON report written to events-helsinki-monorepo/apps/events-helsinki/sonar-report.json
➤ YN0000: [events-helsinki]: stderr | src/common-events/components/category/__tests__/CategoryFilter.test.tsx > matches snapshot
➤ YN0000: [events-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [events-helsinki]:     at a
➤ YN0000: [events-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [events-helsinki]:     at a
➤ YN0000: [events-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [events-helsinki]:     at Link (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:152:16)
➤ YN0000: [events-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at CategoryFilter (events-helsinki-monorepo\apps\events-helsinki\src\common-events\components\category\CategoryFilter.tsx:13:3)
➤ YN0000: [events-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [events-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [events-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [events-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [events-helsinki]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [events-helsinki]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [events-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [events-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [events-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [events-helsinki]:     at wrapper (events-helsinki-monorepo\apps\events-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [events-helsinki]:
➤ YN0000: [events-helsinki]: stderr | src/domain/event/__tests__/EventPageContainer.test.tsx > should render info and load other events + similar events
➤ YN0000: [events-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [events-helsinki]:     at a
➤ YN0000: [events-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [events-helsinki]:     at a
➤ YN0000: [events-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [events-helsinki]:     at Link (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:152:16)
➤ YN0000: [events-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [events-helsinki]:     at li
➤ YN0000: [events-helsinki]:     at ul
➤ YN0000: [events-helsinki]:     at EventList (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\eventList\EventList.tsx:22:22)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at InfoWithIcon (events-helsinki-monorepo\packages\components\src\components\infoWithIcon\InfoWithIcon.tsx:6:25)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at SubEvents (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventsHierarchy.tsx:28:22)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at EventInfo (events-helsinki-monorepo\packages\components\src\components\domain\event\eventInfo\EventInfo.tsx:48:22)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at ContentContainer (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20266:24)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at PageSection (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:20432:24)
➤ YN0000: [events-helsinki]:     at EventContent (events-helsinki-monorepo\packages\components\src\components\domain\event\eventContent\EventContent.tsx:25:3)
➤ YN0000: [events-helsinki]:     at LoadableComponent (events-helsinki-monorepo\node_modules\next\dist\shared\lib\loadable.shared-runtime.js:111:9)
➤ YN0000: [events-helsinki]:     at LoadingSpinner (events-helsinki-monorepo\packages\components\src\components\spinner\LoadingSpinner.tsx:18:3)
➤ YN0000: [events-helsinki]:     at main
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at EventPageContainer (events-helsinki-monorepo\apps\events-helsinki\src\domain\event\EventPageContainer.tsx:41:3)
➤ YN0000: [events-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [events-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [events-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [events-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [events-helsinki]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [events-helsinki]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [events-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [events-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [events-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [events-helsinki]:     at wrapper (events-helsinki-monorepo\apps\events-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [events-helsinki]:
➤ YN0000: [events-helsinki]: stderr | src/domain/search/landingPageSearch/__tests__/LandingPageSearch.test.tsx > Landing page > should route to event search page after clicking submit button
➤ YN0000: [events-helsinki]: Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
➤ YN0000: [events-helsinki]:     at a
➤ YN0000: [events-helsinki]:     at events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18789:23
➤ YN0000: [events-helsinki]:     at a
➤ YN0000: [events-helsinki]:     at LinkComponent (events-helsinki-monorepo\node_modules\next\dist\client\link.js:121:19)
➤ YN0000: [events-helsinki]:     at Link (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:152:16)
➤ YN0000: [events-helsinki]:     at Link (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\archiveSearchPageContent.module-Cgnu3kj4.js:18951:19)
➤ YN0000: [events-helsinki]:     at SecondaryLink (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:122:24)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at form
➤ YN0000: [events-helsinki]:     at LandingPageSearchForm (events-helsinki-monorepo\apps\events-helsinki\src\domain\search\landingPageSearch\LandingPageSearchForm.tsx:19:3)
➤ YN0000: [events-helsinki]:     at div
➤ YN0000: [events-helsinki]:     at Search (events-helsinki-monorepo\apps\events-helsinki\src\domain\search\landingPageSearch\LandingPageSearch.tsx:27:67)
➤ YN0000: [events-helsinki]:     at ErrorBoundary (events-helsinki-monorepo\node_modules\react-error-boundary\dist\react-error-boundary.cjs.js:16:5)
➤ YN0000: [events-helsinki]:     at CmsHelperProvider (events-helsinki-monorepo\packages\components\src\cmsHelperProvider\CmsHelperProvider.tsx:9:3)
➤ YN0000: [events-helsinki]:     at ConfigProvider (events-helsinki-monorepo\node_modules\react-helsinki-headless-cms\index.js:110:25)
➤ YN0000: [events-helsinki]:     at RHHCConfigProviderWithMockedApolloClient (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:94:53)
➤ YN0000: [events-helsinki]:     at ApolloProvider (node_modules/@apollo/client/react/context/ApolloProvider.js:6:21)
➤ YN0000: [events-helsinki]:     at MockedProvider (node_modules/@apollo/client/testing/react/MockedProvider.js:10:28)
➤ YN0000: [events-helsinki]:     at I18nextProvider (node_modules/react-i18next/dist/es/I18nextProvider.js:4:3)
➤ YN0000: [events-helsinki]:     at NavigationProvider (events-helsinki-monorepo\packages\components\src\routingUrlProvider\AppRoutingProvider.tsx:7:3)
➤ YN0000: [events-helsinki]:     at TestProviders (events-helsinki-monorepo\apps\events-helsinki\config\vitest\TestProviders.tsx:48:26)
➤ YN0000: [events-helsinki]:     at wrapper (events-helsinki-monorepo\apps\events-helsinki\config\vitest\test-utils.tsx:40:17)
➤ YN0000: [events-helsinki]:
➤ YN0000: [events-helsinki]: Process exited (exit code 0), completed in 1m 9s
➤ YN0000: Done in 2m 21s
```

</details>


### Automated tests

### Manual testing

## Screenshots

## Additional notes


[TH-1441]: https://helsinkisolutionoffice.atlassian.net/browse/TH-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ