### PR TITLE
In-app back navigation arrow should be hidden when referrer is from external domain

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -8,6 +8,7 @@ import {
   getLocaleFromPathname,
   isVenueHelsinkiCityOwned,
   HelsinkiCityOwnedIcon,
+  useShouldShowAppBackArrow,
 } from '@events-helsinki/components';
 import type { ReturnParams } from '@events-helsinki/components/utils/eventQueryString.util';
 import { extractLatestReturnPath } from '@events-helsinki/components/utils/eventQueryString.util';
@@ -47,16 +48,14 @@ const ReturnPathNavBackArrow: React.FC = () => {
   };
 
   return (
-    <div className={styles.backButtonWrapper}>
-      <IconButton
-        role="link"
-        ariaLabel={t('venue:hero.ariaLabelBackButton')}
-        backgroundColor="white"
-        icon={<IconArrowLeft aria-hidden />}
-        onClick={() => goBack(returnParam)}
-        size="default"
-      />
-    </div>
+    <IconButton
+      role="link"
+      ariaLabel={t('venue:hero.ariaLabelBackButton')}
+      backgroundColor="white"
+      icon={<IconArrowLeft aria-hidden />}
+      onClick={() => goBack(returnParam)}
+      size="default"
+    />
   );
 };
 
@@ -64,7 +63,7 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
   const { t: commonTranslation } = useTranslation('common');
   const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
-
+  const shouldShowAppBackArrow = useShouldShowAppBackArrow();
   const isHelsinkiCityOwned = isVenueHelsinkiCityOwned(venue);
   const imageUrl = venue.image ? getSecureImage(venue.image) : '';
   const { streetAddress, addressLocality, connections, openingHours } = venue;
@@ -110,7 +109,9 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
     <PageSection className={classNames(styles.heroSection)}>
       <ContentContainer className={styles.contentContainer}>
         <div className={styles.contentWrapper}>
-          <ReturnPathNavBackArrow />
+          <div className={styles.backButtonWrapper}>
+            {shouldShowAppBackArrow && <ReturnPathNavBackArrow />}
+          </div>
           <div>
             <BackgroundImage
               className={styles.image}

--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -31,10 +31,8 @@ export interface Props {
   venue: Venue;
 }
 
-const VenueHero: React.FC<Props> = ({ venue }) => {
+const ReturnPathNavBackArrow: React.FC = () => {
   const { t } = useVenueTranslation();
-  const { t: commonTranslation } = useTranslation('common');
-  const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
   const router = useRouter();
   const search = router.asPath.split('?')[1];
@@ -47,6 +45,25 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
     const goBackUrlLocale = getLocaleFromPathname(goBackUrl);
     router.push(goBackUrl, undefined, { locale: goBackUrlLocale });
   };
+
+  return (
+    <div className={styles.backButtonWrapper}>
+      <IconButton
+        role="link"
+        ariaLabel={t('venue:hero.ariaLabelBackButton')}
+        backgroundColor="white"
+        icon={<IconArrowLeft aria-hidden />}
+        onClick={() => goBack(returnParam)}
+        size="default"
+      />
+    </div>
+  );
+};
+
+const VenueHero: React.FC<Props> = ({ venue }) => {
+  const { t: commonTranslation } = useTranslation('common');
+  const { fallbackImageUrls } = useConfig();
+  const locale = useLocale();
 
   const isHelsinkiCityOwned = isVenueHelsinkiCityOwned(venue);
   const imageUrl = venue.image ? getSecureImage(venue.image) : '';
@@ -93,16 +110,7 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
     <PageSection className={classNames(styles.heroSection)}>
       <ContentContainer className={styles.contentContainer}>
         <div className={styles.contentWrapper}>
-          <div className={styles.backButtonWrapper}>
-            <IconButton
-              role="link"
-              ariaLabel={t('venue:hero.ariaLabelBackButton')}
-              backgroundColor="white"
-              icon={<IconArrowLeft aria-hidden />}
-              onClick={() => goBack(returnParam)}
-              size="default"
-            />
-          </div>
+          <ReturnPathNavBackArrow />
           <div>
             <BackgroundImage
               className={styles.image}

--- a/packages/components/src/components/eventHero/EventHero.tsx
+++ b/packages/components/src/components/eventHero/EventHero.tsx
@@ -242,20 +242,11 @@ export const OfferButton: React.FC<
   );
 };
 
-const EventHero: React.FC<EventHeroProps> = ({
-  event,
-  superEvent,
-  withActions = true,
-}) => {
+const ReturnPathNavBackArrow: React.FC = () => {
   const { t } = useTranslation('event');
-  const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
   const router = useRouter();
   const search = router.asPath.split('?')[1];
-
-  const { imageUrl, keywords, today, thisWeek } = getEventFields(event, locale);
-
-  const showKeywords = Boolean(today || thisWeek || keywords.length);
   const returnParam = extractLatestReturnPath(search, `/${locale}`);
 
   const goBack = ({ returnPath, remainingQueryString = '' }: ReturnParams) => {
@@ -267,19 +258,36 @@ const EventHero: React.FC<EventHeroProps> = ({
   };
 
   return (
+    <div className={styles.backButtonWrapper}>
+      <IconButton
+        role="link"
+        ariaLabel={t('hero.ariaLabelBackButton')}
+        backgroundColor="white"
+        icon={<IconArrowLeft aria-hidden />}
+        onClick={() => goBack(returnParam)}
+        size="default"
+      />
+    </div>
+  );
+};
+
+const EventHero: React.FC<EventHeroProps> = ({
+  event,
+  superEvent,
+  withActions = true,
+}) => {
+  const { fallbackImageUrls } = useConfig();
+  const locale = useLocale();
+
+  const { imageUrl, keywords, today, thisWeek } = getEventFields(event, locale);
+
+  const showKeywords = Boolean(today || thisWeek || keywords.length);
+
+  return (
     <PageSection className={classNames(styles.heroSection)}>
       <ContentContainer className={styles.contentContainer}>
         <div className={styles.contentWrapper}>
-          <div className={styles.backButtonWrapper}>
-            <IconButton
-              role="link"
-              ariaLabel={t('hero.ariaLabelBackButton')}
-              backgroundColor="white"
-              icon={<IconArrowLeft aria-hidden />}
-              onClick={() => goBack(returnParam)}
-              size="default"
-            />
-          </div>
+          <ReturnPathNavBackArrow />
           <div>
             <BackgroundImage
               className={styles.image}

--- a/packages/components/src/components/eventHero/EventHero.tsx
+++ b/packages/components/src/components/eventHero/EventHero.tsx
@@ -31,6 +31,7 @@ import InfoWithIcon from '../../components/infoWithIcon/InfoWithIcon';
 import SkeletonLoader from '../../components/skeletonLoader/SkeletonLoader';
 import { EnrolmentStatusLabel } from '../../constants';
 import useLocale from '../../hooks/useLocale';
+import useShouldShowAppBackArrow from '../../hooks/useShouldShowAppBackArrow';
 import { useAppThemeContext } from '../../themeProvider';
 import type { EventFields, SuperEventResponse } from '../../types/event-types';
 import { extractLatestReturnPath } from '../../utils/eventQueryString.util';
@@ -258,16 +259,14 @@ const ReturnPathNavBackArrow: React.FC = () => {
   };
 
   return (
-    <div className={styles.backButtonWrapper}>
-      <IconButton
-        role="link"
-        ariaLabel={t('hero.ariaLabelBackButton')}
-        backgroundColor="white"
-        icon={<IconArrowLeft aria-hidden />}
-        onClick={() => goBack(returnParam)}
-        size="default"
-      />
-    </div>
+    <IconButton
+      role="link"
+      ariaLabel={t('hero.ariaLabelBackButton')}
+      backgroundColor="white"
+      icon={<IconArrowLeft aria-hidden />}
+      onClick={() => goBack(returnParam)}
+      size="default"
+    />
   );
 };
 
@@ -278,7 +277,7 @@ const EventHero: React.FC<EventHeroProps> = ({
 }) => {
   const { fallbackImageUrls } = useConfig();
   const locale = useLocale();
-
+  const shouldShowAppBackArrow = useShouldShowAppBackArrow();
   const { imageUrl, keywords, today, thisWeek } = getEventFields(event, locale);
 
   const showKeywords = Boolean(today || thisWeek || keywords.length);
@@ -287,7 +286,9 @@ const EventHero: React.FC<EventHeroProps> = ({
     <PageSection className={classNames(styles.heroSection)}>
       <ContentContainer className={styles.contentContainer}>
         <div className={styles.contentWrapper}>
-          <ReturnPathNavBackArrow />
+          <div className={styles.backButtonWrapper}>
+            {shouldShowAppBackArrow && <ReturnPathNavBackArrow />}
+          </div>
           <div>
             <BackgroundImage
               className={styles.image}

--- a/packages/components/src/hooks/__tests__/useShouldShowAppBackArrow.test.ts
+++ b/packages/components/src/hooks/__tests__/useShouldShowAppBackArrow.test.ts
@@ -1,0 +1,153 @@
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+
+import useShouldShowAppBackArrow from '../useShouldShowAppBackArrow';
+
+// JSDOM doesn't implement PerformanceNavigationTiming, so we need to mock it.
+class MockPerformanceNavigationTiming {
+  readonly type: PerformanceNavigationTiming['type'];
+  readonly entryType = 'navigation' as const;
+  readonly name = '';
+  readonly startTime = 0;
+  readonly duration = 0;
+  readonly initiatorType = 'navigation' as const;
+  readonly nextHopProtocol = '';
+  readonly workerStart = 0;
+  readonly redirectStart = 0;
+  readonly redirectEnd = 0;
+  readonly fetchStart = 0;
+  readonly domainLookupStart = 0;
+  readonly domainLookupEnd = 0;
+  readonly connectStart = 0;
+  readonly connectEnd = 0;
+  readonly secureConnectionStart = 0;
+  readonly requestStart = 0;
+  readonly responseStart = 0;
+  readonly responseEnd = 0;
+  readonly transferSize = 0;
+  readonly encodedBodySize = 0;
+  readonly decodedBodySize = 0;
+  readonly serverTiming = [];
+  readonly unloadEventStart = 0;
+  readonly unloadEventEnd = 0;
+  readonly domInteractive = 0;
+  readonly domContentLoadedEventStart = 0;
+  readonly domContentLoadedEventEnd = 0;
+  readonly domComplete = 0;
+  readonly loadEventStart = 0;
+  readonly loadEventEnd = 0;
+  toJSON = () => ({});
+
+  constructor(type: PerformanceNavigationTiming['type']) {
+    this.type = type;
+  }
+}
+
+const mockPerformanceNavigationTiming = (
+  type: PerformanceNavigationTiming['type']
+) => {
+  vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+    new MockPerformanceNavigationTiming(type),
+  ] as any);
+};
+
+describe('useShouldShowAppBackArrow', () => {
+  const originalReferrer = document.referrer;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Mock window.location.origin
+    vi.stubGlobal('location', {
+      ...originalLocation,
+      origin: 'http://localhost:3000',
+    });
+    vi.stubGlobal(
+      'PerformanceNavigationTiming',
+      MockPerformanceNavigationTiming
+    );
+  });
+
+  afterEach(() => {
+    // Restore mocks
+    vi.unstubAllGlobals();
+    Object.defineProperty(document, 'referrer', {
+      value: originalReferrer,
+      configurable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('should return false on initial render (SSR safety)', () => {
+    // For this specific test, we want to prevent the useEffect from running
+    // to accurately test the initial state before any client-side effects.
+    const useEffectSpy = vi
+      .spyOn(React, 'useEffect')
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useShouldShowAppBackArrow());
+
+    expect(result.current).toBe(false);
+
+    useEffectSpy.mockRestore();
+  });
+
+  it('should return true for client-side navigation', () => {
+    // 'push' is not a valid type, client-side nav is not a 'full page load'
+    mockPerformanceNavigationTiming('back_forward'); // or 'reload'
+    const { result } = renderHook(() => useShouldShowAppBackArrow());
+    act(() => {
+      // The effect runs here
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('should return true for page reloads', () => {
+    mockPerformanceNavigationTiming('reload');
+    const { result } = renderHook(() => useShouldShowAppBackArrow());
+    act(() => {});
+    expect(result.current).toBe(true);
+  });
+
+  it('should return false for a full page load from an external referrer', () => {
+    mockPerformanceNavigationTiming('navigate');
+    Object.defineProperty(document, 'referrer', {
+      value: 'https://www.google.com',
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useShouldShowAppBackArrow());
+    act(() => {});
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true for a full page load from an internal referrer', () => {
+    mockPerformanceNavigationTiming('navigate');
+    Object.defineProperty(document, 'referrer', {
+      value: 'http://localhost:3000/previous-page',
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useShouldShowAppBackArrow());
+    act(() => {});
+    expect(result.current).toBe(true);
+  });
+
+  it('should return true for a direct navigation (e.g., bookmark or typed URL)', () => {
+    mockPerformanceNavigationTiming('navigate');
+    Object.defineProperty(document, 'referrer', {
+      value: '',
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useShouldShowAppBackArrow());
+    act(() => {});
+    expect(result.current).toBe(true);
+  });
+
+  it('should return true if PerformanceNavigationTiming API is not available', () => {
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([]);
+    const { result } = renderHook(() => useShouldShowAppBackArrow());
+    act(() => {});
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -29,3 +29,4 @@ export { default as useSuperEventLazyLoad } from './useSuperEventLazyLoad';
 export { default as useGeolocation } from './useGeolocation';
 export { default as useClearClosedEventsFromApolloCache } from './useClearClosedEventsFromApolloCache';
 export { default as usePreview } from './usePreview';
+export { default as useShouldShowAppBackArrow } from './useShouldShowAppBackArrow';

--- a/packages/components/src/hooks/useShouldShowAppBackArrow.ts
+++ b/packages/components/src/hooks/useShouldShowAppBackArrow.ts
@@ -1,0 +1,49 @@
+import React from 'react';
+
+/**
+ * Determines whether a custom in-app "back" arrow should be rendered.
+ *
+ * This hook is designed to solve a specific UI problem:
+ * We want to show our app's custom back navigation (e.g., "<- Back to search")
+ * for internal navigation and direct page loads (bookmarks, typed URLs),
+ * but we want to *hide* it if the user landed on this page from an
+ * external domain. This prevents confusing the user, as our in-app arrow
+ * would not take them back to the external site (only the browser's back
+ * button can do that).
+ *
+ * @returns {boolean} `showAppBackArrow`
+ * - `true`: If the user navigated internally OR arrived directly
+ * (e.g., bookmark, typed URL, or page reload).
+ * - `false`: If the user landed from an external domain.
+ */
+const useShouldShowAppBackArrow = (): boolean => {
+  // Default to `false` (no arrow) for the server-side render
+  // and the initial client render. This is crucial to prevent
+  // a React hydration mismatch.
+  const [showAppBackArrow, setShowAppBackArrow] = React.useState(false);
+
+  React.useEffect(() => {
+    // This effect runs *only* on the client, after hydration.
+
+    const referrer = document.referrer; // e.g., "https://www.google.com/" or ""
+    const origin = window.location.origin; // e.g., "https://tapahtumat.hel.fi"
+
+    const isExternalReferrer = referrer && !referrer.startsWith(origin);
+
+    if (isExternalReferrer) {
+      // The user came from an external site.
+      setShowAppBackArrow(false);
+    } else {
+      // This `else` block covers all other cases where we *want* the arrow:
+      // a) Internal navigation: `referrer` starts with our `origin`.
+      // b) Direct navigation: `referrer` is an empty string `""`.
+      // c) Page reload: `referrer` is our own URL (or empty in some cases).
+      // In all these cases, we want to show the app's back button.
+      setShowAppBackArrow(true);
+    }
+  }, []); // Run only once on mount.
+
+  return showAppBackArrow;
+};
+
+export default useShouldShowAppBackArrow;

--- a/packages/components/src/hooks/useShouldShowAppBackArrow.ts
+++ b/packages/components/src/hooks/useShouldShowAppBackArrow.ts
@@ -3,45 +3,74 @@ import React from 'react';
 /**
  * Determines whether a custom in-app "back" arrow should be rendered.
  *
- * This hook is designed to solve a specific UI problem:
- * We want to show our app's custom back navigation (e.g., "<- Back to search")
- * for internal navigation and direct page loads (bookmarks, typed URLs),
- * but we want to *hide* it if the user landed on this page from an
- * external domain. This prevents confusing the user, as our in-app arrow
- * would not take them back to the external site (only the browser's back
- * button can do that).
+ * This hook is designed to solve a specific UI problem where
+ * an in-app custom back navigation (e.g., "<- Back to list")
+ * should be shown for internal navigation and direct page loads (bookmarks, typed URLs),
+ * but hidden if the user landed *directly* on this page
+ * from an external domain.
+ *
+ * This hook correctly handles client-side (Next.js) navigation.
  *
  * @returns {boolean} `showAppBackArrow`
- * - `true`: If the user navigated internally OR arrived directly
- * (e.g., bookmark, typed URL, or page reload).
- * - `false`: If the user landed from an external domain.
+ * - `true`: If the user navigated internally (client-side) OR arrived
+ * directly (bookmark, typed URL, or internal full refresh).
+ * - `false`: If the user landed on this page from an external domain.
  */
-const useShouldShowAppBackArrow = (): boolean => {
-  // Default to `false` (no arrow) for the server-side render
-  // and the initial client render. This is crucial to prevent
-  // a React hydration mismatch.
+const useShouldShowAppBackArrow = () => {
+  // 1. Default to `false` (no arrow) for SSR and initial render
+  //    to prevent a React hydration mismatch.
   const [showAppBackArrow, setShowAppBackArrow] = React.useState(false);
 
   React.useEffect(() => {
     // This effect runs *only* on the client, after hydration.
 
-    const referrer = document.referrer; // e.g., "https://www.google.com/" or ""
-    const origin = window.location.origin; // e.g., "https://tapahtumat.hel.fi"
+    // A determination is needed as to whether this component mount was due to:
+    // 1. A CLIENT-SIDE navigation (e.g., <Link> or router.push)
+    // 2. A FULL PAGE LOAD (e.g., external link, bookmark, typed URL)
 
-    const isExternalReferrer = referrer && !referrer.startsWith(origin);
+    let isFullPageLoad = false;
 
-    if (isExternalReferrer) {
-      // The user came from an external site.
-      setShowAppBackArrow(false);
+    // Use the modern PerformanceNavigationTiming API.
+    // If this API is not supported, `isFullPageLoad` will remain `false`,
+    // and the hook will safely default to showing the back arrow.
+    if (performance.getEntriesByType) {
+      const navigationEntries = performance.getEntriesByType('navigation');
+
+      if (navigationEntries.length > 0) {
+        const entry = navigationEntries[0];
+
+        // Use `instanceof` for a robust, runtime type check.
+        // This confirms 'entry' is the specific object type expected.
+        if (entry instanceof PerformanceNavigationTiming) {
+          isFullPageLoad = entry.type === 'navigate';
+        }
+      }
+    }
+
+    if (isFullPageLoad) {
+      // This was a FULL PAGE LOAD.
+      // The referrer must now be checked to determine *where* the user came from.
+      const referrer = document.referrer;
+      const origin = window.location.origin;
+
+      // An external referrer is one that exists AND is not our own origin.
+      const isExternalReferrer = referrer && !referrer.startsWith(origin);
+
+      if (isExternalReferrer) {
+        // Full page load from an external site (e.g., Google). HIDE arrow.
+        setShowAppBackArrow(false);
+      } else {
+        // Full page load from an internal site OR a direct navigation
+        // (empty referrer). In both cases, SHOW arrow.
+        setShowAppBackArrow(true);
+      }
     } else {
-      // This `else` block covers all other cases where we *want* the arrow:
-      // a) Internal navigation: `referrer` starts with our `origin`.
-      // b) Direct navigation: `referrer` is an empty string `""`.
-      // c) Page reload: `referrer` is our own URL (or empty in some cases).
-      // In all these cases, we want to show the app's back button.
+      // This was NOT a full page load.
+      // It was a CLIENT-SIDE navigation, a page reload, or a back/fwd action.
+      // In all these cases, the app's back arrow should be shown.
       setShowAppBackArrow(true);
     }
-  }, []); // Run only once on mount.
+  }, []); // Runs only once on mount.
 
   return showAppBackArrow;
 };


### PR DESCRIPTION
TH-1334.

We want to show our app's custom back navigation (e.g., "<- Back to search") for internal navigation and direct page loads (bookmarks, typed URLs), but we want to *hide* it if the user landed on this page from an external domain. This prevents confusing the user, as our in-app arrow would not take them back to the external site (only the browser's back button can do that).

Since the referrer stays same all the time after the navigation from external site to our site, we cannot follow only the referrer value, but also check whether the navigation happened internally.