### PR TITLE
fix(sports): move ontology words last in venue hero

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/VenueHero.tsx
@@ -123,9 +123,6 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
             <div className={styles.leftPanelWrapper}>
               <div className={styles.leftPanelEmpty} />
               <div className={styles.textWrapper}>
-                <div>
-                  <VenueKeywords whiteOnly venue={venue} />
-                </div>
                 <h1 className={styles.title}>
                   {venue.name}
                   {isHelsinkiCityOwned && <HelsinkiCityOwnedIcon />}
@@ -143,6 +140,9 @@ const VenueHero: React.FC<Props> = ({ venue }) => {
                       ))}
                     </ul>
                   </div>
+                </div>
+                <div className={styles.keywordsWrapper}>
+                  <VenueKeywords whiteOnly venue={venue} />
                 </div>
               </div>
             </div>

--- a/apps/sports-helsinki/src/domain/venue/venueHero/venueHero.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueHero/venueHero.module.scss
@@ -66,7 +66,6 @@ $logoWidth: 5.5rem;
     }
 
     .additionalInfo {
-      order: 6;
       margin-top: var(--spacing-s);
     }
 
@@ -104,12 +103,7 @@ $logoWidth: 5.5rem;
         width: unset;
       }
 
-      .categoryWrapper {
-        order: 1;
-      }
-
       .date {
-        order: 2;
         margin-top: 0.5rem;
         font-size: var(--fontsize-body-l);
         line-height: 1.625rem;
@@ -117,7 +111,6 @@ $logoWidth: 5.5rem;
       }
 
       .title {
-        order: 3;
         font-size: var(--fontsize-heading-l);
         line-height: var(--lineheight-m);
         font-weight: 400;
@@ -128,30 +121,13 @@ $logoWidth: 5.5rem;
       }
 
       .description {
-        order: 4;
         font-size: var(--fontsize-body-xl);
         line-height: var(--spacing-l);
       }
+    }
 
-      .location {
-        order: 5;
-      }
-
-      .start {
-        order: 6;
-      }
-
-      .price {
-        order: 7;
-      }
-
-      .buyButtonWrapper {
-        order: 8;
-      }
-
-      .registrationButtonWrapper {
-        order: 9;
-      }
+    .keywordsWrapper {
+      margin: var(--spacing-2-xs) 0;
     }
 
     .buyButtonWrapper {


### PR DESCRIPTION
LIIKUNTA-759.

The venue hero still had CSS that used an order attribute to reformat the venue hero content section. Removing the order attributes and moving the keywords last in DOM makes the venue hero now consistent with events hero.

<img width="1249" height="823" alt="image" src="https://github.com/user-attachments/assets/28c06889-d08b-4ac6-8e3a-1c9561b0ce4a" />
