### PR TITLE
Fetch titles and some description texts from CMS on landing page and search page

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.2.1",
+    "react-helsinki-headless-cms": "1.3.0",
     "react-i18next": "15.6.0",
     "react-scroll": "^1.9.3",
     "react-toastify": "^11.0.5",

--- a/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -69,8 +69,7 @@ const SearchPage: React.FC<{
     scrollToResultList: () => void;
     'data-testid'?: string;
   }>;
-  pageTitle: string;
-}> = ({ SearchComponent, pageTitle }) => {
+}> = ({ SearchComponent }) => {
   const { t } = useSearchTranslation();
   const router = useRouter();
   const routerHelper = useCmsRoutedAppHelper();
@@ -158,7 +157,6 @@ const SearchPage: React.FC<{
         favIconSvgUrl={meta?.favIconSvgUrl}
         manifestUrl={meta?.manifestUrl}
       />
-      <SrOnly as="h1">{pageTitle}</SrOnly>
       <SearchComponent
         scrollToResultList={scrollToResultList}
         data-testid="searchContainer"

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearch.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { PageSection, ContentContainer } from 'react-helsinki-headless-cms';
+import {
+  PageSection,
+  ContentContainer,
+  getTextFromHtml,
+  usePageContext,
+} from 'react-helsinki-headless-cms';
 import AdvancedSearchContext from './AdvancedSearchContext';
 import AdvancedSearchForm from './AdvancedSearchForm';
 import styles from './search.module.scss';
@@ -15,6 +20,11 @@ const AdvancedSearch: React.FC<Props> = ({
   'data-testid': dataTestId,
 }) => {
   const searchFormState = useAdvancedSearchFormState();
+  const { page } = usePageContext();
+  const pageTitle = page?.title?.trim() ?? undefined;
+  const pageDescription = page?.content?.trim()
+    ? getTextFromHtml(page?.content)?.trim()
+    : undefined;
 
   const contextValue = React.useMemo(
     () => ({
@@ -32,7 +42,7 @@ const AdvancedSearch: React.FC<Props> = ({
         data-testid={dataTestId}
       >
         <ContentContainer className={styles.contentContainer}>
-          <AdvancedSearchForm />
+          <AdvancedSearchForm title={pageTitle} description={pageDescription} />
         </ContentContainer>
       </PageSection>
     </AdvancedSearchContext.Provider>

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
@@ -31,10 +31,15 @@ import type { TargetAgeGroupOptionType } from './TargetAgeGroupSelector';
 import TargetAgeGroupSelector from './TargetAgeGroupSelector';
 import { useGoToSearch } from './useGoToSearch';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-interface AdvancedSearchFormProps {}
+type AdvancedSearchFormProps = {
+  title?: string;
+  description?: string;
+};
 
-export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
+export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = ({
+  title = 'search:search.titlePage',
+  description = 'search:search.descriptionPage',
+}) => {
   const { t } = useTranslation('search');
   const { t: tAppEvents } = useAppEventsTranslation();
   const router = useRouter();
@@ -145,7 +150,18 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
   return (
     <form onSubmit={handleSubmit}>
       <div className={styles.searchWrapper}>
-        <h1>{t('search.labelSearchField')}</h1>
+        {title && (
+          <h1
+            className={classNames(styles.searchTitle, {
+              [styles.withDescription]: !!description,
+            })}
+          >
+            {tAppEvents(title)}
+          </h1>
+        )}
+        {description && (
+          <p className={styles.searchDescription}>{tAppEvents(description)}</p>
+        )}
         <div className={styles.rowWrapper}>
           <div className={classNames(styles.row, styles.textSearchRow)}>
             <AdvancedSearchTextInput

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -3,6 +3,7 @@ import {
   useCommonTranslation,
   EventTypeId,
   EVENT_SEARCH_FILTERS,
+  CmsPageContent,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -76,6 +77,7 @@ const Search: React.FC = () => {
         toggleIsCustomDate={toggleIsCustomDate}
         handleSubmit={handleSubmit}
       />
+      <CmsPageContent className={styles.pageContent} />
       <SearchShortcuts
         className={styles.categoriesWrapper}
         categories={categories}

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -8,7 +8,11 @@ import {
 } from '@events-helsinki/components';
 import classnames from 'classnames';
 import { Button, IconSearch } from 'hds-react';
-import { SecondaryLink } from 'react-helsinki-headless-cms';
+import {
+  isPageType,
+  SecondaryLink,
+  usePageContext,
+} from 'react-helsinki-headless-cms';
 import { ROUTES } from '../../../constants';
 import routerHelper from '../../../domain/app/routerHelper';
 import styles from './landingPageSearchForm.module.scss';
@@ -45,13 +49,28 @@ export default function LandingPageSearchForm({
   const { t } = useHomeTranslation();
   const { t: tAppEvents } = useAppEventsTranslation();
   const locale = useLocale();
+  const { page } = usePageContext();
+  const heroTitle =
+    isPageType(page) && page?.hero?.title?.trim() !== ''
+      ? page?.hero?.title?.trim()
+      : tAppEvents('appEvents:home.search.title');
+  const heroDescription =
+    isPageType(page) && page?.hero?.description?.trim() !== ''
+      ? page?.hero?.description?.trim()
+      : undefined;
 
   return (
     <form
       className={classnames(className, styles.landingPageSearch)}
       onSubmit={handleSubmit}
     >
-      <h1>{tAppEvents('appEvents:home.search.title')}</h1>
+      <h1
+        id="heroTitle"
+        className={classnames({ [styles.withDescription]: !!heroDescription })}
+      >
+        {heroTitle}
+      </h1>
+      {!!heroDescription && <p id="heroDescription">{heroDescription}</p>}
       <div className={styles.searchRow}>
         <div className={styles.textSearchWrapper}>
           <AdvancedSearchTextInput

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
@@ -1,11 +1,13 @@
 @use '../../../styles/breakpoints' as breakpoints;
 
 .landingPageSearch {
+  --color-heroTitle: var(--color-white);
+  --color-heroDescription: var(--color-brick-light);
   margin-top: -13.5rem;
   background-color: #464646;
   padding: var(--spacing-l) var(--spacing-m);
   z-index: 1;
-  position: absolute;
+  position: relative;
   width: 100%;
 
   @include breakpoints.respond-above(s) {
@@ -21,16 +23,20 @@
     font-weight: 500;
     margin-top: 0;
     margin-bottom: var(--spacing-l);
-    color: var(--color-white);
+    color: var(--color-heroTitle);
+  }
+
+  p {
+    color: var(--color-heroDescription);
+    margin-bottom: var(--spacing-l);
   }
 }
 
 .categoriesWrapper {
   position: relative;
-  top: 2.8rem;
   z-index: 0;
-  padding-top: 4rem;
-  padding-bottom: 3rem;
+  padding-top: 2rem;
+  padding-bottom: 1rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-gap: 1rem;
@@ -40,18 +46,18 @@
   @include breakpoints.respond-below(m) {
     display: flex;
     flex-direction: column;
-    padding-top: 0;
+    padding-top: 2.8rem;
     grid-gap: 2px;
     padding-bottom: 3rem;
   }
 
   @include breakpoints.respond-above(s) {
-    padding-top: 12rem;
+    padding-top: 2rem;
   }
 
   @include breakpoints.respond-above(m) {
     grid-template-columns: 1fr 1fr 1fr;
-    padding-top: 4rem;
+    padding-top: 2rem;
   }
 
   @include breakpoints.respond-above(l) {
@@ -62,5 +68,17 @@
     @include breakpoints.respond-below(m) {
       grid-column-start: 2;
     }
+  }
+}
+.pageContent {
+  margin: var(--spacing-5-xl) var(--spacing-m) 0;
+  color: var(--color-black);
+
+  p {
+    font-size: var(--fontsize-body-l);
+  }
+
+  p:only-of-type {
+    margin-bottom: 0;
   }
 }

--- a/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
+++ b/apps/events-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
@@ -85,3 +85,6 @@
   width: 100%;
   margin-bottom: 1.25rem;
 }
+.withDescription {
+  margin-bottom: var(--spacing-s) !important;
+}

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -1,7 +1,6 @@
 import type { PreviewDataObject } from '@events-helsinki/components';
 import {
   NavigationContext,
-  useAppEventsTranslation,
   Navigation,
   getLanguageOrDefault,
   FooterSection,
@@ -20,6 +19,7 @@ import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
 import {
+  PageContextProvider,
   Page as RHHCPage,
   getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
@@ -44,7 +44,6 @@ const Search: NextPage<{
   const router = useRouter();
   const scrollTo = router.query?.scrollTo;
   const listRef = useRef<HTMLUListElement | null>(null);
-  const { t: tAppEvents } = useAppEventsTranslation();
   const { resilientT } = useResilientTranslation();
   usePageScrollRestoration();
 
@@ -78,7 +77,7 @@ const Search: NextPage<{
       className="pageLayout"
       navigation={<Navigation />}
       content={
-        <>
+        <PageContextProvider page={page}>
           <PreviewNotification token={previewToken} />
           <RouteMeta origin={AppConfig.origin} />
           <PageMeta
@@ -86,11 +85,8 @@ const Search: NextPage<{
             image={page?.featuredImage?.node?.mediaItemUrl || ''}
           />
           {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
-          <SearchPageNoSSR
-            SearchComponent={AdvancedSearch}
-            pageTitle={tAppEvents('appEvents:search.pageTitle')}
-          />
-        </>
+          <SearchPageNoSSR SearchComponent={AdvancedSearch} />
+        </PageContextProvider>
       }
       footer={
         <FooterSection

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.2.1",
+    "react-helsinki-headless-cms": "1.3.0",
     "react-i18next": "15.6.0",
     "react-scroll": "^1.9.3",
     "react-toastify": "^11.0.5",

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -72,8 +72,7 @@ const SearchPage: React.FC<{
     scrollToResultList: () => void;
     'data-testid'?: string;
   }>;
-  pageTitle: string;
-}> = ({ SearchComponent, pageTitle }) => {
+}> = ({ SearchComponent }) => {
   const { t } = useSearchTranslation();
   const router = useRouter();
 
@@ -162,7 +161,6 @@ const SearchPage: React.FC<{
         favIconSvgUrl={meta?.favIconSvgUrl}
         manifestUrl={meta?.manifestUrl}
       />
-      <SrOnly as="h1">{pageTitle}</SrOnly>
       <SearchComponent
         scrollToResultList={scrollToResultList}
         data-testid="searchContainer"

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearch.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearch.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { PageSection, ContentContainer } from 'react-helsinki-headless-cms';
+import {
+  PageSection,
+  ContentContainer,
+  usePageContext,
+  getTextFromHtml,
+} from 'react-helsinki-headless-cms';
 
 import AdvancedSearchContext from './AdvancedSearchContext';
 import { AdvancedSearchForm } from './AdvancedSearchForm';
@@ -17,6 +22,11 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
   'data-testid': dataTestId,
 }) => {
   const searchFormState = useAdvancedSearchFormState();
+  const { page } = usePageContext();
+  const pageTitle = page?.title?.trim() ?? undefined;
+  const pageDescription = page?.content?.trim()
+    ? getTextFromHtml(page?.content)?.trim()
+    : undefined;
 
   const contextValue = React.useMemo(
     () => ({
@@ -35,7 +45,7 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
         data-testid={dataTestId}
       >
         <ContentContainer className={styles.contentContainer}>
-          <AdvancedSearchForm />
+          <AdvancedSearchForm title={pageTitle} description={pageDescription} />
         </ContentContainer>
       </PageSection>
     </AdvancedSearchContext.Provider>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
@@ -30,14 +30,19 @@ import { useAdvancedSearchContext } from './AdvancedSearchContext';
 import styles from './search.module.scss';
 import { useGoToSearch } from './useGoToSearch';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-interface AdvancedSearchFormProps {}
+type AdvancedSearchFormProps = {
+  title?: string;
+  description?: string;
+};
 
 /**
  * AdvancedSearchForm is a child component that consumes the AdvancedSearchContext
  * to access and display the search form elements.
  */
-export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
+export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = ({
+  title = 'search:search.titlePage',
+  description = 'search:search.descriptionPage',
+}) => {
   const { t } = useTranslation('search');
   const { t: tAppHobbies } = useAppHobbiesTranslation();
   const router = useRouter();
@@ -135,7 +140,18 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
   return (
     <form onSubmit={handleSubmit}>
       <div className={styles.searchWrapper}>
-        <h1>{t('search.labelSearchField')}</h1>
+        {title && (
+          <h1
+            className={classNames(styles.searchTitle, {
+              [styles.withDescription]: !!description,
+            })}
+          >
+            {tAppHobbies(title)}
+          </h1>
+        )}
+        {description && (
+          <p className={styles.searchDescription}>{tAppHobbies(description)}</p>
+        )}
         <div className={styles.rowWrapper}>
           <div className={classNames(styles.row, styles.textSearchRow)}>
             <AdvancedSearchTextInput

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -3,6 +3,7 @@ import {
   useCommonTranslation,
   EventTypeId,
   EVENT_SEARCH_FILTERS,
+  CmsPageContent,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -77,6 +78,7 @@ const Search: React.FC = () => {
         toggleIsCustomDate={toggleIsCustomDate}
         handleSubmit={handleSubmit}
       />
+      <CmsPageContent className={styles.pageContent} />
       <SearchShortcuts
         className={styles.categoriesWrapper}
         categories={categories}

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -8,7 +8,11 @@ import {
 } from '@events-helsinki/components';
 import classnames from 'classnames';
 import { Button, IconSearch } from 'hds-react';
-import { SecondaryLink } from 'react-helsinki-headless-cms';
+import {
+  isPageType,
+  SecondaryLink,
+  usePageContext,
+} from 'react-helsinki-headless-cms';
 import { ROUTES } from '../../../constants';
 import routerHelper from '../../../domain/app/routerHelper';
 import styles from './landingPageSearchForm.module.scss';
@@ -45,13 +49,28 @@ export default function LandingPageSearchForm({
   const { t } = useHomeTranslation();
   const { t: tAppHobbies } = useAppHobbiesTranslation();
   const locale = useLocale();
+  const { page } = usePageContext();
+  const heroTitle =
+    isPageType(page) && page?.hero?.title?.trim() !== ''
+      ? page?.hero?.title?.trim()
+      : tAppHobbies('appHobbies:home.search.title');
+  const heroDescription =
+    isPageType(page) && page?.hero?.description?.trim() !== ''
+      ? page?.hero?.description?.trim()
+      : undefined;
 
   return (
     <form
       className={classnames(className, styles.landingPageSearch)}
       onSubmit={handleSubmit}
     >
-      <h1>{tAppHobbies('appHobbies:home.search.title')}</h1>
+      <h1
+        id="heroTitle"
+        className={classnames({ [styles.withDescription]: !!heroDescription })}
+      >
+        {heroTitle}
+      </h1>
+      {!!heroDescription && <p id="heroDescription">{heroDescription}</p>}
       <div className={styles.searchRow}>
         <div className={styles.textSearchWrapper}>
           <AdvancedSearchTextInput

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
@@ -1,11 +1,14 @@
 @use '../../../styles/breakpoints' as breakpoints;
 
 .landingPageSearch {
+  --color-heroTitle: var(--color-white);
+  --color-heroDescription: var(--color-brick-light);
+
   margin-top: -13.5rem;
   background-color: #464646;
   padding: var(--spacing-l) var(--spacing-m);
   z-index: 1;
-  position: absolute;
+  position: relative;
   width: 100%;
 
   @include breakpoints.respond-above(s) {
@@ -21,16 +24,20 @@
     font-weight: 500;
     margin-top: 0;
     margin-bottom: var(--spacing-l);
-    color: var(--color-white);
+    color: var(--color-heroTitle);
+  }
+
+  p {
+    color: var(--color-heroDescription);
+    margin-bottom: var(--spacing-l);
   }
 }
 
 .categoriesWrapper {
   position: relative;
-  top: 2.8rem;
   z-index: 0;
-  padding-top: 4rem;
-  padding-bottom: 3rem;
+  padding-top: 2rem;
+  padding-bottom: 1rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-gap: 1rem;
@@ -40,18 +47,18 @@
   @include breakpoints.respond-below(m) {
     display: flex;
     flex-direction: column;
-    padding-top: 0;
+    padding-top: 2.8rem;
     grid-gap: 2px;
     padding-bottom: 3rem;
   }
 
   @include breakpoints.respond-above(s) {
-    padding-top: 12rem;
+    padding-top: 2rem;
   }
 
   @include breakpoints.respond-above(m) {
     grid-template-columns: 1fr 1fr 1fr;
-    padding-top: 4rem;
+    padding-top: 2rem;
   }
 
   @include breakpoints.respond-above(l) {
@@ -62,5 +69,17 @@
     @include breakpoints.respond-below(m) {
       grid-column-start: 2;
     }
+  }
+}
+.pageContent {
+  margin: var(--spacing-5-xl) var(--spacing-m) 0;
+  color: var(--color-black);
+
+  p {
+    font-size: var(--fontsize-body-l);
+  }
+
+  p:only-of-type {
+    margin-bottom: 0;
   }
 }

--- a/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
@@ -91,3 +91,6 @@
     }
   }
 }
+.withDescription {
+  margin-bottom: var(--spacing-s) !important;
+}

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -1,7 +1,6 @@
 import type { PreviewDataObject } from '@events-helsinki/components';
 import {
   NavigationContext,
-  useAppHobbiesTranslation,
   Navigation,
   FooterSection,
   getLanguageOrDefault,
@@ -20,6 +19,7 @@ import { useRouter } from 'next/router';
 import React, { useRef, useEffect, useContext } from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
 import {
+  PageContextProvider,
   Page as RHHCPage,
   getBreadcrumbsFromPage,
 } from 'react-helsinki-headless-cms';
@@ -41,7 +41,6 @@ const Search: NextPage<{
   page: PageType;
   breadcrumbs?: BreadcrumbListItem[];
 }> = ({ page, breadcrumbs, previewToken }) => {
-  const { t: tAppHobbies } = useAppHobbiesTranslation();
   const { resilientT } = useResilientTranslation();
   const router = useRouter();
   const scrollTo = router.query?.scrollTo;
@@ -77,7 +76,7 @@ const Search: NextPage<{
       className="pageLayout"
       navigation={<Navigation />}
       content={
-        <>
+        <PageContextProvider page={page}>
           <PreviewNotification token={previewToken} />
           <RouteMeta origin={AppConfig.origin} />
           <PageMeta
@@ -85,11 +84,8 @@ const Search: NextPage<{
             image={page?.featuredImage?.node?.mediaItemUrl || ''}
           />
           {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
-          <SearchPageNoSSR
-            SearchComponent={AdvancedSearch}
-            pageTitle={tAppHobbies('appHobbies:search.pageTitle')}
-          />
-        </>
+          <SearchPageNoSSR SearchComponent={AdvancedSearch} />
+        </PageContextProvider>
       }
       footer={
         <FooterSection

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -85,7 +85,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.2.1",
+    "react-helsinki-headless-cms": "1.3.0",
     "react-i18next": "15.6.0",
     "react-leaflet": "4.2.1",
     "react-scroll": "^1.9.3",

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/CombinedSearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/CombinedSearchPage.tsx
@@ -26,7 +26,7 @@ function VenueSearchPanel() {
   return (
     <VenueSearchPage
       SearchComponent={undefined}
-      pageTitle={t('appSports:search.pageTitle')}
+      pageTitle={t(`search:search.searchType.Venue`)}
     />
   );
 }
@@ -37,7 +37,7 @@ function EventSearchPanel({ eventType }: { eventType: EventTypeId }) {
   return (
     <EventSearchPage
       SearchComponent={undefined}
-      pageTitle={t('search:search.labelSearchField')}
+      pageTitle={t(`search:search.searchType.${eventType}`)}
       eventType={eventType}
     />
   );
@@ -74,11 +74,20 @@ export function SearchForm({
   );
 }
 
+type CombinedSearchPageProps = {
+  defaultTab?: SearchTabId;
+  pageTitle?: string;
+  pageDescription?: string;
+  searchTabsDescription?: string;
+};
+
 function CombinedSearchPage({
   defaultTab = 'Venue',
-}: {
-  defaultTab: SearchTabId;
-}) {
+  pageTitle = 'search:search.titlePage',
+  pageDescription = 'search:search.descriptionPage',
+  searchTabsDescription = 'appSports:search.descriptionSearchTabs',
+}: CombinedSearchPageProps) {
+  const { t } = useSearchTranslation();
   const { initTab } = useSearchTabsWithParams(defaultTab);
   return (
     <div>
@@ -90,9 +99,16 @@ function CombinedSearchPage({
             searchRoute={SEARCH_ROUTES.SEARCH}
             searchUtilities={null}
             korosBottom
-            showTitle
+            title={t(pageTitle)}
+            description={t(pageDescription)}
             scrollToResultList={() => true}
           />
+
+          {searchTabsDescription && (
+            <div className={styles.searchTabsDescription}>
+              <p id="searchTabsDescription">{t(searchTabsDescription)}</p>
+            </div>
+          )}
 
           {/* The search tabs, query sorters, search type switchers, etc. */}
           <SearchUtilities />

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/SearchForm.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/SearchForm.tsx
@@ -7,6 +7,7 @@ import {
   SearchSelect,
   AdvancedSearchTextInput,
 } from '@events-helsinki/components';
+import classNames from 'classnames';
 import type { SelectCustomTheme } from 'hds-react';
 import { Button, IconGroup, IconPersonWheelchair, IconSearch } from 'hds-react';
 import React from 'react';
@@ -19,7 +20,8 @@ import styles from './search.module.scss';
 
 export const SimpleSearchForm: React.FC<SearchComponentType> = ({
   scrollToResultList,
-  showTitle = false,
+  title = undefined,
+  description = undefined,
 }) => {
   const { t } = useSearchTranslation();
   const { t: tAppSports } = useAppSportsTranslation();
@@ -82,8 +84,17 @@ export const SimpleSearchForm: React.FC<SearchComponentType> = ({
   return (
     <form onSubmit={handleSubmit}>
       <div className={styles.searchWrapper}>
-        {showTitle && (
-          <h1 className={styles.searchTitle}>{t('search.labelSearchField')}</h1>
+        {title && (
+          <h1
+            className={classNames(styles.searchTitle, {
+              [styles.withDescription]: !!description,
+            })}
+          >
+            {title}
+          </h1>
+        )}
+        {description && (
+          <p className={styles.searchDescription}>{description}</p>
         )}
         <div className={styles.rowWrapper}>
           <div>

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/SearchUtilities.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/SearchUtilities.tsx
@@ -50,7 +50,11 @@ function SearchUtilities() {
   return (
     <PageSection className={styles.searchUtilities}>
       <ContentContainer className={styles.contentContainer}>
-        <div className={styles.flexEnd}>
+        <div
+          className={styles.flexEnd}
+          role="navigation"
+          aria-describedby="searchTabsDescription"
+        >
           <SearchTabs.TabList>
             {tabsData.map((tab) => (
               <SearchTabs.Tab key={tab.id} id={tab.id} theme="black">

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/combinedSearchPage.module.scss
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/combinedSearchPage.module.scss
@@ -108,12 +108,8 @@ $buttonWidth: 180px;
     @include breakpoints.respond-below(l) {
       display: grid;
       grid-template-columns: 1fr;
-      & > div:nth-child(2) {
-        order: 2;
-      }
 
       & > button {
-        order: 1;
         margin: 0 0 var(--spacing-xs) 0;
       }
     }

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/combinedSearchPage.module.scss
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/combinedSearchPage.module.scss
@@ -23,7 +23,8 @@ $buttonWidth: 180px;
   .contentContainer {
     margin-bottom: 2.375rem;
 
-    h2 {
+    h2,
+    h3 {
       font-size: var(--fontsize-heading-xl);
       font-weight: 500;
       margin-top: 2px;
@@ -122,5 +123,17 @@ $buttonWidth: 180px;
         margin-top: var(--spacing-xs);
       }
     }
+  }
+}
+
+.searchTabsDescription {
+  margin: 0 auto;
+  max-width: var(--breakpoint-xl);
+  padding: 0 var(--spacing-m);
+
+  & p {
+    font-size: var(--fontsize-heading-s);
+    margin: 0 auto;
+    padding: 0 0 var(--spacing-m) 0;
   }
 }

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/search.module.scss
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/search.module.scss
@@ -15,6 +15,16 @@ $buttonWidth: 180px;
   font-weight: 500;
   margin-top: 2px;
   margin-bottom: var(--spacing-xl);
+
+  &.withDescription {
+    margin-bottom: var(--spacing-s);
+  }
+}
+
+.searchDescription {
+  font-size: var(--fontsize-heading-m);
+  margin-top: var(--spacing-s);
+  margin-bottom: var(--spacing-xl);
 }
 
 .searchContainer {

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -187,6 +187,7 @@ export interface SearchPage {
 export type SearchComponentType = {
   scrollToResultList: () => void;
   'data-testid'?: string;
-  showTitle?: boolean;
+  title?: string;
+  description?: string;
   searchRoute?: SearchRoute; // TODO: Allow only SEARCH_ROUTE values
 };

--- a/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -71,7 +71,7 @@ const EventSearchPage: React.FC<SearchPageProps> = ({
         favIconSvgUrl={meta?.favIconSvgUrl}
         manifestUrl={meta?.manifestUrl}
       />
-      <SrOnly as="h1">{pageTitle}</SrOnly>
+      <SrOnly as="h2">{pageTitle}</SrOnly>
       {SearchComponent && (
         <SearchComponent
           scrollToResultList={scrollToResultList}

--- a/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/SearchResultsContainer.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/searchResultList/SearchResultsContainer.tsx
@@ -28,11 +28,11 @@ const SearchResultsContainer: React.FC<Props> = ({
         {!loading && (
           <div className={styles.row}>
             <div className={styles.rowGroup}>
-              <h2 className={styles.count}>
+              <h3 className={styles.count}>
                 {t('search:textFoundEvents', {
                   count: eventsCount,
                 })}
-              </h2>
+              </h3>
               {orderBySelectComponent !== undefined && orderBySelectComponent}
             </div>
           </div>

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -2,6 +2,7 @@ import {
   getCurrentSeason,
   useLocale,
   useCommonTranslation,
+  Visible,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -64,16 +65,18 @@ const Search: React.FC = () => {
         setTextSearchInput={setTextSearchInput}
         handleSubmit={handleSubmit}
       />
-      <CmsPageContent />
-      <SearchShortcuts
-        className={styles.categoriesWrapper}
-        categories={categories.filter(
-          (category) =>
-            !category.seasons ||
-            category.seasons.some((season) => season === currentSeason)
-        )}
-        searchFilters={{}}
-      />
+      <Visible above="s">
+        <CmsPageContent />
+        <SearchShortcuts
+          className={styles.categoriesWrapper}
+          categories={categories.filter(
+            (category) =>
+              !category.seasons ||
+              category.seasons.some((season) => season === currentSeason)
+          )}
+          searchFilters={{}}
+        />
+      </Visible>
     </div>
   );
 };

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -5,6 +5,7 @@ import {
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { HtmlToReact, usePageContext } from 'react-helsinki-headless-cms';
 import { ROUTES } from '../../../constants';
 import routerHelper from '../../app/routerHelper';
 import { CATEGORY_CATALOG } from '../eventSearch/constants';
@@ -13,11 +14,31 @@ import styles from './landingPageSearch.module.scss';
 import LandingPageSearchForm from './LandingPageSearchForm';
 import SearchShortcuts from './SearchShortcuts';
 
+/**
+ * Load CMS Page document from Page Context and render it as HTML
+ * with <HtmlToReact/> -component.
+ */
+const CmsPageContent: React.FC = () => {
+  const { page } = usePageContext();
+  const pageContent = page?.content?.trim() ? page?.content?.trim() : undefined;
+
+  return (
+    <>
+      {!!pageContent && (
+        <div className={styles.pageContent}>
+          <HtmlToReact>{pageContent}</HtmlToReact>
+        </div>
+      )}
+    </>
+  );
+};
+
 const Search: React.FC = () => {
   const { t } = useCommonTranslation();
   const [textSearchInput, setTextSearchInput] = React.useState('');
   const router = useRouter();
   const locale = useLocale();
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
 
@@ -28,13 +49,12 @@ const Search: React.FC = () => {
       },
     });
   };
+  const currentSeason = getCurrentSeason();
 
   const categories = getSportsCategoryOptions(
     t,
     CATEGORY_CATALOG.sportsCategories.landingPage
   );
-
-  const currentSeason = getCurrentSeason();
 
   return (
     <div>
@@ -44,6 +64,7 @@ const Search: React.FC = () => {
         setTextSearchInput={setTextSearchInput}
         handleSubmit={handleSubmit}
       />
+      <CmsPageContent />
       <SearchShortcuts
         className={styles.categoriesWrapper}
         categories={categories.filter(

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearch.tsx
@@ -3,10 +3,10 @@ import {
   useLocale,
   useCommonTranslation,
   Visible,
+  CmsPageContent,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import React from 'react';
-import { HtmlToReact, usePageContext } from 'react-helsinki-headless-cms';
 import { ROUTES } from '../../../constants';
 import routerHelper from '../../app/routerHelper';
 import { CATEGORY_CATALOG } from '../eventSearch/constants';
@@ -14,25 +14,6 @@ import { getSportsCategoryOptions } from '../eventSearch/utils';
 import styles from './landingPageSearch.module.scss';
 import LandingPageSearchForm from './LandingPageSearchForm';
 import SearchShortcuts from './SearchShortcuts';
-
-/**
- * Load CMS Page document from Page Context and render it as HTML
- * with <HtmlToReact/> -component.
- */
-const CmsPageContent: React.FC = () => {
-  const { page } = usePageContext();
-  const pageContent = page?.content?.trim() ? page?.content?.trim() : undefined;
-
-  return (
-    <>
-      {!!pageContent && (
-        <div className={styles.pageContent}>
-          <HtmlToReact>{pageContent}</HtmlToReact>
-        </div>
-      )}
-    </>
-  );
-};
 
 const Search: React.FC = () => {
   const { t } = useCommonTranslation();
@@ -55,6 +36,10 @@ const Search: React.FC = () => {
   const categories = getSportsCategoryOptions(
     t,
     CATEGORY_CATALOG.sportsCategories.landingPage
+  ).filter(
+    (category) =>
+      !category.seasons ||
+      category.seasons.some((season) => season === currentSeason)
   );
 
   return (
@@ -66,14 +51,10 @@ const Search: React.FC = () => {
         handleSubmit={handleSubmit}
       />
       <Visible above="s">
-        <CmsPageContent />
+        <CmsPageContent className={styles.pageContent} />
         <SearchShortcuts
           className={styles.categoriesWrapper}
-          categories={categories.filter(
-            (category) =>
-              !category.seasons ||
-              category.seasons.some((season) => season === currentSeason)
-          )}
+          categories={categories}
           searchFilters={{}}
         />
       </Visible>

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/LandingPageSearchForm.tsx
@@ -6,7 +6,11 @@ import {
 } from '@events-helsinki/components';
 import classnames from 'classnames';
 import { Button, IconSearch } from 'hds-react';
-import { SecondaryLink } from 'react-helsinki-headless-cms';
+import {
+  isPageType,
+  SecondaryLink,
+  usePageContext,
+} from 'react-helsinki-headless-cms';
 import { ROUTES } from '../../../constants';
 import routerHelper from '../../../domain/app/routerHelper';
 import styles from './landingPageSearchForm.module.scss';
@@ -27,13 +31,28 @@ export default function LandingPageSearchForm({
   const { t } = useHomeTranslation();
   const { t: tAppSports } = useAppSportsTranslation();
   const locale = useLocale();
+  const { page } = usePageContext();
+  const heroTitle =
+    isPageType(page) && page?.hero?.title?.trim() !== ''
+      ? page?.hero?.title?.trim()
+      : tAppSports('appSports:home.search.title');
+  const heroDescription =
+    isPageType(page) && page?.hero?.description?.trim()
+      ? page?.hero?.description?.trim()
+      : undefined;
 
   return (
     <form
       className={classnames(className, styles.landingPageSearch)}
       onSubmit={handleSubmit}
     >
-      <h1>{tAppSports('appSports:home.search.title')}</h1>
+      <h1
+        id="heroTitle"
+        className={classnames({ [styles.withDescription]: !!heroDescription })}
+      >
+        {heroTitle}
+      </h1>
+      {!!heroDescription && <p id="heroDescription">{heroDescription}</p>}
       <div className={styles.searchRow}>
         <div className={styles.textSearchWrapper}>
           <AdvancedSearchTextInput

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/SearchShortcuts.tsx
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/SearchShortcuts.tsx
@@ -33,7 +33,10 @@ export default function SearchShortcuts({
   };
 
   return (
-    <div className={classNames(className, 'searchShortcuts')}>
+    <div
+      id="searchShortcuts"
+      className={classNames(className, 'searchShortcuts')}
+    >
       {categories.map((category) => {
         return (
           <CategoryFilter

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/landingPageSearch.module.scss
@@ -1,11 +1,14 @@
 @use '../../../styles/breakpoints' as breakpoints;
 
 .landingPageSearch {
+  --color-heroTitle: var(--color-white);
+  --color-heroDescription: var(--color-brick-light);
+
   margin-top: -13.5rem;
   background-color: rgba(0, 0, 0, 0.8);
   padding: var(--spacing-l) var(--spacing-m);
   z-index: 1;
-  position: absolute;
+  position: relative;
   width: 100%;
 
   @include breakpoints.respond-above(s) {
@@ -21,16 +24,20 @@
     font-weight: 500;
     margin-top: 0;
     margin-bottom: var(--spacing-l);
-    color: var(--color-white);
+    color: var(--color-heroTitle);
+  }
+
+  p {
+    color: var(--color-heroDescription);
+    margin-bottom: var(--spacing-l);
   }
 }
 
 .categoriesWrapper {
   position: relative;
-  top: 2.8rem;
   z-index: 0;
-  padding-top: 4rem;
-  padding-bottom: 3rem;
+  padding-top: 2rem;
+  padding-bottom: 1rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-gap: 1rem;
@@ -40,18 +47,18 @@
   @include breakpoints.respond-below(m) {
     display: flex;
     flex-direction: column;
-    padding-top: 0;
+    padding-top: 2.8rem;
     grid-gap: 2px;
     padding-bottom: 3rem;
   }
 
   @include breakpoints.respond-above(s) {
-    padding-top: 12rem;
+    padding-top: 2rem;
   }
 
   @include breakpoints.respond-above(m) {
     grid-template-columns: 1fr 1fr 1fr;
-    padding-top: 4rem;
+    padding-top: 2rem;
   }
 
   @include breakpoints.respond-above(l) {
@@ -62,5 +69,17 @@
     @include breakpoints.respond-below(m) {
       grid-column-start: 2;
     }
+  }
+}
+.pageContent {
+  margin: var(--spacing-5-xl) var(--spacing-m) 0;
+  color: var(--color-black);
+
+  p {
+    font-size: var(--fontsize-body-l);
+  }
+
+  p:only-of-type {
+    margin-bottom: 0;
   }
 }

--- a/apps/sports-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
+++ b/apps/sports-helsinki/src/domain/search/landingPageSearch/landingPageSearchForm.module.scss
@@ -90,3 +90,6 @@
     }
   }
 }
+.withDescription {
+  margin-bottom: var(--spacing-s) !important;
+}

--- a/apps/sports-helsinki/src/domain/search/venueSearch/SearchPage.tsx
+++ b/apps/sports-helsinki/src/domain/search/venueSearch/SearchPage.tsx
@@ -66,7 +66,7 @@ const VenueSearchPage: React.FC<SearchPageProps> = ({
         favIconSvgUrl={meta?.favIconSvgUrl}
         manifestUrl={meta?.manifestUrl}
       />
-      <SrOnly as="h1">{pageTitle}</SrOnly>
+      <SrOnly as="h2">{pageTitle}</SrOnly>
       {SearchComponent && (
         <SearchComponent
           scrollToResultList={scrollToResultList}
@@ -74,7 +74,7 @@ const VenueSearchPage: React.FC<SearchPageProps> = ({
           searchUtilities={
             <VenueSearchUtilities switchShowMode={switchShowMode} />
           }
-          showTitle
+          title={pageTitle}
           korosBottom
         />
       )}

--- a/apps/sports-helsinki/src/domain/search/venueSearch/VenueMapSearch.tsx
+++ b/apps/sports-helsinki/src/domain/search/venueSearch/VenueMapSearch.tsx
@@ -1,18 +1,25 @@
+import { useSearchTranslation } from '@events-helsinki/components';
+import { usePageContext } from 'react-helsinki-headless-cms';
 import { SEARCH_ROUTES } from '../../../constants';
 import styles from './search.module.scss';
 import SimpleVenueSearch from './VenueSearch';
 export const searchContainerDataTestId = 'mapSearchContainer';
 
-const SimpleVenueMapSearch = () => (
-  <SimpleVenueSearch
-    data-testid={searchContainerDataTestId}
-    searchRoute={SEARCH_ROUTES.MAPSEARCH}
-    searchUtilities={null}
-    korosBottom={false}
-    showTitle
-    className={styles.mapView}
-    scrollToResultList={() => true}
-  />
-);
-
+const SimpleVenueMapSearch = () => {
+  const { t } = useSearchTranslation();
+  const { page } = usePageContext();
+  const fallbackTitle = t('search:search.titlePage');
+  const title = page?.title?.trim() || fallbackTitle;
+  return (
+    <SimpleVenueSearch
+      data-testid={searchContainerDataTestId}
+      searchRoute={SEARCH_ROUTES.MAPSEARCH}
+      searchUtilities={null}
+      korosBottom={false}
+      title={title}
+      className={styles.mapView}
+      scrollToResultList={() => true}
+    />
+  );
+};
 export default SimpleVenueMapSearch;

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -20,6 +20,7 @@ import type { PageType } from 'react-helsinki-headless-cms';
 import {
   Page as RHHCPage,
   getBreadcrumbsFromPage,
+  getTextFromHtml,
 } from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
@@ -51,6 +52,10 @@ const Search: NextPage<{
     }
   );
 
+  const pageTitle = page?.title?.trim() || undefined;
+  const pageDescription =
+    getTextFromHtml(page?.content ?? '')?.trim() || undefined;
+
   return (
     <RHHCPage
       className="pageLayout"
@@ -64,7 +69,11 @@ const Search: NextPage<{
             image={page?.featuredImage?.node?.mediaItemUrl || ''}
           />
           {breadcrumbs && <BreadcrumbContainer breadcrumbs={breadcrumbs} />}
-          <CombinedSearchPageNoSSR defaultTab="Venue" />
+          <CombinedSearchPageNoSSR
+            defaultTab="Venue"
+            pageTitle={pageTitle}
+            pageDescription={pageDescription}
+          />
         </>
       }
       footer={

--- a/apps/sports-helsinki/src/pages/search/map.tsx
+++ b/apps/sports-helsinki/src/pages/search/map.tsx
@@ -15,7 +15,11 @@ import { useRouter } from 'next/router';
 import queryString from 'query-string';
 import React from 'react';
 import type { PageType } from 'react-helsinki-headless-cms';
-import { PageSection, Page as RHHCPage } from 'react-helsinki-headless-cms';
+import {
+  PageContextProvider,
+  PageSection,
+  Page as RHHCPage,
+} from 'react-helsinki-headless-cms';
 import type {
   PageQuery,
   PageQueryVariables,
@@ -138,7 +142,7 @@ export default function MapSearch({ page }: { page: PageType }) {
       className="pageLayout"
       navigation={<Navigation />}
       content={
-        <>
+        <PageContextProvider page={page}>
           <RouteMeta origin={AppConfig.origin} />
           <PageMeta
             {...page?.seo}
@@ -147,7 +151,7 @@ export default function MapSearch({ page }: { page: PageType }) {
           <CombinedSearchProvider>
             <MapSearchPageContent />
           </CombinedSearchProvider>
-        </>
+        </PageContextProvider>
       }
       footer={null}
     />

--- a/packages/common-i18n/src/locales/en/appSports.json
+++ b/packages/common-i18n/src/locales/en/appSports.json
@@ -32,6 +32,7 @@
     "pageTitle": "Find sport",
     "search": {
       "placeholder": "Enter a keyword, eg. swimming hall or yoga"
-    }
+    },
+    "descriptionSearchTabs": "Select venues, events or hobbies:"
   }
 }

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -34,6 +34,8 @@
     "titleDropdownPlace": "Search venue",
     "placeholder": "Enter a keyword, eg. French or cooking",
     "labelSearchField": "What are you looking for?",
+    "titlePage": "What are you looking for?",
+    "descriptionPage": "",
     "checkboxAlsoOngoingCourses": "Show also ongoing courses",
     "checkboxIsFree": "Show only courses that are free",
     "titleDropdownTargetGroup": "Target group",

--- a/packages/common-i18n/src/locales/fi/appSports.json
+++ b/packages/common-i18n/src/locales/fi/appSports.json
@@ -32,6 +32,7 @@
     "pageTitle": "Löydä liikuntaa",
     "search": {
       "placeholder": "Kirjoita hakusana, esim. uimahalli tai jooga"
-    }
+    },
+    "descriptionSearchTabs": "Valitse paikat, tapahtumat tai harrastukset:"
   }
 }

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -47,6 +47,8 @@
     "titleDropdownPlace": "Etsi tapahtumapaikka",
     "placeholder": "Kirjoita hakusana, esim. ranska tai ruoanlaitto",
     "labelSearchField": "Mitä etsit?",
+    "titlePage": "Mitä etsit?",
+    "descriptionPage": "",
     "checkboxAlsoOngoingCourses": "Näytä myös meneillään olevat",
     "checkboxIsFree": "Näytä vain maksuttomat",
     "titleDropdownTargetGroup": "Kohderyhmä",

--- a/packages/common-i18n/src/locales/sv/appSports.json
+++ b/packages/common-i18n/src/locales/sv/appSports.json
@@ -32,6 +32,7 @@
     "pageTitle": "Hitta motion",
     "search": {
       "placeholder": "Ange ett sökord, t. ex. simhall eller yoga"
-    }
+    },
+    "descriptionSearchTabs": "Välj platser, evenemang eller hobbyer:"
   }
 }

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -35,6 +35,8 @@
     "checkboxIsFree": "Visa endast avgiftsfria",
     "placeholder": "Ange ett sökord, t. ex. Franska eller matlagning",
     "labelSearchField": "Vad letar du efter?",
+    "titlePage": "Vad letar du efter?",
+    "descriptionPage": "",
     "checkboxAlsoOngoingCourses": "Visa även pågående kurser",
     "titleDropdownTargetGroup": "Målgrupp",
     "titleDropdownSportsCategory": "Typ av sport",

--- a/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
+++ b/packages/common-tests/browser-tests/page-model/eventSearchPage.ts
@@ -138,7 +138,7 @@ class EventSearchPage {
   public async verify() {
     // eslint-disable-next-line no-console
     console.info('EventSearchPage: verify');
-    await t.expect(this.searchFormHeading.exists).ok();
+    await t.expect(this.textSearchInput.exists).ok();
   }
 }
 

--- a/packages/common-tests/browser-tests/page-model/landingPage.ts
+++ b/packages/common-tests/browser-tests/page-model/landingPage.ts
@@ -16,14 +16,6 @@ class LandingPage {
     console.log('LandingPage: verify');
     const searchPlaceholderText = i18n.t(`home:search.placeholder`);
 
-    await t
-      .expect(
-        screen.getByRole('heading', {
-          name: i18n.t(`${this.appNamespace}:home.search.title`) ?? '',
-        }).exists
-      )
-      .ok();
-
     const searchInput = screen.findByPlaceholderText(searchPlaceholderText);
 
     // NOTE: There is some debounce wait time set to the search

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "^8.4.0",
     "react-dom": "18.3.1",
     "react-error-boundary": "4.0.10",
-    "react-helsinki-headless-cms": "1.2.1",
+    "react-helsinki-headless-cms": "1.3.0",
     "react-i18next": "15.6.0",
     "react-leaflet": "4.2.1",
     "react-toastify": "^11.0.5",

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -73,3 +73,4 @@ export { default as EventPageMeta } from './eventPageMeta/EventPageMeta';
 export { default as PreviewNotification } from './previewNotification/PreviewNotification';
 export { default as UserTrackingFeatures } from './widgets/UserTrackingFeatures';
 export * from './advancedSearch';
+export { default as CmsPageContent } from './landingPage/CmsPageContent';

--- a/packages/components/src/components/landingPage/CmsPageContent.tsx
+++ b/packages/components/src/components/landingPage/CmsPageContent.tsx
@@ -1,0 +1,42 @@
+import { HtmlToReact, usePageContext } from 'react-helsinki-headless-cms';
+
+type CmsPageContentProps = {
+  /**
+   * An optional CSS class name to apply to the wrapping `div` element.
+   */
+  className?: string;
+};
+
+/**
+ * Loads the 'content' field from the current CMS page (via `usePageContext`)
+ * and renders the HTML content as React components using `<HtmlToReact>`.
+ *
+ * This component automatically handles:
+ * - Safely accessing `page.content`.
+ * - Trimming whitespace from the content.
+ * - Rendering `null` (nothing) if the content is empty, just whitespace, or undefined.
+ *
+ * The rendered content is wrapped in a `div` that accepts a `className` for styling.
+ */
+const CmsPageContent = ({ className }: CmsPageContentProps) => {
+  const { page } = usePageContext();
+
+  // Safely access and trim the content.
+  // This will be `undefined` if `page` or `content` is missing.
+  // It will be `""` (a falsy value) if the content is just whitespace.
+  const pageContent = page?.content?.trim();
+
+  // If there's no content, render nothing.
+  if (!pageContent) {
+    return null;
+  }
+
+  // Render the content inside the styled div
+  return (
+    <div className={className}>
+      <HtmlToReact>{pageContent}</HtmlToReact>
+    </div>
+  );
+};
+
+export default CmsPageContent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3171,7 +3171,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.2.1"
+    react-helsinki-headless-cms: "npm:1.3.0"
     react-i18next: "npm:15.6.0"
     react-leaflet: "npm:4.2.1"
     react-toastify: "npm:^11.0.5"
@@ -13434,7 +13434,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.2.1"
+    react-helsinki-headless-cms: "npm:1.3.0"
     react-i18next: "npm:15.6.0"
     react-scroll: "npm:^1.9.3"
     react-toastify: "npm:^11.0.5"
@@ -15176,7 +15176,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.2.1"
+    react-helsinki-headless-cms: "npm:1.3.0"
     react-i18next: "npm:15.6.0"
     react-scroll: "npm:^1.9.3"
     react-toastify: "npm:^11.0.5"
@@ -21367,9 +21367,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-helsinki-headless-cms@npm:1.2.1":
-  version: 1.2.1
-  resolution: "react-helsinki-headless-cms@npm:1.2.1"
+"react-helsinki-headless-cms@npm:1.3.0":
+  version: 1.3.0
+  resolution: "react-helsinki-headless-cms@npm:1.3.0"
   dependencies:
     classnames: "npm:^2.5.1"
     hds-design-tokens: "npm:^3.11.0"
@@ -21387,7 +21387,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: bb3f3eed472a10fcbcebfa4f8f695041061124319402374a236f0e60e63685357a5d305f120f73d75cb9faa0db59f10ddc66fdd4d386bf26f9f208e00fd4dce6
+  checksum: de476f2bdf679fae34bcd9a41249fea51b6846076375b6e8438533f5e6fb9f715185b0f0529d1ca8c96a9345c9aaf13f5dc76c9fe4f6669846ca57d93ea6e7f5
   languageName: node
   linkType: hard
 
@@ -23512,7 +23512,7 @@ __metadata:
     react-datepicker: "npm:^8.4.0"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:4.0.10"
-    react-helsinki-headless-cms: "npm:1.2.1"
+    react-helsinki-headless-cms: "npm:1.3.0"
     react-i18next: "npm:15.6.0"
     react-leaflet: "npm:4.2.1"
     react-scroll: "npm:^1.9.3"


### PR DESCRIPTION
LIIKUNTA-661 LIIKUNTA-755.

Updated HCRC-lib to get new utilities.

Landing page changes:
1. Use hero title as H1 in a search form that is floating on hero element. Old (hard coded production env) translation as default.
2. Use hero description under the hero title. Empty by default.
3. Remove absolute positions, reposition and style the elements related to hero-form-shortcuts -section.
4. Use page content from CMS over shortcuts. It can be used as plain body text or as a description for shortcuts area.
5. Hide the shortcuts and new page content -section on small screens.

Search page changes:
1. Use search page title as H1 in a search form. Old (hard coded production env) translation as default.
2. Render search page content from CMS as text in 1 paragraph under the title.
3. Add a new hard coded text above tabs to describe that section.
