### PR TITLE
fix: dynamic imports should not be done inside components

### DIFF
--- a/apps/events-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/articles/[...slug].tsx
@@ -59,6 +59,13 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const CATEGORIES_AMOUNT = 20;
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const NextCmsArticle: NextPage<{
   previewToken: string;
   article: ArticleType;
@@ -101,13 +108,6 @@ const NextCmsArticle: NextPage<{
   // NOTE: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
   if (!article) return null;
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/events-helsinki/src/pages/articles/index.tsx
+++ b/apps/events-helsinki/src/pages/articles/index.tsx
@@ -52,6 +52,14 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const CATEGORIES_AMOUNT = 20;
 
+const SearchPageContentNoSSR = dynamic(
+  () =>
+    import('react-helsinki-headless-cms').then((mod) => mod.SearchPageContent),
+  {
+    ssr: false,
+  }
+);
+
 interface ArticleFilters {
   text?: string | null;
   tags?: string[];
@@ -208,16 +216,6 @@ export default function ArticleArchive({
   );
 
   const { footerMenu } = useContext(NavigationContext);
-
-  const SearchPageContentNoSSR = dynamic(
-    () =>
-      import('react-helsinki-headless-cms').then(
-        (mod) => mod.SearchPageContent
-      ),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/events-helsinki/src/pages/index.tsx
+++ b/apps/events-helsinki/src/pages/index.tsx
@@ -38,6 +38,13 @@ import cmsHelper from '../domain/app/headlessCmsHelper';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 import { LandingPageContentLayout } from '../domain/search/landingPage/LandingPage';
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const HomePage: NextPage<{
   page: PageType;
   locale: string;
@@ -48,13 +55,6 @@ const HomePage: NextPage<{
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/events-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/events-helsinki/src/pages/pages/[...slug].tsx
@@ -43,6 +43,13 @@ import cmsHelper from '../../domain/app/headlessCmsHelper';
 import { eventsApolloClient } from '../../domain/clients/eventsApolloClient';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const NextCmsPage: NextPage<{
   previewToken: string;
   page: PageType;
@@ -58,13 +65,6 @@ const NextCmsPage: NextPage<{
   // NOTE: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
   if (!page) return null;
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/events-helsinki/src/pages/search/index.tsx
+++ b/apps/events-helsinki/src/pages/search/index.tsx
@@ -36,6 +36,13 @@ import { eventsApolloClient } from '../../domain/clients/eventsApolloClient';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 import AdvancedSearch from '../../domain/search/eventSearch/advancedSearch/AdvancedSearch';
 
+const SearchPageNoSSR = dynamic(
+  () => import('../../domain/search/eventSearch/SearchPage'),
+  {
+    ssr: false,
+  }
+);
+
 const Search: NextPage<{
   previewToken: string;
   page: PageType;
@@ -64,13 +71,6 @@ const Search: NextPage<{
   }, [scrollTo]);
 
   const { footerMenu } = useContext(NavigationContext);
-
-  const SearchPageNoSSR = dynamic(
-    () => import('../../domain/search/eventSearch/SearchPage'),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/[...slug].tsx
@@ -59,6 +59,13 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const CATEGORIES_AMOUNT = 20;
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const NextCmsArticle: NextPage<{
   previewToken: string;
   article: ArticleType;
@@ -100,13 +107,6 @@ const NextCmsArticle: NextPage<{
   // NOTE: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
   if (!article) return null;
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/hobbies-helsinki/src/pages/articles/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/articles/index.tsx
@@ -52,6 +52,14 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const CATEGORIES_AMOUNT = 20;
 
+const SearchPageContentNoSSR = dynamic(
+  () =>
+    import('react-helsinki-headless-cms').then((mod) => mod.SearchPageContent),
+  {
+    ssr: false,
+  }
+);
+
 interface ArticleFilters {
   text?: string | null;
   tags?: string[];
@@ -208,16 +216,6 @@ export default function ArticleArchive({
   );
 
   const { footerMenu } = useContext(NavigationContext);
-
-  const SearchPageContentNoSSR = dynamic(
-    () =>
-      import('react-helsinki-headless-cms').then(
-        (mod) => mod.SearchPageContent
-      ),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/hobbies-helsinki/src/pages/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/index.tsx
@@ -32,6 +32,13 @@ import cmsHelper from '../domain/app/headlessCmsHelper';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 import { LandingPageContentLayout } from '../domain/search/landingPage/LandingPage';
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const HomePage: NextPage<{
   previewToken: string;
   page: PageType;
@@ -42,13 +49,6 @@ const HomePage: NextPage<{
   } = useConfig();
   const { footerMenu } = useContext(NavigationContext);
   const { resilientT } = useResilientTranslation();
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/hobbies-helsinki/src/pages/pages/[...slug].tsx
@@ -43,6 +43,13 @@ import cmsHelper from '../../domain/app/headlessCmsHelper';
 import { hobbiesApolloClient } from '../../domain/clients/hobbiesApolloClient';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const NextCmsPage: NextPage<{
   previewToken: string;
   page: PageType;
@@ -58,13 +65,6 @@ const NextCmsPage: NextPage<{
   // NOTE: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
   if (!page) return null;
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/hobbies-helsinki/src/pages/search/index.tsx
+++ b/apps/hobbies-helsinki/src/pages/search/index.tsx
@@ -36,6 +36,13 @@ import { hobbiesApolloClient } from '../../domain/clients/hobbiesApolloClient';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 import AdvancedSearch from '../../domain/search/eventSearch/advancedSearch/AdvancedSearch';
 
+const SearchPageNoSSR = dynamic(
+  () => import('../../domain/search/eventSearch/SearchPage'),
+  {
+    ssr: false,
+  }
+);
+
 const Search: NextPage<{
   previewToken: string;
   page: PageType;
@@ -63,13 +70,6 @@ const Search: NextPage<{
     }
   }, [scrollTo]);
   const { footerMenu } = useContext(NavigationContext);
-
-  const SearchPageNoSSR = dynamic(
-    () => import('../../domain/search/eventSearch/SearchPage'),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/sports-helsinki/src/pages/articles/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/articles/[...slug].tsx
@@ -59,6 +59,13 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const CATEGORIES_AMOUNT = 20;
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const NextCmsArticle: NextPage<{
   previewToken: string;
   article: ArticleType;
@@ -100,13 +107,6 @@ const NextCmsArticle: NextPage<{
   // NOTE: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
   if (!article) return null;
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/sports-helsinki/src/pages/articles/index.tsx
+++ b/apps/sports-helsinki/src/pages/articles/index.tsx
@@ -52,6 +52,13 @@ import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTransl
 
 const CATEGORIES_AMOUNT = 20;
 
+const SearchPageContentNoSSR = dynamic(
+  () =>
+    import('react-helsinki-headless-cms').then((mod) => mod.SearchPageContent),
+  {
+    ssr: false,
+  }
+);
 interface ArticleFilters {
   text?: string | null;
   tags?: string[];
@@ -208,16 +215,6 @@ export default function ArticleArchive({
   );
 
   const { footerMenu } = useContext(NavigationContext);
-
-  const SearchPageContentNoSSR = dynamic(
-    () =>
-      import('react-helsinki-headless-cms').then(
-        (mod) => mod.SearchPageContent
-      ),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/sports-helsinki/src/pages/index.tsx
+++ b/apps/sports-helsinki/src/pages/index.tsx
@@ -32,6 +32,13 @@ import cmsHelper from '../domain/app/headlessCmsHelper';
 import serverSideTranslationsWithCommon from '../domain/i18n/serverSideTranslationsWithCommon';
 import { LandingPageContentLayout } from '../domain/search/landingPage/LandingPage';
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const HomePage: NextPage<{
   page: PageType;
   previewToken: string;
@@ -43,13 +50,6 @@ const HomePage: NextPage<{
   const { footerMenu } = useContext(NavigationContext);
 
   const { resilientT } = useResilientTranslation();
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/sports-helsinki/src/pages/pages/[...slug].tsx
+++ b/apps/sports-helsinki/src/pages/pages/[...slug].tsx
@@ -43,6 +43,13 @@ import cmsHelper from '../../domain/app/headlessCmsHelper';
 import { sportsApolloClient } from '../../domain/clients/sportsApolloClient';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 
+const RHHCPageContentNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
+  {
+    ssr: false,
+  }
+);
+
 const NextCmsPage: NextPage<{
   previewToken: string;
   page: PageType;
@@ -58,13 +65,6 @@ const NextCmsPage: NextPage<{
   // NOTE: Return null to fix SSR rendering for notFound-page.
   // This is needed only with fallback: true, but should not be needed at all.
   if (!page) return null;
-
-  const RHHCPageContentNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.PageContent),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <RHHCPage

--- a/apps/sports-helsinki/src/pages/search/index.tsx
+++ b/apps/sports-helsinki/src/pages/search/index.tsx
@@ -34,6 +34,13 @@ import cmsHelper from '../../domain/app/headlessCmsHelper';
 import { sportsApolloClient } from '../../domain/clients/sportsApolloClient';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 
+const CombinedSearchPageNoSSR = dynamic(
+  () => import('../../domain/search/combinedSearch/CombinedSearchPage'),
+  {
+    ssr: false,
+  }
+);
+
 const Search: NextPage<{
   page: PageType;
   previewToken: string;
@@ -44,13 +51,6 @@ const Search: NextPage<{
   const { resilientT } = useResilientTranslation();
 
   usePageScrollRestoration();
-
-  const CombinedSearchPageNoSSR = dynamic(
-    () => import('../../domain/search/combinedSearch/CombinedSearchPage'),
-    {
-      ssr: false,
-    }
-  );
 
   const pageTitle = page?.title?.trim() || undefined;
   const pageDescription =

--- a/packages/components/src/components/footer/Footer.tsx
+++ b/packages/components/src/components/footer/Footer.tsx
@@ -10,6 +10,13 @@ import useLocale from '../../hooks/useLocale';
 import { resetFocusId } from '../resetFocus/ResetFocus';
 import styles from './footer.module.scss';
 
+const UserTrackingFeatures = dynamic(
+  () => import('../widgets/UserTrackingFeatures').then((mod) => mod),
+  {
+    ssr: false,
+  }
+);
+
 type FooterSectionProps = {
   appName: string;
   menu?: Menu;
@@ -44,13 +51,6 @@ const FooterSection: FunctionComponent<FooterSectionProps> = ({
     window?.scrollTo({ top: 0 });
     document.querySelector<HTMLDivElement>(`#${resetFocusId}`)?.focus();
   };
-
-  const UserTrackingFeatures = dynamic(
-    () => import('../widgets/UserTrackingFeatures').then((mod) => mod),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <>

--- a/packages/components/src/components/navigation/Navigation.tsx
+++ b/packages/components/src/components/navigation/Navigation.tsx
@@ -21,6 +21,13 @@ type NavigationProps = {
   languages?: Language[];
 };
 
+const RHHCNavigationNoSSR = dynamic(
+  () => import('react-helsinki-headless-cms').then((mod) => mod.Navigation),
+  {
+    ssr: false,
+  }
+);
+
 export default function Navigation({
   page,
   menu,
@@ -39,13 +46,6 @@ export default function Navigation({
     forcedLanguages ??
     languages ??
     languagesQuery.data?.languages?.filter(isLanguage);
-
-  const RHHCNavigationNoSSR = dynamic(
-    () => import('react-helsinki-headless-cms').then((mod) => mod.Navigation),
-    {
-      ssr: false,
-    }
-  );
 
   return (
     <>


### PR DESCRIPTION
HCRC-178 TH-1458 LIIKUNTA-649.

IF a dynamic import is made inside a component, it's imported every time a component rerenders. 

This is a really bad practise. Why it’s wrong:

- React Principles: This violates a core rule of React. Defining a component (or calling a Hook-like function) inside another component's render function means a new, different component is created on every single render.
- State Loss: Because React thinks it's a completely new component type each time MyPage renders, it will destroy the old component (and all its internal state, like form inputs or useState) and mount a new one.
- Performance: This is extremely inefficient and will lead to unpredictable behavior and performance problems.



