### PR TITLE
LIIKUNTA-684 | Update unified-search subgraph & supergraph

### DIFF
--- a/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
+++ b/proxies/events-graphql-federation/subgraphs/unified-search/unified-search.graphql
@@ -167,6 +167,13 @@ type Query {
     Mutually exclusive with other orderBy* parameters.
     """
     orderByAccessibilityProfile: AccessibilityProfile
+
+    """
+    Optional, show Culture and Leisure Division's venues first?
+    If false or not given, does nothing.
+    If true, shows Culture and Leisure Division's venues first, then others'.
+    """
+    showCultureAndLeisureDivisionFirst: Boolean
   ): SearchResultConnection
   unifiedSearchCompletionSuggestions(
     """
@@ -330,6 +337,7 @@ type UnifiedSearchVenue {
   accessibilityShortcomingFor(profile: AccessibilityProfile): AccessibilityShortcoming
   images: [LocationImage]
   ontologyWords: [OntologyWord]
+  isCultureAndLeisureDivisionVenue: Boolean
 }
 
 type Address {

--- a/proxies/events-graphql-federation/supergraph.graphql
+++ b/proxies/events-graphql-federation/supergraph.graphql
@@ -12979,6 +12979,13 @@ type Query
     Mutually exclusive with other orderBy* parameters.
     """
     orderByAccessibilityProfile: AccessibilityProfile
+
+    """
+    Optional, show Culture and Leisure Division's venues first?
+    If false or not given, does nothing.
+    If true, shows Culture and Leisure Division's venues first, then others'.
+    """
+    showCultureAndLeisureDivisionFirst: Boolean
   ): SearchResultConnection @join__field(graph: UNIFIED_SEARCH)
   unifiedSearchCompletionSuggestions(
     """
@@ -18261,6 +18268,7 @@ type UnifiedSearchVenue
   accessibilityShortcomingFor(profile: AccessibilityProfile): AccessibilityShortcoming
   images: [LocationImage]
   ontologyWords: [OntologyWord]
+  isCultureAndLeisureDivisionVenue: Boolean
 }
 
 """Any node that has a URI"""


### PR DESCRIPTION
## Description

Update unified-search subgraph & supergraph.

unified-search's schema changed in City-of-Helsinki/unified-search#209

done in proxies/events-graphql-federation:
```
$ rover subgraph introspect
https://kuva-unified-search.api.dev.hel.ninja/search >
subgraphs/unified-search/unified-search.graphql

$ rover supergraph compose --config ./supergraph-config.yaml >
supergraph.graphql
```

## Related

- [LIIKUNTA-684](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-684)
- Changes to unified-search schema:
  - City-of-Helsinki/unified-search#209

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-684]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ