### PR TITLE
LIIKUNTA-684 | Show Culture and Leisure Division's venues first in relevance sort

### DIFF
--- a/apps/sports-helsinki/config/vitest/mockDataUtils.ts
+++ b/apps/sports-helsinki/config/vitest/mockDataUtils.ts
@@ -453,6 +453,7 @@ export const fakeVenuesSearchList = (
               reservation: null,
               serviceOwner: null,
               targetGroups: [],
+              isCultureAndLeisureDivisionVenue: true,
             },
           },
         };

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/VenueSearchAdapter.ts
@@ -6,7 +6,6 @@ import type {
   AppLanguage,
   Coordinates,
   OrderByDistance,
-  UnifiedSearchLanguage,
 } from '@events-helsinki/components/types';
 import {
   SortOrder,
@@ -43,6 +42,7 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
   orderByName: VenueSearchParams['orderByName'];
   orderByDistance: VenueSearchParams['orderByDistance'];
   orderByAccessibilityProfile: VenueSearchParams['orderByAccessibilityProfile'];
+  showCultureAndLeisureDivisionFirst: VenueSearchParams['showCultureAndLeisureDivisionFirst'];
   after?: VenueSearchParams['after'];
   first?: VenueSearchParams['first'];
 
@@ -60,9 +60,7 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
     // Initialize the object with default values
     Object.assign(this, initialVenueSearchAdapterValues);
 
-    this.language = appToUnifiedSearchLanguageMap[
-      locale
-    ] as UnifiedSearchLanguage;
+    this.language = appToUnifiedSearchLanguageMap[locale];
     this.text = input.text || initialVenueSearchAdapterValues.text;
     this.ontologyTreeIdOrSets =
       this.getOntologyTreeIdOrSets(input) ||
@@ -74,6 +72,7 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
       ? [ServiceOwnerType.MunicipalService]
       : initialVenueSearchAdapterValues.serviceOwnerTypes;
     this.mustHaveReservableResource = !!input.reservable;
+
     if (input.venueOrderBy?.includes('name')) {
       this.orderByName = input.venueOrderBy.startsWith('-')
         ? { order: SortOrder.Descending }
@@ -88,6 +87,10 @@ class VenueSearchAdapter implements CombinedSearchAdapter<VenueSearchParams> {
       } as OrderByDistance;
     } else if (isAccessibilityProfile(input.venueOrderBy)) {
       this.orderByAccessibilityProfile = input.venueOrderBy;
+    } else {
+      // Only show Culture and Leisure Division's venues first
+      // if no other specific ordering is defined → means "Sort by relevance",
+      this.showCultureAndLeisureDivisionFirst = true;
     }
   }
 

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -131,6 +131,7 @@ describe('CombinedSearchFormAdapter', () => {
           first: AppConfig.pageSize,
           ontologyTreeIdOrSets: [['551']],
           openAt: null,
+          showCultureAndLeisureDivisionFirst: true,
         },
       ],
       [

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/VenueSearchAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/VenueSearchAdapter.test.ts
@@ -1,13 +1,39 @@
+import type { Coordinates } from '@events-helsinki/components';
 import {
+  OrderDir,
   SENIORS_ONTOLOGY_TREE_IDS,
+  UnifiedSearchOrderBy,
   YOUTH_ONTOLOGY_TREE_IDS,
 } from '@events-helsinki/components';
 import { SortOrder, TARGET_GROUPS } from '@events-helsinki/components/types';
 import AppConfig from '../../../../app/AppConfig';
+import { initialCombinedSearchFormValues } from '../../constants';
 import type { CombinedSearchAdapterInput } from '../../types';
 import VenueSearchAdapter from '../VenueSearchAdapter';
 
 const locale = 'fi';
+
+const TEST_GEOLOCATION = {
+  latitude: 12.5,
+  longitude: 34.75,
+} as const satisfies Coordinates;
+
+const VENUE_ORDER_BY_RELEVANCE_COMBINATIONS = [
+  undefined,
+  null,
+  '',
+  `${UnifiedSearchOrderBy.relevance}-${OrderDir.asc}`,
+  `${UnifiedSearchOrderBy.relevance}-${OrderDir.desc}`,
+] as const;
+
+const VENUE_ORDER_BY_NAME_OR_DISTANCE_COMBINATIONS = [
+  `${UnifiedSearchOrderBy.name}-${OrderDir.asc}`,
+  `${UnifiedSearchOrderBy.name}-${OrderDir.desc}`,
+  `${UnifiedSearchOrderBy.distance}-${OrderDir.asc}`,
+  `${UnifiedSearchOrderBy.distance}-${OrderDir.desc}`,
+] as const;
+
+const TEST_TEXTS = ['test', '', null, '*'] as const;
 
 describe('VenueSearchAdapter', () => {
   describe('getQueryVariables', () => {
@@ -63,5 +89,62 @@ describe('VenueSearchAdapter', () => {
         ontologyTreeIdOrSet2.sort()
       );
     });
+  });
+
+  describe('showCultureAndLeisureDivisionFirst is undefined', () => {
+    it.each(VENUE_ORDER_BY_NAME_OR_DISTANCE_COMBINATIONS)(
+      'when sorting by %s regardless of search text',
+      (venueOrderBy) => {
+        for (const text in TEST_TEXTS) {
+          const input: CombinedSearchAdapterInput = {
+            ...initialCombinedSearchFormValues,
+            text,
+            venueOrderBy,
+          };
+          const adapter = new VenueSearchAdapter(
+            input,
+            locale,
+            TEST_GEOLOCATION
+          );
+          expect(
+            adapter.getQueryVariables()['showCultureAndLeisureDivisionFirst']
+          ).toBeUndefined();
+        }
+      }
+    );
+  });
+
+  describe('showCultureAndLeisureDivisionFirst set to true', () => {
+    it('by default', () => {
+      const adapter = new VenueSearchAdapter(
+        initialCombinedSearchFormValues,
+        locale,
+        TEST_GEOLOCATION
+      );
+      expect(
+        adapter.getQueryVariables()['showCultureAndLeisureDivisionFirst']
+      ).toStrictEqual(true);
+    });
+
+    it.each(VENUE_ORDER_BY_RELEVANCE_COMBINATIONS)(
+      'when sorting by %s regardless of search text',
+      (venueOrderBy) => {
+        for (const text in TEST_TEXTS) {
+          const input: CombinedSearchAdapterInput = {
+            ...initialCombinedSearchFormValues,
+            text,
+            venueOrderBy,
+          };
+          const adapter = new VenueSearchAdapter(
+            input,
+            locale,
+            TEST_GEOLOCATION
+          );
+          expect(
+            adapter.getQueryVariables()['showCultureAndLeisureDivisionFirst']
+          ).toStrictEqual(true);
+        }
+      }
+    );
   });
 });

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -134,6 +134,7 @@ export type VenueSearchParams = Pick<
   | 'orderByName'
   | 'orderByDistance'
   | 'orderByAccessibilityProfile'
+  | 'showCultureAndLeisureDivisionFirst'
   | 'after'
   | 'first'
 >;

--- a/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
+++ b/packages/components/src/components/domain/unifiedSearch/graphql/unifiedSearchList.query.ts
@@ -18,6 +18,7 @@ export const SEARCH_LIST_QUERY = gql`
     $orderByAccessibilityProfile: AccessibilityProfile
     $showAccessibilityShortcomingsFor: AccessibilityProfile
     $mustHaveReservableResource: Boolean
+    $showCultureAndLeisureDivisionFirst: Boolean
     $includeHaukiFields: Boolean = true
   ) {
     unifiedSearch(
@@ -37,6 +38,7 @@ export const SEARCH_LIST_QUERY = gql`
       orderByDistance: $orderByDistance
       orderByName: $orderByName
       orderByAccessibilityProfile: $orderByAccessibilityProfile
+      showCultureAndLeisureDivisionFirst: $showCultureAndLeisureDivisionFirst
     ) {
       count
       pageInfo {
@@ -49,6 +51,7 @@ export const SEARCH_LIST_QUERY = gql`
             meta {
               id
             }
+            isCultureAndLeisureDivisionVenue
             name {
               fi
               sv

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -85,7 +85,6 @@ export enum AccessibilityViewpointValue {
   Unknown = 'unknown',
 }
 
-/** TODO: give real structure */
 export type Address = {
   __typename?: 'Address';
   city?: Maybe<LanguageString>;
@@ -1590,23 +1589,6 @@ export enum ContactIdType {
   Uri = 'URI',
 }
 
-/** Contact details for a person, legal entity, venue or project */
-export type ContactInfo = {
-  __typename?: 'ContactInfo';
-  contactUrl?: Maybe<Scalars['String']['output']>;
-  emailAddresses: Array<Scalars['String']['output']>;
-  phoneNumbers: Array<PhoneNumber>;
-  postalAddresses: Array<Address>;
-};
-
-export enum ContactMedium {
-  Asiointi = 'ASIOINTI',
-  Email = 'EMAIL',
-  MobileNotification = 'MOBILE_NOTIFICATION',
-  Sms = 'SMS',
-  SmsAndEmail = 'SMS_AND_EMAIL',
-}
-
 /** Connection between the Contact type and the contact type */
 export type ContactToPreviewConnectionEdge = ContactConnectionEdge &
   Edge &
@@ -2975,17 +2957,6 @@ export type DeleteUserPayload = {
   user?: Maybe<User>;
 };
 
-/**
- * Resources (media) that provide extra description of a resource,
- * facility, event or venue, such as images, videos, info pages, etc.
- */
-export type DescriptionResources = {
-  __typename?: 'DescriptionResources';
-  externalLinks: Array<Scalars['String']['output']>;
-  infoUrls: Array<Scalars['String']['output']>;
-  mediaResources: Array<MediaResource>;
-};
-
 /** The discussion setting type */
 export type DiscussionSettings = {
   __typename?: 'DiscussionSettings';
@@ -3190,97 +3161,6 @@ export type EnqueuedStylesheetConnectionPageInfo = {
   startCursor?: Maybe<Scalars['String']['output']>;
 };
 
-/** Information about enrolled participant(s) in an event occurrence */
-export type Enrolment = {
-  __typename?: 'Enrolment';
-  enroller?: Maybe<Person>;
-  event?: Maybe<EventOccurrence>;
-  extraInformation?: Maybe<Scalars['String']['output']>;
-  meta?: Maybe<NodeMeta>;
-  overseerCount?: Maybe<Scalars['Int']['output']>;
-  overseers?: Maybe<Array<Person>>;
-  participantCategory?: Maybe<KeywordString>;
-  participantCount: Scalars['Int']['output'];
-  participants?: Maybe<Array<Person>>;
-  requestedMethodOfNotification?: Maybe<ContactMedium>;
-  status?: Maybe<EnrolmentStatus>;
-};
-
-/** Rules about who can enroll to an event and how */
-export type EnrolmentPolicy = {
-  __typename?: 'EnrolmentPolicy';
-  allowedParticipantCategories: Array<KeywordString>;
-  enrolmentTime?: Maybe<TimeDescription>;
-  /** maximum number of people who can enrol together (at the same time) */
-  maximumEnrolmentCount?: Maybe<Scalars['Int']['output']>;
-  meta?: Maybe<NodeMeta>;
-  /** minimum number of people who can enrol together (at the same time) */
-  minimumEnrolmentCount?: Maybe<Scalars['Int']['output']>;
-  participantMaximumAge: Scalars['Int']['output'];
-  participantMinimumAge: Scalars['Int']['output'];
-  type: Array<EnrolmentPolicyType>;
-};
-
-export enum EnrolmentPolicyType {
-  Groups = 'GROUPS',
-  GroupsWithSupervisors = 'GROUPS_WITH_SUPERVISORS',
-  Individuals = 'INDIVIDUALS',
-  NoEnrolmentNeeded = 'NO_ENROLMENT_NEEDED',
-}
-
-export enum EnrolmentStatus {
-  Cancelled = 'CANCELLED',
-  Confirmed = 'CONFIRMED',
-  Declined = 'DECLINED',
-  Queued = 'QUEUED',
-  Requested = 'REQUESTED',
-}
-
-/**
- * Request for equipment - if someone needs equipment for a purpose such
- * as organising a volunteering event (as is the case in park cleaning
- * bees), a specification of what is being requested.
- */
-export type EquipmentRequest = {
-  __typename?: 'EquipmentRequest';
-  deliveryLocation?: Maybe<LocationDescription>;
-  estimatedAmount?: Maybe<Scalars['Int']['output']>;
-  extraInformation: Scalars['String']['output'];
-  meta?: Maybe<NodeMeta>;
-  requestedEquipment: Scalars['String']['output'];
-  requestedForEvent?: Maybe<Event>;
-  returnLocation?: Maybe<LocationDescription>;
-};
-
-/**
- * An organised event - something that happens at a specific time, has a
- * specific topic or content, and people can participate.  Examples include
- * meetups, concerts, volunteering occasions (or bees), happenings.  This
- * corresponds to Linked events/courses event, beta.kultus
- * PalvelutarjotinEventNode, Kukkuu event.
- */
-export type Event = {
-  __typename?: 'Event';
-  contactPerson?: Maybe<LegalEntity>;
-  description?: Maybe<LanguageString>;
-  descriptionResources?: Maybe<DescriptionResources>;
-  enrolmentPolicy?: Maybe<EnrolmentPolicy>;
-  eventDataSource?: Maybe<Scalars['String']['output']>;
-  eventLanguages: Array<UnifiedSearchLanguageEnum>;
-  keywords: Array<KeywordString>;
-  meta?: Maybe<NodeMeta>;
-  name?: Maybe<LanguageString>;
-  occurrences: Array<EventOccurrence>;
-  organiser?: Maybe<LegalEntity>;
-  pricing?: Maybe<Array<EventPricing>>;
-  published?: Maybe<Scalars['DateTime']['output']>;
-  publisher?: Maybe<LegalEntity>;
-  shortDescription?: Maybe<Scalars['String']['output']>;
-  subEvents: Array<Event>;
-  superEvent?: Maybe<Event>;
-  targetAudience?: Maybe<Array<KeywordString>>;
-};
-
 export type EventDetails = {
   __typename?: 'EventDetails';
   audience: Array<Audience>;
@@ -3344,43 +3224,6 @@ export type EventListResponse = {
   __typename?: 'EventListResponse';
   data: Array<EventDetails>;
   meta: Meta;
-};
-
-export type EventOccurrence = {
-  __typename?: 'EventOccurrence';
-  /** for events where equipment is requested from the City of Helsinki */
-  cityEquipmentRequests?: Maybe<Array<EquipmentRequest>>;
-  currentlyAvailableParticipantCount?: Maybe<Scalars['Int']['output']>;
-  enrolments: Array<Enrolment>;
-  /**
-   * for information - for example, to guide people who are looking for
-   * big or small events, or to give city officials a hint on how much
-   * equipment is needed
-   */
-  estimatedAttendeeCount?: Maybe<Scalars['Int']['output']>;
-  happensAt?: Maybe<TimeDescription>;
-  location?: Maybe<LocationDescription>;
-  maximumAttendeeCount?: Maybe<Scalars['Int']['output']>;
-  meta?: Maybe<NodeMeta>;
-  minimumAttendeeCount?: Maybe<Scalars['Int']['output']>;
-  /** which event this is an occurrence of */
-  ofEvent?: Maybe<Event>;
-  status?: Maybe<EventOccurrenceStatus>;
-};
-
-export enum EventOccurrenceStatus {
-  Cancelled = 'CANCELLED',
-  Postponed = 'POSTPONED',
-  Published = 'PUBLISHED',
-  Rescheduled = 'RESCHEDULED',
-  Unpublished = 'UNPUBLISHED',
-}
-
-/** TODO: improve (a lot) over Linked events' offer type */
-export type EventPricing = {
-  __typename?: 'EventPricing';
-  meta?: Maybe<NodeMeta>;
-  todo?: Maybe<Scalars['String']['output']>;
 };
 
 /** Collection Module: EventSearch */
@@ -4051,19 +3894,6 @@ export type Hits = {
   total?: Maybe<HitTotal>;
 };
 
-export enum IdentificationStrength {
-  /** If the person has authenticated with at least some method */
-  Authenticated = 'AUTHENTICATED',
-  /** If the person has done some identifiable action such as payment */
-  Indirect = 'INDIRECT',
-  /** If the person has proved their legal identity */
-  LegallyConnected = 'LEGALLY_CONNECTED',
-  /** If this person is just a pseudoperson for contacting */
-  Nonidentifiable = 'NONIDENTIFIABLE',
-  /** If the identity of this person is not known at all */
-  Unidentified = 'UNIDENTIFIED',
-}
-
 /** Kuva */
 export type Image = {
   __typename?: 'Image';
@@ -4121,15 +3951,6 @@ export type KeywordListResponse = {
   __typename?: 'KeywordListResponse';
   data: Array<Keyword>;
   meta: Meta;
-};
-
-/**
- * TODO: merge all free tags, categories, and keywords
- * KEYWORDS ARE GIVEN FROM events-proxy (https://events-graphql-proxy.test.hel.ninja/proxy/graphql)
- */
-export type KeywordString = {
-  __typename?: 'KeywordString';
-  name: Scalars['String']['output'];
 };
 
 /** The landingPage type */
@@ -4699,7 +4520,6 @@ export enum LanguageCodeFilterEnum {
   Sv = 'SV',
 }
 
-/** TODO: convert all String's to LanguageString's if linguistic content */
 export type LanguageString = {
   __typename?: 'LanguageString';
   en?: Maybe<Scalars['String']['output']>;
@@ -4918,8 +4738,6 @@ export type LayoutSteps = {
   type?: Maybe<Scalars['String']['output']>;
 };
 
-export type LegalEntity = Organisation | Person;
-
 /** Linkin kenttä */
 export type Link = {
   __typename?: 'Link';
@@ -4929,62 +4747,6 @@ export type Link = {
   title?: Maybe<Scalars['String']['output']>;
   /** Linkin URL osoite */
   url?: Maybe<Scalars['String']['output']>;
-};
-
-export type LinkedeventsPlace = {
-  __typename?: 'LinkedeventsPlace';
-  _at_context?: Maybe<Scalars['String']['output']>;
-  _at_id?: Maybe<Scalars['String']['output']>;
-  _at_type?: Maybe<Scalars['String']['output']>;
-  address_country?: Maybe<Scalars['String']['output']>;
-  address_locality?: Maybe<LinkedeventsPlaceLocalityString>;
-  address_region?: Maybe<Scalars['String']['output']>;
-  contact_type?: Maybe<Scalars['String']['output']>;
-  created_time?: Maybe<Scalars['String']['output']>;
-  custom_data?: Maybe<Scalars['String']['output']>;
-  data_source?: Maybe<Scalars['String']['output']>;
-  deleted?: Maybe<Scalars['Boolean']['output']>;
-  description?: Maybe<LinkedeventsPlaceLocalityString>;
-  divisions?: Maybe<Array<Maybe<LinkedeventsPlaceDivision>>>;
-  email?: Maybe<Scalars['String']['output']>;
-  has_upcoming_events?: Maybe<Scalars['Boolean']['output']>;
-  id?: Maybe<Scalars['String']['output']>;
-  image?: Maybe<Scalars['String']['output']>;
-  info_url?: Maybe<LinkedeventsPlaceLocalityString>;
-  last_modified_time?: Maybe<Scalars['String']['output']>;
-  n_events?: Maybe<Scalars['Int']['output']>;
-  name?: Maybe<LinkedeventsPlaceLocalityString>;
-  /** Raw Linkedevents Place fields */
-  origin?: Maybe<Scalars['String']['output']>;
-  parent?: Maybe<Scalars['String']['output']>;
-  position?: Maybe<LinkedeventsPlacePosition>;
-  post_office_box_num?: Maybe<Scalars['String']['output']>;
-  postal_code?: Maybe<Scalars['String']['output']>;
-  publisher?: Maybe<Scalars['String']['output']>;
-  replaced_by?: Maybe<Scalars['String']['output']>;
-  street_address?: Maybe<LinkedeventsPlaceLocalityString>;
-  telephone?: Maybe<Scalars['String']['output']>;
-};
-
-export type LinkedeventsPlaceDivision = {
-  __typename?: 'LinkedeventsPlaceDivision';
-  municipality?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<LinkedeventsPlaceLocalityString>;
-  ocd_id?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
-};
-
-export type LinkedeventsPlaceLocalityString = {
-  __typename?: 'LinkedeventsPlaceLocalityString';
-  en?: Maybe<Scalars['String']['output']>;
-  fi?: Maybe<Scalars['String']['output']>;
-  sv?: Maybe<Scalars['String']['output']>;
-};
-
-export type LinkedeventsPlacePosition = {
-  __typename?: 'LinkedeventsPlacePosition';
-  coordinates?: Maybe<Array<Maybe<Scalars['Float']['output']>>>;
-  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type LocalizedCmsImage = {
@@ -5008,7 +4770,7 @@ export type LocalizedObject = {
   sv?: Maybe<Scalars['String']['output']>;
 };
 
-/** Free-form location, not necessarily at a know venue. */
+/** Free-form location, not necessarily at a known venue. */
 export type LocationDescription = {
   __typename?: 'LocationDescription';
   address?: Maybe<Address>;
@@ -5016,7 +4778,6 @@ export type LocationDescription = {
   explanation?: Maybe<Scalars['String']['output']>;
   geoLocation?: Maybe<GeoJsonFeature>;
   url?: Maybe<LanguageString>;
-  venue?: Maybe<UnifiedSearchVenue>;
 };
 
 export type LocationImage = {
@@ -5395,13 +5156,6 @@ export enum MediaItemStatusEnum {
   /** Objects with the trash status */
   Trash = 'TRASH',
 }
-
-/** TODO: take this from Linked events Image type. */
-export type MediaResource = {
-  __typename?: 'MediaResource';
-  meta?: Maybe<NodeMeta>;
-  todo?: Maybe<Scalars['String']['output']>;
-};
 
 /** Details of an available size for a media item */
 export type MediaSize = {
@@ -6439,13 +6193,6 @@ export enum OrderEnum {
   Desc = 'DESC',
 }
 
-/** TODO: merge beta.kultus organisation, etc */
-export type Organisation = {
-  __typename?: 'Organisation';
-  contactDetails?: Maybe<ContactInfo>;
-  meta?: Maybe<NodeMeta>;
-};
-
 export type OrganizationDetails = {
   __typename?: 'OrganizationDetails';
   affiliatedOrganizations?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
@@ -6889,23 +6636,6 @@ export type PalvelukarttaUnit = {
   www_en?: Maybe<Scalars['String']['output']>;
   www_fi?: Maybe<Scalars['String']['output']>;
   www_sv?: Maybe<Scalars['String']['output']>;
-};
-
-/** TODO: take from Profile */
-export type Person = {
-  __typename?: 'Person';
-  contactDetails?: Maybe<ContactInfo>;
-  identificationStrength?: Maybe<IdentificationStrength>;
-  meta?: Maybe<NodeMeta>;
-  name?: Maybe<Scalars['String']['output']>;
-  preferredLanguages?: Maybe<Array<UnifiedSearchLanguageEnum>>;
-  preferredMedium?: Maybe<ContactMedium>;
-};
-
-export type PhoneNumber = {
-  __typename?: 'PhoneNumber';
-  countryCode: Scalars['String']['output'];
-  restNumber: Scalars['String']['output'];
 };
 
 export type Place = {
@@ -8321,6 +8051,20 @@ export enum ProviderType {
 export type Query = {
   __typename?: 'Query';
   _empty?: Maybe<Scalars['String']['output']>;
+  /**
+   * Get Helsinki/Finland administrative divisions i.e.
+   * neighborhoods (=kaupunginosat), sub-districts (=osa-alueet),
+   * municipalities (=kunnat) etc.
+   *
+   * Based on imported data from [django-munigeo](https://github.com/City-of-Helsinki/django-munigeo):
+   * - "geo_import finland --municipalities"
+   * - "geo_import helsinki --divisions"
+   *
+   * Used django-munigeo importers:
+   * - [geo_import](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/management/commands/geo_import.py)
+   *   - [finland](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/finland.py)
+   *   - [helsinki](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/helsinki.py)
+   */
   administrativeDivisions?: Maybe<Array<Maybe<AdministrativeDivision>>>;
   /** Entry point to get all settings for the site */
   allSettings?: Maybe<Settings>;
@@ -9086,6 +8830,7 @@ export type QueryUnifiedSearchArgs = {
   orderByName?: InputMaybe<OrderByName>;
   providerTypes?: InputMaybe<Array<InputMaybe<ProviderType>>>;
   serviceOwnerTypes?: InputMaybe<Array<InputMaybe<ServiceOwnerType>>>;
+  showCultureAndLeisureDivisionFirst?: InputMaybe<Scalars['Boolean']['input']>;
   targetGroups?: InputMaybe<Array<InputMaybe<TargetGroup>>>;
   text?: InputMaybe<Scalars['String']['input']>;
 };
@@ -11356,9 +11101,7 @@ export type SearchResultEdge = {
 export type SearchResultNode = {
   __typename?: 'SearchResultNode';
   _score?: Maybe<Scalars['Float']['output']>;
-  event?: Maybe<Event>;
   id: Scalars['ID']['output'];
-  searchCategories: Array<UnifiedSearchResultCategory>;
   venue?: Maybe<UnifiedSearchVenue>;
 };
 
@@ -11894,6 +11637,7 @@ export enum TargetGroup {
   Enterprises = 'ENTERPRISES',
   Immigrants = 'IMMIGRANTS',
   Individuals = 'INDIVIDUALS',
+  LongTermPatients = 'LONG_TERM_PATIENTS',
   Youth = 'YOUTH',
 }
 
@@ -12354,14 +12098,6 @@ export type Time = {
   startTime: Scalars['String']['output'];
 };
 
-/** any kind of description answering the question "when". */
-export type TimeDescription = {
-  __typename?: 'TimeDescription';
-  ending?: Maybe<Scalars['DateTime']['output']>;
-  otherTime?: Maybe<TimeDescription>;
-  starting?: Maybe<Scalars['DateTime']['output']>;
-};
-
 /** The translation type */
 export type Translation = ContentNode &
   DatabaseIdentifier &
@@ -12631,7 +12367,6 @@ export type TranslationToRevisionConnectionWhereArgs = {
 
 export enum UnifiedSearchIndex {
   AdministrativeDivision = 'administrative_division',
-  Event = 'event',
   HelsinkiCommonAdministrativeDivision = 'helsinki_common_administrative_division',
   Location = 'location',
   OntologyTree = 'ontology_tree',
@@ -12644,21 +12379,6 @@ export enum UnifiedSearchLanguage {
   Swedish = 'SWEDISH',
 }
 
-/** TODO: take from Profile or external source */
-export enum UnifiedSearchLanguageEnum {
-  Fi = 'FI',
-}
-
-export enum UnifiedSearchResultCategory {
-  Article = 'ARTICLE',
-  Artwork = 'ARTWORK',
-  Enrollable = 'ENROLLABLE',
-  Event = 'EVENT',
-  PointOfInterest = 'POINT_OF_INTEREST',
-  Reservable = 'RESERVABLE',
-  Service = 'SERVICE',
-}
-
 /**
  * A place that forms a unit and can be used for some specific purpose -
  * respa unit or resource, service map unit, beta.kultus venue, linked
@@ -12669,20 +12389,15 @@ export type UnifiedSearchVenue = {
   accessibility?: Maybe<Accessibility>;
   /** Accessibility shortcoming for a specific accessibility profile. */
   accessibilityShortcomingFor?: Maybe<AccessibilityShortcoming>;
-  additionalInfo?: Maybe<Scalars['String']['output']>;
-  arrivalInstructions?: Maybe<Scalars['String']['output']>;
-  contactDetails?: Maybe<ContactInfo>;
   description?: Maybe<LanguageString>;
-  descriptionResources?: Maybe<DescriptionResources>;
-  facilities?: Maybe<Array<VenueFacility>>;
+  eventCount?: Maybe<Scalars['Int']['output']>;
   images?: Maybe<Array<Maybe<LocationImage>>>;
+  isCultureAndLeisureDivisionVenue?: Maybe<Scalars['Boolean']['output']>;
   location?: Maybe<LocationDescription>;
-  manager?: Maybe<LegalEntity>;
   meta?: Maybe<NodeMeta>;
   name?: Maybe<LanguageString>;
   ontologyWords?: Maybe<Array<Maybe<OntologyWord>>>;
   openingHours?: Maybe<OpeningHours>;
-  partOf?: Maybe<UnifiedSearchVenue>;
   reservation?: Maybe<Reservation>;
   serviceOwner?: Maybe<ServiceOwner>;
   targetGroups?: Maybe<Array<Maybe<TargetGroup>>>;
@@ -14172,14 +13887,6 @@ export type VenueDepartment = {
   www?: Maybe<Scalars['String']['output']>;
 };
 
-/** TODO: combine beta.kultus Venue stuff with respa equipment type */
-export type VenueFacility = {
-  __typename?: 'VenueFacility';
-  categories?: Maybe<Array<KeywordString>>;
-  meta?: Maybe<NodeMeta>;
-  name: Scalars['String']['output'];
-};
-
 /** Information about pagination in a connection. */
 export type WpPageInfo = {
   /** When paginating forwards, the cursor to continue. */
@@ -15612,6 +15319,7 @@ export type SearchListQueryVariables = Exact<{
   orderByAccessibilityProfile?: InputMaybe<AccessibilityProfile>;
   showAccessibilityShortcomingsFor?: InputMaybe<AccessibilityProfile>;
   mustHaveReservableResource?: InputMaybe<Scalars['Boolean']['input']>;
+  showCultureAndLeisureDivisionFirst?: InputMaybe<Scalars['Boolean']['input']>;
   includeHaukiFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
@@ -15631,6 +15339,7 @@ export type SearchListQuery = {
         __typename?: 'SearchResultNode';
         venue?: {
           __typename?: 'UnifiedSearchVenue';
+          isCultureAndLeisureDivisionVenue?: boolean | null;
           targetGroups?: Array<TargetGroup | null> | null;
           meta?: { __typename?: 'NodeMeta'; id: string } | null;
           name?: {
@@ -17712,6 +17421,7 @@ export const SearchListDocument = gql`
     $orderByAccessibilityProfile: AccessibilityProfile
     $showAccessibilityShortcomingsFor: AccessibilityProfile
     $mustHaveReservableResource: Boolean
+    $showCultureAndLeisureDivisionFirst: Boolean
     $includeHaukiFields: Boolean = true
   ) {
     unifiedSearch(
@@ -17731,6 +17441,7 @@ export const SearchListDocument = gql`
       orderByDistance: $orderByDistance
       orderByName: $orderByName
       orderByAccessibilityProfile: $orderByAccessibilityProfile
+      showCultureAndLeisureDivisionFirst: $showCultureAndLeisureDivisionFirst
     ) {
       count
       pageInfo {
@@ -17743,6 +17454,7 @@ export const SearchListDocument = gql`
             meta {
               id
             }
+            isCultureAndLeisureDivisionVenue
             name {
               fi
               sv
@@ -17862,6 +17574,7 @@ export const SearchListDocument = gql`
  *      orderByAccessibilityProfile: // value for 'orderByAccessibilityProfile'
  *      showAccessibilityShortcomingsFor: // value for 'showAccessibilityShortcomingsFor'
  *      mustHaveReservableResource: // value for 'mustHaveReservableResource'
+ *      showCultureAndLeisureDivisionFirst: // value for 'showCultureAndLeisureDivisionFirst'
  *      includeHaukiFields: // value for 'includeHaukiFields'
  *   },
  * });

--- a/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
+++ b/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
@@ -338,6 +338,7 @@ type UnifiedSearchVenue {
   images: [LocationImage]
   ontologyWords: [OntologyWord]
   isCultureAndLeisureDivisionVenue: Boolean
+  eventCount: Int
 }
 
 type Address {

--- a/proxies/events-graphql-federation/supergraph.graphql
+++ b/proxies/events-graphql-federation/supergraph.graphql
@@ -18269,6 +18269,7 @@ type UnifiedSearchVenue
   images: [LocationImage]
   ontologyWords: [OntologyWord]
   isCultureAndLeisureDivisionVenue: Boolean
+  eventCount: Int
 }
 
 """Any node that has a URI"""


### PR DESCRIPTION
## Description

Show Culture and Leisure Division's venues first in relevance sort,
and secondarily by event count after relevance sorting (The latter
is now by default when sorting by relevance, so nothing is needed
to enable this in events-helsinki-monorepo, only using a suitably
upgraded unified-search instance is needed—which is the case).

## Related

- [LIIKUNTA-684](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-684)
- Unified search support for sorting by Culture and Leisure Division inclusion:
  - https://github.com/City-of-Helsinki/unified-search/pull/209
- Add support for secondary sorting of venues by event count after relevance score:
  - https://github.com/City-of-Helsinki/unified-search/pull/218

## Manual testing

Approved by Liikunta's product owner.

I tried some of the Liikunta venue search queries using test unified search and checked that
they were sorted first according to isCultureAndLeisureDivisionVenue and then with eventCount. ✅ 

## Additional notes

Browser tests are still failing because of Chrome 140→142 breaking testcafe tests.
Testcafe's fix is still ongoing, see https://github.com/DevExpress/testcafe/issues/8446

[LIIKUNTA-684]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ