### PR TITLE
Fix remaining cases of incorrect use of respond-* mixins

### DIFF
--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -69,7 +69,7 @@ button {
 .page h1,
 .article-page header > h1 {
   font-size: var(--fontsize-heading-xl) !important;
-  @include breakpoints.respond_below(s) {
+  @include breakpoints.respond-below(s) {
     font-size: var(--fontsize-heading-xl-mobile) !important;
   }
 }

--- a/packages/components/src/components/keyword/keyword.module.scss
+++ b/packages/components/src/components/keyword/keyword.module.scss
@@ -2,7 +2,7 @@
 
 .keyword {
   &.hideOnMobile {
-    @include breakpoints.respond_below(s) {
+    @include breakpoints.respond-below(s) {
       display: none;
     }
   }
@@ -15,7 +15,7 @@
   }
 
   &.blackOnMobile {
-    @include breakpoints.respond_below(s) {
+    @include breakpoints.respond-below(s) {
       background-color: var(--color-black-80);
       color: var(--color-white);
     }


### PR DESCRIPTION
## Description

Fix remaining cases of incorrect use of respond-* mixins in SCSS.

## Additional notes

Originally:
- Haven't tested these in action, but they for sure did not work before, and now they can work.

After PR:
- They actually did work before, because SASS did some magic and thus `respond-above` and `respond_above` were treated the same