### PR TITLE
fix: remember event search sort ordering value on new search

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchContext.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchContext.tsx
@@ -29,6 +29,8 @@ type SearchFormState = {
   setIsOnlyRemoteEvents: React.Dispatch<React.SetStateAction<boolean>>;
   isFree: boolean;
   setIsFree: React.Dispatch<React.SetStateAction<boolean>>;
+  sortOrder: string;
+  setSortOrder: React.Dispatch<React.SetStateAction<string>>;
 };
 
 export type AdvancedSearchContextType = SearchFormState & {

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
@@ -72,6 +72,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
     isFree,
     setIsFree,
     scrollToResultList,
+    sortOrder,
   } = useAdvancedSearchContext();
 
   const searchFilters = {
@@ -106,6 +107,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
     const filters = {
       ...searchFilters,
       [EVENT_SEARCH_FILTERS.TEXT]: [textSearchInput],
+      sort: sortOrder ?? undefined,
     };
     const search = getSearchQuery(filters);
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/useAdvancedSearchFormState.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/useAdvancedSearchFormState.tsx
@@ -1,4 +1,8 @@
-import { EVENT_SEARCH_FILTERS } from '@events-helsinki/components';
+import {
+  DEFAULT_EVENT_SORT_OPTION,
+  EVENT_SEARCH_FILTERS,
+  isEventSortOption,
+} from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
 import React from 'react';
@@ -6,7 +10,7 @@ import { getSearchFilters } from '../utils';
 
 export function useAdvancedSearchFormState() {
   const router = useRouter();
-  const params: { place?: string } = router.query;
+  const params: { place?: string; sort?: string } = router.query;
   const searchParams = React.useMemo(
     () => new URLSearchParams(queryString.stringify(router.query)),
     [router.query]
@@ -35,6 +39,9 @@ export function useAdvancedSearchFormState() {
   const [isOnlyRemoteEvents, setIsOnlyRemoteEvents] =
     React.useState<boolean>(false);
   const [isFree, setIsFree] = React.useState<boolean>(false);
+  const [sortOrder, setSortOrder] = React.useState<string>(
+    DEFAULT_EVENT_SORT_OPTION
+  );
 
   // Initialize fields when page is loaded
   React.useEffect(() => {
@@ -50,6 +57,12 @@ export function useAdvancedSearchFormState() {
       [EVENT_SEARCH_FILTERS.ONLY_REMOTE_EVENTS]: onlyRemoteEvents,
       [EVENT_SEARCH_FILTERS.IS_FREE]: isFreeEvent,
     } = getSearchFilters(searchParams);
+
+    if (isEventSortOption(params.sort)) {
+      setSortOrder(params.sort);
+    } else {
+      setSortOrder('');
+    }
 
     setSelectedCategories(categories);
     setSelectedTargetAgeGroup(targetAgeGroup ?? '');
@@ -70,6 +83,8 @@ export function useAdvancedSearchFormState() {
   }, [searchParams, params]);
 
   return {
+    sortOrder,
+    setSortOrder,
     categoryInput,
     setCategoryInput,
     placeInput,

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchContext.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchContext.tsx
@@ -25,6 +25,8 @@ type SearchFormState = {
   setTextSearchInput: React.Dispatch<React.SetStateAction<string>>;
   isFree: boolean;
   setIsFree: React.Dispatch<React.SetStateAction<boolean>>;
+  sortOrder: string;
+  setSortOrder: React.Dispatch<React.SetStateAction<string>>;
 };
 
 export type AdvancedSearchContextType = SearchFormState & {

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
@@ -71,6 +71,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
     isFree,
     setIsFree,
     scrollToResultList,
+    sortOrder,
   } = useAdvancedSearchContext();
 
   const searchFilters = {
@@ -101,6 +102,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = () => {
     const filters = {
       ...searchFilters,
       [EVENT_SEARCH_FILTERS.TEXT]: [textSearchInput],
+      sort: sortOrder ?? undefined,
     };
     const search = getSearchQuery(filters);
 

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/useAdvancedSearchFormState.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/useAdvancedSearchFormState.tsx
@@ -1,4 +1,8 @@
-import { EVENT_SEARCH_FILTERS } from '@events-helsinki/components';
+import {
+  DEFAULT_EVENT_SORT_OPTION,
+  EVENT_SEARCH_FILTERS,
+  isEventSortOption,
+} from '@events-helsinki/components';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
 import React from 'react';
@@ -7,7 +11,7 @@ import { clampAgeInput, getSearchFilters } from '../utils';
 
 export function useAdvancedSearchFormState() {
   const router = useRouter();
-  const params: { place?: string } = router.query;
+  const params: { place?: string; sort?: string } = router.query;
   const searchParams = React.useMemo(
     () => new URLSearchParams(queryString.stringify(router.query)),
     [router.query]
@@ -30,6 +34,10 @@ export function useAdvancedSearchFormState() {
   const [textSearchInput, setTextSearchInput] = React.useState('');
   const [isFree, setIsFree] = React.useState<boolean>(false);
 
+  const [sortOrder, setSortOrder] = React.useState<string>(
+    DEFAULT_EVENT_SORT_OPTION
+  );
+
   // Initialize fields when page is loaded
   React.useEffect(() => {
     const {
@@ -49,6 +57,11 @@ export function useAdvancedSearchFormState() {
       places.push(pathPlace);
     }
 
+    if (isEventSortOption(params.sort)) {
+      setSortOrder(params.sort);
+    } else {
+      setSortOrder('');
+    }
     setSelectedCategories(categories);
     setSelectedPlaces(places);
     setSelectedTexts(text || []);
@@ -66,6 +79,8 @@ export function useAdvancedSearchFormState() {
   }, [searchParams, params]);
 
   return {
+    sortOrder,
+    setSortOrder,
     categoryInput,
     setCategoryInput,
     ageInput,


### PR DESCRIPTION
TH-1442.

NOTE: Bases on `TH-1442-hobbies-order-by` branch
