### PR TITLE
fix(events-proxy): add trailing slash to LinkedEvents requests

### DIFF
--- a/proxies/events-graphql-proxy/src/__tests__/eventIntegration.test.ts
+++ b/proxies/events-graphql-proxy/src/__tests__/eventIntegration.test.ts
@@ -149,7 +149,7 @@ describe('sends REST requests correctly', () => {
       variables: {},
     });
 
-    expect(getMock).toHaveBeenCalledWith('event?event_type=General');
+    expect(getMock).toHaveBeenCalledWith('event/?event_type=General');
   });
 
   it('sends Course event type with event type param', async () => {
@@ -160,7 +160,7 @@ describe('sends REST requests correctly', () => {
       } as QueryEventListArgs,
     });
 
-    expect(getMock).toHaveBeenCalledWith('event?event_type=Course');
+    expect(getMock).toHaveBeenCalledWith('event/?event_type=Course');
   });
 
   it('sends all params in query string correctly', async () => {
@@ -169,7 +169,7 @@ describe('sends REST requests correctly', () => {
       variables: { eventType: [EventTypeId.Course] } as QueryEventListArgs,
     });
 
-    expect(getMock).toHaveBeenCalledWith('event?event_type=Course');
+    expect(getMock).toHaveBeenCalledWith('event/?event_type=Course');
   });
 });
 
@@ -217,7 +217,7 @@ it('sends REST request correctly with query params (course)', async () => {
   expect(getMock).toHaveBeenCalledTimes(1);
   expect(getMock.mock.calls[0][0]).toMatchInlineSnapshot(
     // eslint-disable-next-line @stylistic/max-len
-    `"event?event_type=Course&internet_based=true&all_ongoing=true&all_ongoing_AND=asd&division=division1,division2&end=end&ends_after=09.10.2020&ends_before=10.10.2020&include=include&in_language=fi&is_free=true&keyword=keyword1,keyword2&keyword_AND=keywordAnd,keywordAnd2&keyword!=keywordNot&language=fi&location=location2,location3&page=10&page_size=10&publisher=publisher&publisher_ancestor=ahjo:123&sort=asc&start=10.10.2021&starts_after=10.20.2021&starts_before=10.10.2022&super_event=123aasd&super_event_type=course,event&text=testText&translation=translation"`
+    `"event/?event_type=Course&internet_based=true&all_ongoing=true&all_ongoing_AND=asd&division=division1,division2&end=end&ends_after=09.10.2020&ends_before=10.10.2020&include=include&in_language=fi&is_free=true&keyword=keyword1,keyword2&keyword_AND=keywordAnd,keywordAnd2&keyword!=keywordNot&language=fi&location=location2,location3&page=10&page_size=10&publisher=publisher&publisher_ancestor=ahjo:123&sort=asc&start=10.10.2021&starts_after=10.20.2021&starts_before=10.10.2022&super_event=123aasd&super_event_type=course,event&text=testText&translation=translation"`
   );
 });
 

--- a/proxies/events-graphql-proxy/src/__tests__/keywordIntegration.test.ts
+++ b/proxies/events-graphql-proxy/src/__tests__/keywordIntegration.test.ts
@@ -43,7 +43,7 @@ it('sends REST request correctly with params', async () => {
   );
 
   expect(getMock).toHaveBeenCalledWith(
-    'keyword?data_source=yso&has_upcoming_events=true&page=1&page_size=10&show_all_keywords=false&sort=asc&text=malmi'
+    'keyword/?data_source=yso&has_upcoming_events=true&page=1&page_size=10&show_all_keywords=false&sort=asc&text=malmi'
   );
 });
 
@@ -106,7 +106,7 @@ it('uses correct path when source is provided', async () => {
     query: GET_KEYWORDS,
   });
 
-  expect(getMock).toHaveBeenCalledWith('keyword');
+  expect(getMock).toHaveBeenCalledWith('keyword/');
 });
 
 const GET_KEYWORDS = gql`

--- a/proxies/events-graphql-proxy/src/datasources/eventDataSource.ts
+++ b/proxies/events-graphql-proxy/src/datasources/eventDataSource.ts
@@ -9,11 +9,11 @@ class EventDataSource extends LinkedEventsDataSource {
     id: string,
     query: string
   ): Promise<EventDetails> {
-    return this.get(`event/${id}${query}`);
+    return this.get(`event/${id}/${query}`);
   }
 
   public async getEventList(query: string): Promise<EventListResponse> {
-    return this.get(`event${query}`);
+    return this.get(`event/${query}`);
   }
 }
 

--- a/proxies/events-graphql-proxy/src/datasources/keywordDataSource.ts
+++ b/proxies/events-graphql-proxy/src/datasources/keywordDataSource.ts
@@ -3,11 +3,11 @@ import LinkedEventsDataSource from './LinkedEventsDataSource.js';
 
 class KeywordDataSource extends LinkedEventsDataSource {
   public async getKeywordDetails(id: string): Promise<Keyword> {
-    return this.get(`keyword/${id}`);
+    return this.get(`keyword/${id}/`);
   }
 
   public async getKeywordList(query: string): Promise<KeywordListResponse> {
-    return this.get(`keyword${query}`);
+    return this.get(`keyword/${query}`);
   }
 }
 

--- a/proxies/events-graphql-proxy/src/datasources/organizationDataSource.ts
+++ b/proxies/events-graphql-proxy/src/datasources/organizationDataSource.ts
@@ -5,7 +5,7 @@ class OrganizationDataSource extends LinkedEventsDataSource {
   public async getOrganizationDetails(
     id: string
   ): Promise<OrganizationDetails> {
-    return this.get(`organization/${id}`);
+    return this.get(`organization/${id}/`);
   }
 }
 

--- a/proxies/events-graphql-proxy/src/datasources/placeDataSource.ts
+++ b/proxies/events-graphql-proxy/src/datasources/placeDataSource.ts
@@ -2,10 +2,10 @@ import type { Place, PlaceListResponse } from '../types/__generated__.js';
 import LinkedEventsDataSource from './LinkedEventsDataSource.js';
 class PlaceDataSource extends LinkedEventsDataSource {
   public async getPlaceDetails(id: string): Promise<Place> {
-    return this.get(`place/${id}`);
+    return this.get(`place/${id}/`);
   }
   public async getPlaceList(query: string): Promise<PlaceListResponse> {
-    return this.get(`place${query}`);
+    return this.get(`place/${query}`);
   }
 }
 


### PR DESCRIPTION
TH-1455.

LinkedEvents endpoints are called without trailing slash, which leads to bad request when huge amount of keywords are used.

Test functionality with these two links:

1. Broken, where the slash is missing: https://api.hel.fi/linkedevents/v1/event?event_type=General&division=kunta:helsinki&include=in_language,keywords,location,audience&keyword=yso:p1808,yso:p18434,yso:p27962,yso:p3064,yso:p20421,yso:p6422,yso:p2162,yso:p768,yso:p18718,yso:p24765,yso:p5470,yso:p23218,yso:p2841,yso:p29817,yso:p12257,yso:p3065,yso:p1235,yso:p16327,yso:p13637,yso:p15697,yso:p20056,yso:p15403,yso:p38530,yso:p6735,yso:p7966,yso:p371,yso:p1616,yso:p15693,yso:p10047,yso:p5667,yso:p2003,kulke:29,kulke:205,kultus:23,yso:p2625,yso:p2315,yso:p25077,yso:p17654,yso:p4587,yso:p23411,yso:p29817,yso:p16163,yso:p28525,yso:p28339,yso:p9058,yso:p15018,yso:p4586,yso:p10047,yso:p6484,yso:p23410,yso:p16162,yso:p28744,yso:p17826,matko:teatteri,matko:tanssi%20ja%20teatteri,yso:p16164,kulke:33,kulke:351,kulke:49,kultus:16,yso:p4934,yso:p8144,yso:p11345,yso:p10041,yso:p26642,yso:p17814,yso:p21113,matko:museo,yso:p360,yso:p372,yso:p4804,yso:p10647,yso:p9509,yso:p25144,yso:p18452,yso:p10041,yso:p28692,yso:p24860,yso:p5529,yso:p371,yso:p25440,yso:p39416,yso:p4806,yso:p37969,yso:p18003,yso:p14256,yso:p21847,yso:p6,kulke:669,matko:kulttuuri,helfi:12,yso:p5121,yso:p6889,yso:p16866,matko:n%C3%A4yttely,yso:p4240,yso:p25242,matko:n%C3%A4yttelyt,kulke:50,kultus:7,helmet:10778,helmet:11930,yso:p2739,yso:p2625,yso:p2851,yso:p18434,yso:p8144,yso:p7266,yso:p9592,yso:p6044,yso:p8883,yso:p695,yso:p10649,yso:p8884,yso:p5378,yso:p13235,yso:p4099,yso:p18749,yso:p4445,yso:p11955,yso:p9593,yso:p7969,yso:p5007,yso:p13810,yso:p1000,yso:p15737,yso:p21073,yso:p19845,yso:p4969,yso:p5457,yso:p27081,yso:p6841,yso:p26879,yso:p13274,yso:p11951,yso:p4795,yso:p20069,yso:p16782,yso:p22465,yso:p8400,yso:p4059,yso:p3655,yso:p11231,yso:p38773,yso:p5065,yso:p5450,yso:p25042,yso:p22192,yso:p20844,yso:p11954,yso:p4818,yso:p25605,yso:p5452,yso:p9567,yso:p24187,yso:p778,yso:p16327,yso:p17647,kulke:30,kulke:218,kulke:104,kulke:223,kulke:737,kulke:658,kulke:631,kultus:18,yso:p1278,yso:p27351,yso:p10105,yso:p3046,yso:p7818,yso:p12354,yso:p37874,yso:p29932,yso:p3984,yso:p19065,yso:p210,yso:p15817,yso:p13872,yso:p18196,yso:p6484,yso:p16584,yso:p725,yso:p181,yso:p6283,yso:p16699,yso:p27800,yso:p39168,yso:p9918,yso:p29806,yso:p20097,yso:p21524,yso:p23949,yso:p16669,matko:tanssi,matko:tanssi%20ja%20teatteri,kulke:32,kulke:350,kultus:16,yso:p13084,yso:p9654,yso:p6198,yso:p29460,yso:p7071,yso:p17728,yso:p5349,yso:p39484,yso:p20751,yso:p3034,kultus:22,kultus:3,yso:p2771,yso:p4858,yso:p5350,yso:p2770,yso:p3670,yso:p5529,yso:p14373,yso:p28276,yso:p18295,yso:p23647,yso:p11416,yso:p26216,yso:p27023,yso:p27352,yso:p17568,matko:ruoka,yso:p1657,yso:p10590,kultus:27,kultus:15,yso:p10591,yso:p21288,yso:p10727,yso:p26626,yso:p5164,yso:p10728,yso:p20692,kulke:751,kultus:30,yso:p18105,yso:p14004,yso:p8612,kulke:733,helmet:11733&keyword_AND=yso:p4354&language=fi&page_size=9&sort=end_time&start=now&super_event_type=umbrella,none

2. Working, with the slash added: https://api.hel.fi/linkedevents/v1/event/?event_type=General&division=kunta:helsinki&include=in_language,keywords,location,audience&keyword=yso:p1808,yso:p18434,yso:p27962,yso:p3064,yso:p20421,yso:p6422,yso:p2162,yso:p768,yso:p18718,yso:p24765,yso:p5470,yso:p23218,yso:p2841,yso:p29817,yso:p12257,yso:p3065,yso:p1235,yso:p16327,yso:p13637,yso:p15697,yso:p20056,yso:p15403,yso:p38530,yso:p6735,yso:p7966,yso:p371,yso:p1616,yso:p15693,yso:p10047,yso:p5667,yso:p2003,kulke:29,kulke:205,kultus:23,yso:p2625,yso:p2315,yso:p25077,yso:p17654,yso:p4587,yso:p23411,yso:p29817,yso:p16163,yso:p28525,yso:p28339,yso:p9058,yso:p15018,yso:p4586,yso:p10047,yso:p6484,yso:p23410,yso:p16162,yso:p28744,yso:p17826,matko:teatteri,matko:tanssi%20ja%20teatteri,yso:p16164,kulke:33,kulke:351,kulke:49,kultus:16,yso:p4934,yso:p8144,yso:p11345,yso:p10041,yso:p26642,yso:p17814,yso:p21113,matko:museo,yso:p360,yso:p372,yso:p4804,yso:p10647,yso:p9509,yso:p25144,yso:p18452,yso:p10041,yso:p28692,yso:p24860,yso:p5529,yso:p371,yso:p25440,yso:p39416,yso:p4806,yso:p37969,yso:p18003,yso:p14256,yso:p21847,yso:p6,kulke:669,matko:kulttuuri,helfi:12,yso:p5121,yso:p6889,yso:p16866,matko:n%C3%A4yttely,yso:p4240,yso:p25242,matko:n%C3%A4yttelyt,kulke:50,kultus:7,helmet:10778,helmet:11930,yso:p2739,yso:p2625,yso:p2851,yso:p18434,yso:p8144,yso:p7266,yso:p9592,yso:p6044,yso:p8883,yso:p695,yso:p10649,yso:p8884,yso:p5378,yso:p13235,yso:p4099,yso:p18749,yso:p4445,yso:p11955,yso:p9593,yso:p7969,yso:p5007,yso:p13810,yso:p1000,yso:p15737,yso:p21073,yso:p19845,yso:p4969,yso:p5457,yso:p27081,yso:p6841,yso:p26879,yso:p13274,yso:p11951,yso:p4795,yso:p20069,yso:p16782,yso:p22465,yso:p8400,yso:p4059,yso:p3655,yso:p11231,yso:p38773,yso:p5065,yso:p5450,yso:p25042,yso:p22192,yso:p20844,yso:p11954,yso:p4818,yso:p25605,yso:p5452,yso:p9567,yso:p24187,yso:p778,yso:p16327,yso:p17647,kulke:30,kulke:218,kulke:104,kulke:223,kulke:737,kulke:658,kulke:631,kultus:18,yso:p1278,yso:p27351,yso:p10105,yso:p3046,yso:p7818,yso:p12354,yso:p37874,yso:p29932,yso:p3984,yso:p19065,yso:p210,yso:p15817,yso:p13872,yso:p18196,yso:p6484,yso:p16584,yso:p725,yso:p181,yso:p6283,yso:p16699,yso:p27800,yso:p39168,yso:p9918,yso:p29806,yso:p20097,yso:p21524,yso:p23949,yso:p16669,matko:tanssi,matko:tanssi%20ja%20teatteri,kulke:32,kulke:350,kultus:16,yso:p13084,yso:p9654,yso:p6198,yso:p29460,yso:p7071,yso:p17728,yso:p5349,yso:p39484,yso:p20751,yso:p3034,kultus:22,kultus:3,yso:p2771,yso:p4858,yso:p5350,yso:p2770,yso:p3670,yso:p5529,yso:p14373,yso:p28276,yso:p18295,yso:p23647,yso:p11416,yso:p26216,yso:p27023,yso:p27352,yso:p17568,matko:ruoka,yso:p1657,yso:p10590,kultus:27,kultus:15,yso:p10591,yso:p21288,yso:p10727,yso:p26626,yso:p5164,yso:p10728,yso:p20692,kulke:751,kultus:30,yso:p18105,yso:p14004,yso:p8612,kulke:733,helmet:11733&keyword_AND=yso:p4354&language=fi&page_size=9&sort=end_time&start=now&super_event_type=umbrella,none