### PR TITLE
US-189 | Update unified-search subgraph & supergraph

### DIFF
--- a/proxies/events-graphql-federation/README.md
+++ b/proxies/events-graphql-federation/README.md
@@ -113,7 +113,7 @@ curl -sSL https://router.apollo.dev/download/nix/latest | sh
 To run the router locally with your configuration and supergraph, run:
 
 ```sh
-./router --config=router.yaml --supergraph=schemas/supergraph.graphql
+./router --config=router.yaml --supergraph=supergraph.graphql
 ```
 
 ### Serve dockerized local router
@@ -188,10 +188,10 @@ rover graph introspect https://tapahtumat.app-staging.hkih.hion.dev/graphql > my
 
 #### Work with supergraph
 
-To compose a new supergraph, use:
+To compose a new supergraph and save it, use:
 
 ```sh
-rover supergraph compose --config ./supergraph-config.yaml
+rover supergraph compose --config ./supergraph-config.yaml > supergraph.graphql
 ```
 
 ## Router configuration

--- a/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
+++ b/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
@@ -1,50 +1,25 @@
-schema @link(url: "https://specs.apollo.dev/link/v1.0") {
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+{
   query: Query
 }
 
 extend schema
-  @link(
-    url: "https://specs.apollo.dev/federation/v2.0"
-    import: ["@key", "@shareable"]
-  )
+  @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
 
-directive @origin(
-  service: String
-  type: String
-  attr: String
-) repeatable on FIELD_DEFINITION | OBJECT
+directive @cacheControl(maxAge: Int, scope: CacheControlScope, inheritMaxAge: Boolean) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
-directive @cacheControl(
-  maxAge: Int
-  scope: CacheControlScope
-  inheritMaxAge: Boolean
-) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-directive @link(
-  url: String
-  as: String
-  for: link__Purpose
-  import: [link__Import]
-) repeatable on SCHEMA
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @key(
-  fields: federation__FieldSet!
-  resolvable: Boolean = true
-) repeatable on OBJECT | INTERFACE
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-directive @federation__requires(
-  fields: federation__FieldSet!
-) on FIELD_DEFINITION
-
-directive @federation__provides(
-  fields: federation__FieldSet!
-) on FIELD_DEFINITION
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
 
 directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
 
-directive @federation__tag(
-  name: String!
-) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @federation__extends on OBJECT | INTERFACE
 
@@ -54,18 +29,6 @@ directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | U
 
 directive @federation__override(from: String!) on FIELD_DEFINITION
 
-directive @federation__composeDirective(name: String) repeatable on SCHEMA
-
-enum UnifiedSearchResultCategory {
-  POINT_OF_INTEREST
-  EVENT
-  RESERVABLE
-  ENROLLABLE
-  ARTWORK
-  ARTICLE
-  SERVICE
-}
-
 enum UnifiedSearchLanguage {
   FINNISH
   SWEDISH
@@ -73,9 +36,7 @@ enum UnifiedSearchLanguage {
 }
 
 type SearchResultConnection {
-  """
-  Elasticsearch raw results
-  """
+  """Elasticsearch raw results"""
   es_results: [ElasticSearchResult]
   count: Int
   max_score: Float
@@ -99,8 +60,6 @@ type SearchResultNode {
   _score: Float
   id: ID!
   venue: UnifiedSearchVenue @cacheControl(inheritMaxAge: true)
-  event: Event
-  searchCategories: [UnifiedSearchResultCategory!]!
 }
 
 type Suggestion {
@@ -131,50 +90,33 @@ enum UnifiedSearchIndex {
   helsinki_common_administrative_division
   ontology_tree
   ontology_word
-  event
   location
 }
 
 type Query {
   unifiedSearch(
-    """
-    Free form query string, corresponding to user search input
-    """
+    """Free form query string, corresponding to user search input"""
     text: String
 
-    """
-    Optional, filter to match only these ontology words
-    """
+    """Optional, filter to match only these ontology words"""
     ontology: String
 
-    """
-    Optional, filter to match only these administrative divisions
-    """
+    """Optional, filter to match only these administrative divisions"""
     administrativeDivisionIds: [ID]
 
-    """
-    Optional, filter to match at least one ontology tree ID from each list
-    """
+    """Optional, filter to match at least one ontology tree ID from each list"""
     ontologyTreeIdOrSets: [[ID!]!]
 
-    """
-    Optional, filter to match at least one ontology word ID from each list
-    """
+    """Optional, filter to match at least one ontology word ID from each list"""
     ontologyWordIdOrSets: [[ID!]!]
 
-    """
-    Optional, filter to match any of these provider types
-    """
+    """Optional, filter to match any of these provider types"""
     providerTypes: [ProviderType]
 
-    """
-    Optional, filter to match any of these service owner types
-    """
+    """Optional, filter to match any of these service owner types"""
     serviceOwnerTypes: [ServiceOwnerType]
 
-    """
-    Optional, filter to match any of these target groups
-    """
+    """Optional, filter to match any of these target groups"""
     targetGroups: [TargetGroup]
 
     """
@@ -183,24 +125,16 @@ type Query {
     """
     mustHaveReservableResource: Boolean
 
-    """
-    Optional search index.
-    """
+    """Optional search index."""
     index: UnifiedSearchIndex
 
-    """
-    Optional pagination variable, match results after this cursor.
-    """
+    """Optional pagination variable, match results after this cursor."""
     after: String
 
-    """
-    Optional pagination variable, limit the amount of results to N.
-    """
+    """Optional pagination variable, limit the amount of results to N."""
     first: Int
 
-    """
-    Targets the search to fields of specified language
-    """
+    """Targets the search to fields of specified language"""
     languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
 
     """
@@ -229,7 +163,7 @@ type Query {
     first the results that have no accessibility shortcomings for the given profile,
     then the ones with 1 shortcoming, 2 shortcomings, ..., N shortcomings and
     last the ones with unknown shortcomings (i.e. no data for or against).
-
+    
     Mutually exclusive with other orderBy* parameters.
     """
     orderByAccessibilityProfile: AccessibilityProfile
@@ -240,25 +174,35 @@ type Query {
     """
     prefix: String
 
-    """
-    Limits the result set into the specified languages
-    """
+    """Limits the result set into the specified languages"""
     languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
 
-    """
-    Optional search index.
-    """
+    """Optional search index."""
     index: UnifiedSearchIndex
 
-    """
-    Optional result size.
-    """
+    """Optional result size."""
     size: Int = 5
   ): SearchSuggestionConnection
+
+  """
+  Get Helsinki/Finland administrative divisions i.e.
+  neighborhoods (=kaupunginosat), sub-districts (=osa-alueet),
+  municipalities (=kunnat) etc.
+  
+  Based on imported data from [django-munigeo](https://github.com/City-of-Helsinki/django-munigeo):
+  - "geo_import finland --municipalities"
+  - "geo_import helsinki --divisions"
+  
+  Used django-munigeo importers:
+  - [geo_import](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/management/commands/geo_import.py)
+    - [finland](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/finland.py)
+    - [helsinki](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/helsinki.py)
+  """
   administrativeDivisions(
     """
-    Return only Helsinki administrative divisions that make a sensible set to be
-    used as an option list in an UI for example.
+    If true, return only Helsinki municipality's neighborhoods and sub-districts
+    (=Helsingin kunnan kaupunginosat ja osa-alueet),
+    otherwise return also all the municipalities of Finland.
     """
     helsinkiCommonOnly: Boolean
   ): [AdministrativeDivision]
@@ -267,9 +211,7 @@ type Query {
   _service: _Service!
 }
 
-"""
-Elasticsearch results
-"""
+"""Elasticsearch results"""
 type ElasticSearchResult {
   took: Int
   timed_out: Boolean
@@ -308,9 +250,7 @@ type RawJSON {
 }
 
 type PalvelukarttaUnit {
-  """
-  Raw palvelukartta Unit fields
-  """
+  """Raw palvelukartta Unit fields"""
   origin: String
   id: Int
   org_id: String
@@ -370,60 +310,6 @@ type Ontologyword {
   unit_ids: [Int]
 }
 
-type LinkedeventsPlace {
-  """
-  Raw Linkedevents Place fields
-  """
-  origin: String
-  id: String
-  data_source: String
-  publisher: String
-  divisions: [LinkedeventsPlaceDivision]
-  created_time: String
-  last_modified_time: String
-  custom_data: String
-  email: String
-  contact_type: String
-  address_region: String
-  postal_code: String
-  post_office_box_num: String
-  address_country: String
-  deleted: Boolean
-  has_upcoming_events: Boolean
-  n_events: Int
-  image: String
-  parent: String
-  replaced_by: String
-  position: LinkedeventsPlacePosition
-  address_locality: LinkedeventsPlaceLocalityString
-  info_url: LinkedeventsPlaceLocalityString
-  description: LinkedeventsPlaceLocalityString
-  telephone: String
-  street_address: LinkedeventsPlaceLocalityString
-  name: LinkedeventsPlaceLocalityString
-  _at_id: String
-  _at_context: String
-  _at_type: String
-}
-
-type LinkedeventsPlaceDivision {
-  type: String
-  ocd_id: String
-  municipality: String
-  name: LinkedeventsPlaceLocalityString
-}
-
-type LinkedeventsPlacePosition {
-  type: String
-  coordinates: [Float]
-}
-
-type LinkedeventsPlaceLocalityString {
-  fi: String
-  sv: String
-  en: String
-}
-
 """
 A place that forms a unit and can be used for some specific purpose -
 respa unit or resource, service map unit, beta.kultus venue, linked
@@ -436,38 +322,29 @@ type UnifiedSearchVenue {
   description: LanguageString
   serviceOwner: ServiceOwner
   targetGroups: [TargetGroup]
-  descriptionResources: DescriptionResources
-  partOf: UnifiedSearchVenue
   openingHours: OpeningHours
-  manager: LegalEntity
-  contactDetails: ContactInfo
   reservation: Reservation
   accessibility: Accessibility
 
-  """
-  Accessibility shortcoming for a specific accessibility profile.
-  """
-  accessibilityShortcomingFor(
-    profile: AccessibilityProfile
-  ): AccessibilityShortcoming
-  arrivalInstructions: String
-  additionalInfo: String
-  facilities: [VenueFacility!]
+  """Accessibility shortcoming for a specific accessibility profile."""
+  accessibilityShortcomingFor(profile: AccessibilityProfile): AccessibilityShortcoming
   images: [LocationImage]
   ontologyWords: [OntologyWord]
 }
 
-"""
-Free-form location, not necessarily at a know venue.
-"""
+type Address {
+  postalCode: String
+  streetAddress: LanguageString
+  city: LanguageString
+}
+
+"""Free-form location, not necessarily at a known venue."""
 type LocationDescription {
   url: LanguageString
   geoLocation: GeoJSONFeature @cacheControl(inheritMaxAge: true)
   address: Address
   explanation: String
-    @origin(service: "linked", type: "event", attr: "location_extra_info")
   administrativeDivisions: [AdministrativeDivision]
-  venue: UnifiedSearchVenue
 }
 
 enum TargetGroup {
@@ -478,6 +355,7 @@ enum TargetGroup {
   ENTERPRISES
   IMMIGRANTS
   INDIVIDUALS
+  LONG_TERM_PATIENTS
   YOUTH
 }
 
@@ -566,15 +444,6 @@ type Reservation {
   externalReservationUrl: LanguageString
 }
 
-"""
-TODO: combine beta.kultus Venue stuff with respa equipment type
-"""
-type VenueFacility {
-  meta: NodeMeta
-  name: String!
-  categories: [KeywordString!]
-}
-
 type OpeningHours {
   url: String
   is_open_now_url: String
@@ -614,65 +483,20 @@ type OpeningHoursTimes {
 
 scalar DateTime
 
-type NodeMeta @cacheControl(inheritMaxAge: true) {
+type NodeMeta
+  @cacheControl(inheritMaxAge: true)
+{
   id: ID!
   createdAt: DateTime
   updatedAt: DateTime
 }
 
-"""
-TODO: merge all free tags, categories, and keywords
-KEYWORDS ARE GIVEN FROM events-proxy (https://events-graphql-proxy.test.hel.ninja/proxy/graphql)
-"""
-type KeywordString {
-  name: String!
-}
-
-"""
-TODO: take from Profile or external source
-"""
-enum UnifiedSearchLanguageEnum {
-  FI
-}
-
-"""
-TODO: convert all String's to LanguageString's if linguistic content
-"""
-type LanguageString @cacheControl(inheritMaxAge: true) {
+type LanguageString
+  @cacheControl(inheritMaxAge: true)
+{
   fi: String
   sv: String
   en: String
-}
-
-"""
-any kind of description answering the question "when".
-"""
-type TimeDescription {
-  starting: DateTime
-    @origin(service: "linked", type: "event", attr: "start_time")
-  ending: DateTime @origin(service: "linked", type: "event", attr: "end_time")
-  otherTime: TimeDescription
-}
-
-"""
-Resources (media) that provide extra description of a resource,
-facility, event or venue, such as images, videos, info pages, etc.
-"""
-type DescriptionResources {
-  mediaResources: [MediaResource!]!
-    @origin(service: "linked", type: "event", attr: "images")
-    @origin(service: "linked", type: "event", attr: "videos")
-  infoUrls: [String!]!
-    @origin(service: "linked", type: "event", attr: "info_url")
-  externalLinks: [String!]!
-}
-
-"""
-TODO: take this from Linked events Image type.
-"""
-type MediaResource {
-  meta: NodeMeta
-  todo: String
 }
 
 enum CacheControlScope {
@@ -680,293 +504,19 @@ enum CacheControlScope {
   PRIVATE
 }
 
-"""
-An organised event - something that happens at a specific time, has a
-specific topic or content, and people can participate.  Examples include
-meetups, concerts, volunteering occasions (or bees), happenings.  This
-corresponds to Linked events/courses event, beta.kultus
-PalvelutarjotinEventNode, Kukkuu event.
-"""
-type Event {
-  meta: NodeMeta
-  name: LanguageString @origin(service: "linked", type: "event", attr: "name")
-  description: LanguageString
-    @origin(service: "linked", type: "event", attr: "description")
-  shortDescription: String
-    @origin(service: "linked", type: "event", attr: "short_description")
-  descriptionResources: DescriptionResources
-  keywords: [KeywordString!]!
-    @origin(service: "linked", type: "event", attr: "keywords")
-  eventDataSource: String
-    @origin(service: "linked", type: "event", attr: "data_source")
-  occurrences: [EventOccurrence!]!
-  pricing: [EventPricing!]
-    @origin(service: "linked", type: "event", attr: "offers")
-  organiser: LegalEntity
-    @origin(service: "linked", type: "event", attr: "provider")
-  publisher: LegalEntity
-    @origin(service: "linked", type: "event", attr: "publisher")
-  published: DateTime
-    @origin(service: "linked", type: "event", attr: "date_published")
-  contactPerson: LegalEntity
-  eventLanguages: [UnifiedSearchLanguageEnum!]!
-    @origin(service: "linked", type: "event", attr: "in_language")
-  subEvents: [Event!]!
-    @origin(service: "linked", type: "event", attr: "sub_events")
-  superEvent: Event
-    @origin(service: "linked", type: "event", attr: "super_event")
-  enrolmentPolicy: EnrolmentPolicy
-  targetAudience: [KeywordString!]
-    @origin(service: "linked", type: "event", attr: "audience")
-}
-
-"""
-TODO: improve (a lot) over Linked events' offer type
-"""
-type EventPricing {
-  meta: NodeMeta
-  todo: String
-}
-
-type EventOccurrence {
-  meta: NodeMeta
-
-  """
-  which event this is an occurrence of
-  """
-  ofEvent: Event
-  happensAt: TimeDescription
-
-  """
-  for information - for example, to guide people who are looking for
-  big or small events, or to give city officials a hint on how much
-  equipment is needed
-  """
-  estimatedAttendeeCount: Int
-  location: LocationDescription
-    @origin(service: "linked", type: "event", attr: "location")
-  status: EventOccurrenceStatus
-    @origin(service: "linked", type: "event", attr: "event_status")
-  enrolments: [Enrolment!]!
-  minimumAttendeeCount: Int
-    @origin(
-      service: "linked"
-      type: "extension_course"
-      attr: "minimum_attendee_capacity"
-    )
-  maximumAttendeeCount: Int
-    @origin(
-      service: "linked"
-      type: "extension_course"
-      attr: "maximum_attendee_capacity"
-    )
-  currentlyAvailableParticipantCount: Int
-    @origin(
-      service: "linked"
-      type: "extension_course"
-      attr: "remaining_attendee_capacity"
-    )
-
-  """
-  for events where equipment is requested from the City of Helsinki
-  """
-  cityEquipmentRequests: [EquipmentRequest!]
-}
-
-enum EventOccurrenceStatus {
-  UNPUBLISHED
-  PUBLISHED
-  CANCELLED
-  RESCHEDULED
-  POSTPONED
-}
-
-"""
-Rules about who can enroll to an event and how
-"""
-type EnrolmentPolicy {
-  meta: NodeMeta
-  type: [EnrolmentPolicyType!]!
-  enrolmentTime: TimeDescription
-    @origin(
-      service: "linked"
-      type: "extension_course"
-      attr: "enrolment_start_time"
-    )
-    @origin(
-      service: "linked"
-      type: "extension_course"
-      attr: "enrolment_end_time"
-    )
-  allowedParticipantCategories: [KeywordString!]!
-  participantMinimumAge: Int!
-    @origin(service: "linked", type: "event", attr: "audience_min_age")
-  participantMaximumAge: Int!
-    @origin(service: "linked", type: "event", attr: "audience_max_age")
-
-  """
-  minimum number of people who can enrol together (at the same time)
-  """
-  minimumEnrolmentCount: Int
-
-  """
-  maximum number of people who can enrol together (at the same time)
-  """
-  maximumEnrolmentCount: Int
-}
-
-enum EnrolmentPolicyType {
-  NO_ENROLMENT_NEEDED
-  GROUPS
-  GROUPS_WITH_SUPERVISORS
-  INDIVIDUALS
-}
-
-"""
-Information about enrolled participant(s) in an event occurrence
-"""
-type Enrolment {
-  meta: NodeMeta
-  event: EventOccurrence
-  enroller: Person
-  participantCount: Int!
-  participants: [Person!]
-  participantCategory: KeywordString
-  overseerCount: Int
-  overseers: [Person!]
-  requestedMethodOfNotification: ContactMedium
-  status: EnrolmentStatus
-  extraInformation: String
-}
-
-enum EnrolmentStatus {
-  REQUESTED
-  QUEUED
-  CONFIRMED
-  CANCELLED
-  DECLINED
-}
-
-"""
-Request for equipment - if someone needs equipment for a purpose such
-as organising a volunteering event (as is the case in park cleaning
-bees), a specification of what is being requested.
-"""
-type EquipmentRequest {
-  meta: NodeMeta
-  requestedEquipment: String!
-  estimatedAmount: Int
-  requestedForEvent: Event
-  deliveryLocation: LocationDescription
-  returnLocation: LocationDescription
-  extraInformation: String!
-}
-
-"""
-TODO: take from Profile
-"""
-type Person {
-  meta: NodeMeta
-  name: String
-  identificationStrength: IdentificationStrength
-  contactDetails: ContactInfo
-  preferredLanguages: [UnifiedSearchLanguageEnum!]
-  preferredMedium: ContactMedium
-}
-
-enum IdentificationStrength {
-  """
-  If this person is just a pseudoperson for contacting
-  """
-  NONIDENTIFIABLE
-
-  """
-  If the identity of this person is not known at all
-  """
-  UNIDENTIFIED
-
-  """
-  If the person has authenticated with at least some method
-  """
-  AUTHENTICATED
-
-  """
-  If the person has done some identifiable action such as payment
-  """
-  INDIRECT
-
-  """
-  If the person has proved their legal identity
-  """
-  LEGALLY_CONNECTED
-}
-
-"""
-TODO: merge beta.kultus organisation, etc
-"""
-type Organisation {
-  meta: NodeMeta
-  contactDetails: ContactInfo
-}
-
-union LegalEntity = Person | Organisation
-
-enum ContactMedium {
-  SMS
-  EMAIL
-  SMS_AND_EMAIL
-  MOBILE_NOTIFICATION
-  ASIOINTI
-}
-
-"""
-Contact details for a person, legal entity, venue or project
-"""
-type ContactInfo
-  @origin(service: "linked", type: "event", attr: "provider_contact_info") {
-  contactUrl: String
-  phoneNumbers: [PhoneNumber!]!
-  emailAddresses: [String!]!
-  postalAddresses: [Address!]!
-}
-
-type PhoneNumber {
-  countryCode: String!
-  restNumber: String!
-}
-
-"""
-TODO: give real structure
-"""
-type Address {
-  postalCode: String
-  streetAddress: LanguageString
-  city: LanguageString
-}
-
-"""
-Coordinate Reference System (CRS) object.
-"""
+"""Coordinate Reference System (CRS) object."""
 type GeoJSONCoordinateReferenceSystem {
   type: GeoJSONCRSType!
   properties: GeoJSONCRSProperties!
 }
 
-"""
-A (multidimensional) set of coordinates following x, y, z order.
-"""
+"""A (multidimensional) set of coordinates following x, y, z order."""
 scalar GeoJSONCoordinates
 
-"""
-CRS object properties.
-"""
-union GeoJSONCRSProperties =
-    GeoJSONNamedCRSProperties
-  | GeoJSONLinkedCRSProperties
+"""CRS object properties."""
+union GeoJSONCRSProperties = GeoJSONNamedCRSProperties | GeoJSONLinkedCRSProperties
 
-"""
-Enumeration of all GeoJSON CRS object types.
-"""
+"""Enumeration of all GeoJSON CRS object types."""
 enum GeoJSONCRSType {
   name
   link
@@ -984,9 +534,7 @@ type GeoJSONFeature implements GeoJSONInterface {
   id: String
 }
 
-"""
-A set of multiple features.
-"""
+"""A set of multiple features."""
 type GeoJSONFeatureCollection implements GeoJSONInterface {
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
@@ -994,9 +542,7 @@ type GeoJSONFeatureCollection implements GeoJSONInterface {
   features: [GeoJSONFeature!]!
 }
 
-"""
-A set of multiple geometries, possibly of various types.
-"""
+"""A set of multiple geometries, possibly of various types."""
 type GeoJSONGeometryCollection implements GeoJSONInterface {
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
@@ -1017,9 +563,7 @@ interface GeoJSONInterface {
   bbox: [Float]
 }
 
-"""
-Object describing a single connected sequence of geographical points.
-"""
+"""Object describing a single connected sequence of geographical points."""
 type GeoJSONLineString implements GeoJSONInterface & GeoJSONGeometryInterface {
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
@@ -1027,17 +571,13 @@ type GeoJSONLineString implements GeoJSONInterface & GeoJSONGeometryInterface {
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Properties for link based CRS object.
-"""
+"""Properties for link based CRS object."""
 type GeoJSONLinkedCRSProperties {
   href: String!
   type: String
 }
 
-"""
-Object describing multiple connected sequences of geographical points.
-"""
+"""Object describing multiple connected sequences of geographical points."""
 type GeoJSONMultiLineString implements GeoJSONInterface & GeoJSONGeometryInterface {
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
@@ -1045,9 +585,7 @@ type GeoJSONMultiLineString implements GeoJSONInterface & GeoJSONGeometryInterfa
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Object describing multiple geographical points.
-"""
+"""Object describing multiple geographical points."""
 type GeoJSONMultiPoint implements GeoJSONInterface & GeoJSONGeometryInterface {
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
@@ -1065,16 +603,12 @@ type GeoJSONMultiPolygon implements GeoJSONInterface & GeoJSONGeometryInterface 
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Properties for name based CRS object.
-"""
+"""Properties for name based CRS object."""
 type GeoJSONNamedCRSProperties {
   name: String!
 }
 
-"""
-Object describing a single geographical point.
-"""
+"""Object describing a single geographical point."""
 type GeoJSONPoint implements GeoJSONInterface & GeoJSONGeometryInterface {
   type: GeoJSONType!
   crs: GeoJSONCoordinateReferenceSystem!
@@ -1092,9 +626,7 @@ type GeoJSONPolygon implements GeoJSONInterface & GeoJSONGeometryInterface {
   coordinates: GeoJSONCoordinates
 }
 
-"""
-Enumeration of all GeoJSON object types.
-"""
+"""Enumeration of all GeoJSON object types."""
 enum GeoJSONType {
   Point
   MultiPoint
@@ -1107,9 +639,7 @@ enum GeoJSONType {
   FeatureCollection
 }
 
-"""
-Arbitrary JSON value
-"""
+"""Arbitrary JSON value"""
 scalar JSONObject
 
 type OntologyTree {

--- a/proxies/events-graphql-federation/supergraph.graphql
+++ b/proxies/events-graphql-federation/supergraph.graphql
@@ -82,7 +82,6 @@ enum AccessibilityViewpointValue
   green @join__enumValue(graph: UNIFIED_SEARCH)
 }
 
-"""TODO: give real structure"""
 type Address
   @join__type(graph: UNIFIED_SEARCH)
 {
@@ -2398,26 +2397,6 @@ enum ContactIdType
   URI @join__enumValue(graph: CMS)
 }
 
-"""Contact details for a person, legal entity, venue or project"""
-type ContactInfo
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  contactUrl: String
-  phoneNumbers: [PhoneNumber!]!
-  emailAddresses: [String!]!
-  postalAddresses: [Address!]!
-}
-
-enum ContactMedium
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  SMS @join__enumValue(graph: UNIFIED_SEARCH)
-  EMAIL @join__enumValue(graph: UNIFIED_SEARCH)
-  SMS_AND_EMAIL @join__enumValue(graph: UNIFIED_SEARCH)
-  MOBILE_NOTIFICATION @join__enumValue(graph: UNIFIED_SEARCH)
-  ASIOINTI @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
 """Connection between the Contact type and the contact type"""
 type ContactToPreviewConnectionEdge implements OneToOneConnection & Edge & ContactConnectionEdge
   @join__implements(graph: CMS, interface: "OneToOneConnection")
@@ -4565,18 +4544,6 @@ type DeleteUserPayload
   user: User
 }
 
-"""
-Resources (media) that provide extra description of a resource,
-facility, event or venue, such as images, videos, info pages, etc.
-"""
-type DescriptionResources
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  mediaResources: [MediaResource!]!
-  infoUrls: [String!]!
-  externalLinks: [String!]!
-}
-
 """The discussion setting type"""
 type DiscussionSettings
   @join__type(graph: CMS)
@@ -4865,107 +4832,6 @@ interface EnqueuedStylesheetConnectionPageInfo implements WPPageInfo & PageInfo
   startCursor: String
 }
 
-"""Information about enrolled participant(s) in an event occurrence"""
-type Enrolment
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  event: EventOccurrence
-  enroller: Person
-  participantCount: Int!
-  participants: [Person!]
-  participantCategory: KeywordString
-  overseerCount: Int
-  overseers: [Person!]
-  requestedMethodOfNotification: ContactMedium
-  status: EnrolmentStatus
-  extraInformation: String
-}
-
-"""Rules about who can enroll to an event and how"""
-type EnrolmentPolicy
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  type: [EnrolmentPolicyType!]!
-  enrolmentTime: TimeDescription
-  allowedParticipantCategories: [KeywordString!]!
-  participantMinimumAge: Int!
-  participantMaximumAge: Int!
-
-  """minimum number of people who can enrol together (at the same time)"""
-  minimumEnrolmentCount: Int
-
-  """maximum number of people who can enrol together (at the same time)"""
-  maximumEnrolmentCount: Int
-}
-
-enum EnrolmentPolicyType
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  NO_ENROLMENT_NEEDED @join__enumValue(graph: UNIFIED_SEARCH)
-  GROUPS @join__enumValue(graph: UNIFIED_SEARCH)
-  GROUPS_WITH_SUPERVISORS @join__enumValue(graph: UNIFIED_SEARCH)
-  INDIVIDUALS @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
-enum EnrolmentStatus
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  REQUESTED @join__enumValue(graph: UNIFIED_SEARCH)
-  QUEUED @join__enumValue(graph: UNIFIED_SEARCH)
-  CONFIRMED @join__enumValue(graph: UNIFIED_SEARCH)
-  CANCELLED @join__enumValue(graph: UNIFIED_SEARCH)
-  DECLINED @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
-"""
-Request for equipment - if someone needs equipment for a purpose such
-as organising a volunteering event (as is the case in park cleaning
-bees), a specification of what is being requested.
-"""
-type EquipmentRequest
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  requestedEquipment: String!
-  estimatedAmount: Int
-  requestedForEvent: Event
-  deliveryLocation: LocationDescription
-  returnLocation: LocationDescription
-  extraInformation: String!
-}
-
-"""
-An organised event - something that happens at a specific time, has a
-specific topic or content, and people can participate.  Examples include
-meetups, concerts, volunteering occasions (or bees), happenings.  This
-corresponds to Linked events/courses event, beta.kultus
-PalvelutarjotinEventNode, Kukkuu event.
-"""
-type Event
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  name: LanguageString
-  description: LanguageString
-  shortDescription: String
-  descriptionResources: DescriptionResources
-  keywords: [KeywordString!]!
-  eventDataSource: String
-  occurrences: [EventOccurrence!]!
-  pricing: [EventPricing!]
-  organiser: LegalEntity
-  publisher: LegalEntity
-  published: DateTime
-  contactPerson: LegalEntity
-  eventLanguages: [UnifiedSearchLanguageEnum!]!
-  subEvents: [Event!]!
-  superEvent: Event
-  enrolmentPolicy: EnrolmentPolicy
-  targetAudience: [KeywordString!]
-}
-
 type EventDetails
   @join__type(graph: EVENTS)
 {
@@ -5032,50 +4898,6 @@ type EventListResponse
 {
   meta: Meta!
   data: [EventDetails!]!
-}
-
-type EventOccurrence
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-
-  """which event this is an occurrence of"""
-  ofEvent: Event
-  happensAt: TimeDescription
-
-  """
-  for information - for example, to guide people who are looking for
-  big or small events, or to give city officials a hint on how much
-  equipment is needed
-  """
-  estimatedAttendeeCount: Int
-  location: LocationDescription
-  status: EventOccurrenceStatus
-  enrolments: [Enrolment!]!
-  minimumAttendeeCount: Int
-  maximumAttendeeCount: Int
-  currentlyAvailableParticipantCount: Int
-
-  """for events where equipment is requested from the City of Helsinki"""
-  cityEquipmentRequests: [EquipmentRequest!]
-}
-
-enum EventOccurrenceStatus
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  UNPUBLISHED @join__enumValue(graph: UNIFIED_SEARCH)
-  PUBLISHED @join__enumValue(graph: UNIFIED_SEARCH)
-  CANCELLED @join__enumValue(graph: UNIFIED_SEARCH)
-  RESCHEDULED @join__enumValue(graph: UNIFIED_SEARCH)
-  POSTPONED @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
-"""TODO: improve (a lot) over Linked events' offer type"""
-type EventPricing
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  todo: String
 }
 
 """Collection Module: EventSearch"""
@@ -6071,25 +5893,6 @@ type HitTotal
   relation: String
 }
 
-enum IdentificationStrength
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  """If this person is just a pseudoperson for contacting"""
-  NONIDENTIFIABLE @join__enumValue(graph: UNIFIED_SEARCH)
-
-  """If the identity of this person is not known at all"""
-  UNIDENTIFIED @join__enumValue(graph: UNIFIED_SEARCH)
-
-  """If the person has authenticated with at least some method"""
-  AUTHENTICATED @join__enumValue(graph: UNIFIED_SEARCH)
-
-  """If the person has done some identifiable action such as payment"""
-  INDIRECT @join__enumValue(graph: UNIFIED_SEARCH)
-
-  """If the person has proved their legal identity"""
-  LEGALLY_CONNECTED @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
 """Kuva"""
 type Image
   @join__type(graph: CMS)
@@ -6171,16 +5974,6 @@ type KeywordListResponse
 {
   meta: Meta!
   data: [Keyword!]!
-}
-
-"""
-TODO: merge all free tags, categories, and keywords
-KEYWORDS ARE GIVEN FROM events-proxy (https://events-graphql-proxy.test.hel.ninja/proxy/graphql)
-"""
-type KeywordString
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  name: String!
 }
 
 """The landingPage type"""
@@ -7047,7 +6840,6 @@ enum LanguageCodeFilterEnum
   SV @join__enumValue(graph: CMS)
 }
 
-"""TODO: convert all String's to LanguageString's if linguistic content"""
 type LanguageString
   @join__type(graph: UNIFIED_SEARCH)
 {
@@ -7335,12 +7127,6 @@ type LayoutSteps
   type: String
 }
 
-union LegalEntity
-  @join__type(graph: UNIFIED_SEARCH)
-  @join__unionMember(graph: UNIFIED_SEARCH, member: "Person")
-  @join__unionMember(graph: UNIFIED_SEARCH, member: "Organisation")
- = Person | Organisation
-
 """Linkin kenttä"""
 type Link
   @join__type(graph: CMS)
@@ -7369,66 +7155,6 @@ enum link__Purpose {
   EXECUTION
 }
 
-type LinkedeventsPlace
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  """Raw Linkedevents Place fields"""
-  origin: String
-  id: String
-  data_source: String
-  publisher: String
-  divisions: [LinkedeventsPlaceDivision]
-  created_time: String
-  last_modified_time: String
-  custom_data: String
-  email: String
-  contact_type: String
-  address_region: String
-  postal_code: String
-  post_office_box_num: String
-  address_country: String
-  deleted: Boolean
-  has_upcoming_events: Boolean
-  n_events: Int
-  image: String
-  parent: String
-  replaced_by: String
-  position: LinkedeventsPlacePosition
-  address_locality: LinkedeventsPlaceLocalityString
-  info_url: LinkedeventsPlaceLocalityString
-  description: LinkedeventsPlaceLocalityString
-  telephone: String
-  street_address: LinkedeventsPlaceLocalityString
-  name: LinkedeventsPlaceLocalityString
-  _at_id: String
-  _at_context: String
-  _at_type: String
-}
-
-type LinkedeventsPlaceDivision
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  type: String
-  ocd_id: String
-  municipality: String
-  name: LinkedeventsPlaceLocalityString
-}
-
-type LinkedeventsPlaceLocalityString
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  fi: String
-  sv: String
-  en: String
-}
-
-type LinkedeventsPlacePosition
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  type: String
-  coordinates: [Float]
-}
-
 type LocalizedCmsImage
   @join__type(graph: EVENTS)
 {
@@ -7453,7 +7179,7 @@ type LocalizedObject
   en: String
 }
 
-"""Free-form location, not necessarily at a know venue."""
+"""Free-form location, not necessarily at a known venue."""
 type LocationDescription
   @join__type(graph: UNIFIED_SEARCH)
 {
@@ -7462,7 +7188,6 @@ type LocationDescription
   address: Address
   explanation: String
   administrativeDivisions: [AdministrativeDivision]
-  venue: UnifiedSearchVenue
 }
 
 type LocationImage
@@ -8014,14 +7739,6 @@ enum MediaItemStatusEnum
 
   """Objects with the trash status"""
   TRASH @join__enumValue(graph: CMS)
-}
-
-"""TODO: take this from Linked events Image type."""
-type MediaResource
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  todo: String
 }
 
 """Details of an available size for a media item"""
@@ -9337,14 +9054,6 @@ enum OrderEnum
   DESC @join__enumValue(graph: CMS)
 }
 
-"""TODO: merge beta.kultus organisation, etc"""
-type Organisation
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  contactDetails: ContactInfo
-}
-
 type OrganizationDetails
   @join__type(graph: EVENTS)
 {
@@ -9991,25 +9700,6 @@ type PalvelukarttaUnit
   created_time: String
   modified_time: String
   ontologyword_ids_enriched: [Ontologyword]
-}
-
-"""TODO: take from Profile"""
-type Person
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  name: String
-  identificationStrength: IdentificationStrength
-  contactDetails: ContactInfo
-  preferredLanguages: [UnifiedSearchLanguageEnum!]
-  preferredMedium: ContactMedium
-}
-
-type PhoneNumber
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  countryCode: String!
-  restNumber: String!
 }
 
 type Place
@@ -13305,10 +12995,26 @@ type Query
     """Optional result size."""
     size: Int = 5
   ): SearchSuggestionConnection @join__field(graph: UNIFIED_SEARCH)
+
+  """
+  Get Helsinki/Finland administrative divisions i.e.
+  neighborhoods (=kaupunginosat), sub-districts (=osa-alueet),
+  municipalities (=kunnat) etc.
+  
+  Based on imported data from [django-munigeo](https://github.com/City-of-Helsinki/django-munigeo):
+  - "geo_import finland --municipalities"
+  - "geo_import helsinki --divisions"
+  
+  Used django-munigeo importers:
+  - [geo_import](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/management/commands/geo_import.py)
+    - [finland](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/finland.py)
+    - [helsinki](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/helsinki.py)
+  """
   administrativeDivisions(
     """
-    Return only Helsinki administrative divisions that make a sensible set to be
-    used as an option list in an UI for example.
+    If true, return only Helsinki municipality's neighborhoods and sub-districts
+    (=Helsingin kunnan kaupunginosat ja osa-alueet),
+    otherwise return also all the municipalities of Finland.
     """
     helsinkiCommonOnly: Boolean
   ): [AdministrativeDivision] @join__field(graph: UNIFIED_SEARCH)
@@ -16575,8 +16281,6 @@ type SearchResultNode
   _score: Float
   id: ID!
   venue: UnifiedSearchVenue
-  event: Event
-  searchCategories: [UnifiedSearchResultCategory!]!
 }
 
 type SearchResultPageInfo
@@ -17388,6 +17092,7 @@ enum TargetGroup
   ENTERPRISES @join__enumValue(graph: UNIFIED_SEARCH)
   IMMIGRANTS @join__enumValue(graph: UNIFIED_SEARCH)
   INDIVIDUALS @join__enumValue(graph: UNIFIED_SEARCH)
+  LONG_TERM_PATIENTS @join__enumValue(graph: UNIFIED_SEARCH)
   YOUTH @join__enumValue(graph: UNIFIED_SEARCH)
 }
 
@@ -18103,15 +17808,6 @@ type Time
   periods: [Int!]!
 }
 
-"""any kind of description answering the question "when"."""
-type TimeDescription
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  starting: DateTime
-  ending: DateTime
-  otherTime: TimeDescription
-}
-
 """The translation type"""
 type Translation implements Node & ContentNode & UniformResourceIdentifiable & DatabaseIdentifier & NodeWithTemplate & Previewable & NodeWithTitle & NodeWithRevisions
   @join__implements(graph: CMS, interface: "Node")
@@ -18532,7 +18228,6 @@ enum UnifiedSearchIndex
   helsinki_common_administrative_division @join__enumValue(graph: UNIFIED_SEARCH)
   ontology_tree @join__enumValue(graph: UNIFIED_SEARCH)
   ontology_word @join__enumValue(graph: UNIFIED_SEARCH)
-  event @join__enumValue(graph: UNIFIED_SEARCH)
   location @join__enumValue(graph: UNIFIED_SEARCH)
 }
 
@@ -18542,25 +18237,6 @@ enum UnifiedSearchLanguage
   FINNISH @join__enumValue(graph: UNIFIED_SEARCH)
   SWEDISH @join__enumValue(graph: UNIFIED_SEARCH)
   ENGLISH @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
-"""TODO: take from Profile or external source"""
-enum UnifiedSearchLanguageEnum
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  FI @join__enumValue(graph: UNIFIED_SEARCH)
-}
-
-enum UnifiedSearchResultCategory
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  POINT_OF_INTEREST @join__enumValue(graph: UNIFIED_SEARCH)
-  EVENT @join__enumValue(graph: UNIFIED_SEARCH)
-  RESERVABLE @join__enumValue(graph: UNIFIED_SEARCH)
-  ENROLLABLE @join__enumValue(graph: UNIFIED_SEARCH)
-  ARTWORK @join__enumValue(graph: UNIFIED_SEARCH)
-  ARTICLE @join__enumValue(graph: UNIFIED_SEARCH)
-  SERVICE @join__enumValue(graph: UNIFIED_SEARCH)
 }
 
 """
@@ -18577,19 +18253,12 @@ type UnifiedSearchVenue
   description: LanguageString
   serviceOwner: ServiceOwner
   targetGroups: [TargetGroup]
-  descriptionResources: DescriptionResources
-  partOf: UnifiedSearchVenue
   openingHours: OpeningHours
-  manager: LegalEntity
-  contactDetails: ContactInfo
   reservation: Reservation
   accessibility: Accessibility
 
   """Accessibility shortcoming for a specific accessibility profile."""
   accessibilityShortcomingFor(profile: AccessibilityProfile): AccessibilityShortcoming
-  arrivalInstructions: String
-  additionalInfo: String
-  facilities: [VenueFacility!]
   images: [LocationImage]
   ontologyWords: [OntologyWord]
 }
@@ -20881,15 +20550,6 @@ type VenueDepartment
   phone: String
   streetAddress: String
   www: String
-}
-
-"""TODO: combine beta.kultus Venue stuff with respa equipment type"""
-type VenueFacility
-  @join__type(graph: UNIFIED_SEARCH)
-{
-  meta: NodeMeta
-  name: String!
-  categories: [KeywordString!]
 }
 
 """Information about pagination in a connection."""


### PR DESCRIPTION
## Description

Update unified-search subgraph & supergraph

done in proxies/events-graphql-federation:
```
$ rover subgraph introspect
https://kuva-unified-search.api.dev.hel.ninja/search >
subgraphs/unified-search/unified-search.graphql

$ rover supergraph compose --config ./supergraph-config.yaml >
supergraph.graphql
HINT: Enum type "CacheControlScope" is defined but unused. It will be
included in the supergraph with all the values appearing in any subgraph
("as if" it was only used as an output type).
```

also:
 - update commands in events-graphql-federation's README

## Related

[US-189](https://helsinkisolutionoffice.atlassian.net/browse/US-189)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[US-189]: https://helsinkisolutionoffice.atlassian.net/browse/US-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ