### PR TITLE
feat: add "relevance" to event and course search ordering options

### DIFF
--- a/apps/events-helsinki/src/domain/error/errorHero.module.scss
+++ b/apps/events-helsinki/src/domain/error/errorHero.module.scss
@@ -8,7 +8,7 @@
   padding-bottom: 4rem;
   padding-top: 3rem;
 
-  @include breakpoints.respond_above(s) {
+  @include breakpoints.respond-above(s) {
     padding-bottom: 7rem;
     padding-top: 5rem;
   }

--- a/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/searchResultList.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/searchResultList/searchResultList.module.scss
@@ -16,11 +16,11 @@
   margin-bottom: 1.5rem;
   text-align: center;
 
-  @include breakpoints.respond_above(s) {
+  @include breakpoints.respond-above(s) {
     text-align: left;
   }
 
-  @include breakpoints.respond_above(m) {
+  @include breakpoints.respond-above(m) {
     margin-top: 0;
     margin-bottom: 2rem;
   }
@@ -36,7 +36,7 @@
     .loadMoreWrapper {
       margin-top: 1.5rem;
 
-      @include breakpoints.respond_above(s) {
+      @include breakpoints.respond-above(s) {
         margin-top: 0;
       }
     }

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -3,7 +3,6 @@ import type {
   AppLanguage,
   Meta,
   QueryEventListArgs,
-  EVENT_SORT_OPTIONS,
   KeywordOnClickHandlerType,
   Venue,
 } from '@events-helsinki/components';
@@ -16,6 +15,7 @@ import {
   scrollToTop,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID,
   EVENT_SEARCH_FILTERS,
+  EVENT_SORT_OPTIONS,
 } from '@events-helsinki/components';
 import {
   addDays,
@@ -262,7 +262,12 @@ export const getEventSearchVariables = ({
     location: places.sort((a, b) => a.localeCompare(b)),
     pageSize,
     publisher,
-    sort: sortOrder,
+    /**
+     * As per LinkedEvents requirements (see LINK-2422; https://helsinkisolutionoffice.atlassian.net/browse/LINK-2422),
+     * relevance sorting (rank) is activated by providing an *empty string* as the sort parameter when
+     * `x_full_text` is used, not the literal '-rank' value.
+     */
+    sort: sortOrder === EVENT_SORT_OPTIONS.RANK_DESC ? '' : sortOrder,
     start,
     startsAfter,
     superEventType,

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/SearchPage.tsx
@@ -9,11 +9,13 @@ import {
   getLargeEventCardId,
   useEventListQuery,
   MAIN_CONTENT_ID,
-  EVENT_SORT_OPTIONS,
   EventList,
   useClearClosedEventsFromApolloCache,
   HELSINKI_OCD_DIVISION_ID,
   EVENT_SEARCH_FILTERS,
+  EventsOrderBySelect,
+  DEFAULT_EVENT_SORT_OPTION,
+  isEventSortOption,
 } from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
@@ -36,12 +38,15 @@ const useSearchQuery = () => {
     const searchParams = new URLSearchParams(
       queryString.stringify(router.query)
     );
+    const sortParam = searchParams.get('sort');
     const variables: QueryEventListArgs = getEventSearchVariables({
       include: AppConfig.eventSearchQueryIncludeParamValue,
       pageSize: AppConfig.pageSize,
       params: searchParams,
       place: params.place,
-      sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+      sortOrder: isEventSortOption(sortParam)
+        ? sortParam
+        : DEFAULT_EVENT_SORT_OPTION,
       // Always filter with HELSINKI_OCD_DIVISION_ID to limit the results to city of Helsinki events.
       // NOTE: This is not needed if using any `*Ongoing` -filter as
       // they automatically limit the results to city of Helsinki events.
@@ -202,6 +207,7 @@ const SearchPage: React.FC<{
                     loadMoreButtonTheme="coat"
                   />
                 }
+                orderBySelectComponent={<EventsOrderBySelect />}
               />
             )}
           </LoadingSpinner>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/SearchResultsContainer.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/SearchResultsContainer.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useSearchTranslation } from '@events-helsinki/components';
 import React from 'react';
 import { ContentContainer, PageSection } from 'react-helsinki-headless-cms';
 
@@ -9,23 +9,32 @@ interface Props {
   loading: boolean;
   eventsCount: number;
   eventList: React.ReactElement;
+  orderBySelectComponent?: React.ReactElement;
 }
 
 const SearchResultsContainer: React.FC<Props> = ({
   loading,
   eventsCount,
   eventList,
+  orderBySelectComponent,
 }) => {
-  const { t } = useTranslation('search');
+  const { t } = useSearchTranslation();
 
   return (
     <PageSection className={styles.searchResultListContainer}>
       <ContentContainer>
-        <h2 className={styles.count}>
-          {t('textFoundEvents', {
-            count: eventsCount,
-          })}
-        </h2>
+        {!loading && (
+          <div className={styles.row}>
+            <div className={styles.rowGroup}>
+              <h2 className={styles.count}>
+                {t('search:textFoundEvents', {
+                  count: eventsCount,
+                })}
+              </h2>
+              {orderBySelectComponent !== undefined && orderBySelectComponent}
+            </div>
+          </div>
+        )}
         {!!eventsCount && eventList}
         {!loading && <ResultsInfoContainer resultsCount={eventsCount} />}
       </ContentContainer>

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/searchResultList.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/searchResultList/searchResultList.module.scss
@@ -42,3 +42,23 @@
     }
   }
 }
+
+.row {
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+
+  @include breakpoints.respond-above(s) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+.rowGroup {
+  display: contents;
+  align-items: center;
+
+  & > *:not(:last-child) {
+    margin-right: var(--spacing-m);
+  }
+}

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -7,13 +7,13 @@ import {
   scrollToTop,
   EVENT_SEARCH_FILTERS,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID,
+  EVENT_SORT_OPTIONS,
 } from '@events-helsinki/components';
 import type {
   AppLanguage,
   Meta,
   QueryEventListArgs,
   EventFields,
-  EVENT_SORT_OPTIONS,
   KeywordOnClickHandlerType,
   Venue,
 } from '@events-helsinki/components';
@@ -247,7 +247,12 @@ export const getEventSearchVariables = ({
     location: places.sort((a, b) => a.localeCompare(b)),
     pageSize,
     publisher,
-    sort: sortOrder,
+    /**
+     * As per LinkedEvents requirements (see LINK-2422; https://helsinkisolutionoffice.atlassian.net/browse/LINK-2422),
+     * relevance sorting (rank) is activated by providing an *empty string* as the sort parameter when
+     * `x_full_text` is used, not the literal '-rank' value.
+     */
+    sort: sortOrder === EVENT_SORT_OPTIONS.RANK_DESC ? '' : sortOrder,
     start,
     startsAfter,
     superEventType,

--- a/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -1,6 +1,5 @@
 import type {
   AppLanguage,
-  EVENT_SORT_OPTIONS,
   EventFields,
   FilterType,
   KeywordOnClickHandlerType,
@@ -22,6 +21,7 @@ import {
   isEventFields,
   isVenue,
   scrollToTop,
+  EVENT_SORT_OPTIONS,
 } from '@events-helsinki/components';
 import {
   addDays,
@@ -244,7 +244,12 @@ export const getEventSearchVariables = ({
     pageSize,
     publisher,
     publisherAncestor: null,
-    sort: sortOrder,
+    /**
+     * As per LinkedEvents requirements (see LINK-2422; https://helsinkisolutionoffice.atlassian.net/browse/LINK-2422),
+     * relevance sorting (rank) is activated by providing an *empty string* as the sort parameter when
+     * `x_full_text` is used, not the literal '-rank' value.
+     */
+    sort: sortOrder === EVENT_SORT_OPTIONS.RANK_DESC ? '' : sortOrder,
     start,
     superEventType,
     superEvent,

--- a/packages/common-i18n/src/locales/en/search.json
+++ b/packages/common-i18n/src/locales/en/search.json
@@ -9,7 +9,6 @@
     "relevance": "Relevance",
     "distance": "Proximity",
     "endTime": "End time",
-    "lastModifiedTime": "Last modified time",
     "startTime": "Start time",
     "label": "Order"
   },

--- a/packages/common-i18n/src/locales/fi/search.json
+++ b/packages/common-i18n/src/locales/fi/search.json
@@ -22,7 +22,6 @@
     "relevance": "Osuvuuden mukaan",
     "distance": "Lähimmät ensin",
     "endTime": "Loppumisaika",
-    "lastModifiedTime": "Muokattu viimeksi",
     "startTime": "Alkamisaika",
     "label": "Järjestys"
   },

--- a/packages/common-i18n/src/locales/sv/search.json
+++ b/packages/common-i18n/src/locales/sv/search.json
@@ -9,7 +9,6 @@
     "relevance": "Efter relevans",
     "distance": "Närmaste först",
     "endTime": "Sluttid",
-    "lastModifiedTime": "Senast ändrad",
     "startTime": "Starttid",
     "label": "Ordning"
   },

--- a/packages/components/src/components/orderBySelect/EventsOrderBySelect.tsx
+++ b/packages/components/src/components/orderBySelect/EventsOrderBySelect.tsx
@@ -26,6 +26,10 @@ const EventsOrderBySelect: React.FC<{
       value: EVENT_SORT_OPTIONS.END_TIME,
     },
     {
+      text: t('search:orderBy.relevance'),
+      value: EVENT_SORT_OPTIONS.RANK_DESC,
+    },
+    {
       text: t('search:orderBy.lastModifiedTime'),
       value: EVENT_SORT_OPTIONS.LAST_MODIFIED_TIME_DESC,
     },

--- a/packages/components/src/components/orderBySelect/EventsOrderBySelect.tsx
+++ b/packages/components/src/components/orderBySelect/EventsOrderBySelect.tsx
@@ -30,10 +30,6 @@ const EventsOrderBySelect: React.FC<{
       value: EVENT_SORT_OPTIONS.RANK_DESC,
     },
     {
-      text: t('search:orderBy.lastModifiedTime'),
-      value: EVENT_SORT_OPTIONS.LAST_MODIFIED_TIME_DESC,
-    },
-    {
       text: t('search:orderBy.startTime'),
       value: EVENT_SORT_OPTIONS.START_TIME,
     },

--- a/packages/components/src/constants/event-constants.ts
+++ b/packages/components/src/constants/event-constants.ts
@@ -27,6 +27,18 @@ export enum EVENT_SORT_OPTIONS {
   LAST_MODIFIED_TIME_DESC = '-last_modified_time',
   START_TIME = 'start_time',
   START_TIME_DESC = '-start_time',
+  /**
+   * NOTE: Rank is effective only when using `x_full_text` -parameter.
+   *
+   * NOTE: Rank should not be explicitly set, but left empty instead, when wanted.
+   * The rank sorting needs a mandatory secondary order field and scoring annotation to queryset,
+   * which are only activated when `x_full_text` -parameter is used and sort-parameter is left empty.
+   *
+   * However, in our own apps' URL we want sort-param to be set and visible, so it needs to be converted on search.
+   *
+   * Ref. [LINK-2422](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2422)
+   * */
+  RANK_DESC = '-rank',
 }
 
 export const isEventSortOption = (


### PR DESCRIPTION
TH-1442.

Add "relevance" as a new ordering option in events and courses search. It is using "-rank" as sort-parameter value, which means descending "rank", which is also the default sort-parameter in LinkedEvents, when a full text search -parameter is used.

Rank sorting option and filter scoring system is effective only when using `x_full_text` -parameter.

Rank should not be explicitly set, but left empty instead, when wanted to be affective. The rank sorting needs a mandatory secondary order field and scoring annotation to queryset, which are only activated when `x_full_text` -parameter is used and sort-parameter is left empty.

Ref.
[LINK-2422](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2422)

<img width="1264" height="911" alt="image" src="https://github.com/user-attachments/assets/77868c3e-09a1-498c-b18c-dc3e831d2130" />

<img width="1246" height="1128" alt="image" src="https://github.com/user-attachments/assets/e334d94a-0338-4e99-8c26-11dc90bd45d7" />


[LINK-2422]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Also, removed the sorting option of `last_modified_time`.