### PR TITLE
HH-426 | Unify all LICENSE files' contents

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 City of Helsinki
+Copyright (c) 2020 City of Helsinki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/common-i18n/LICENSE
+++ b/packages/common-i18n/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Sébastien Vanvelthem
+Copyright (c) 2020 City of Helsinki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/common-tests/LICENSE
+++ b/packages/common-tests/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Sébastien Vanvelthem
+Copyright (c) 2020 City of Helsinki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/components/LICENSE
+++ b/packages/components/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Sébastien Vanvelthem
+Copyright (c) 2020 City of Helsinki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/graphql-proxy-server/LICENSE
+++ b/packages/graphql-proxy-server/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 City of Helsinki
+Copyright (c) 2020 City of Helsinki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/proxies/events-graphql-proxy/LICENSE
+++ b/proxies/events-graphql-proxy/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 City of Helsinki
+Copyright (c) 2020 City of Helsinki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/proxies/venue-graphql-proxy/LICENSE
+++ b/proxies/venue-graphql-proxy/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 City of Helsinki
+Copyright (c) 2020 City of Helsinki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description

Unify all LICENSE files' contents

All use now the same year i.e. the events-helsinki-monorepo repository's
first commit's year (2020) and same copyright holder i.e. "City of Helsinki".

## Related

- [HH-426](https://helsinkisolutionoffice.atlassian.net/browse/HH-426)
- https://opensource.org/license/mit
- https://liferay.dev/b/how-and-why-to-properly-write-copyright-statements-in-your-code 

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-426]: https://helsinkisolutionoffice.atlassian.net/browse/HH-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ