### PR TITLE
fix: venue content line breaks (by using pre-line for white-space)

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueContent/venueContent.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueContent/venueContent.module.scss
@@ -73,6 +73,7 @@
 
 .description {
   line-height: 1.5;
+  white-space: pre-line;
 
   p {
     font-size: var(--description-font-size);


### PR DESCRIPTION
LIIKUNTA-765.

Fix line breaks of a text in a venue content. The text might contain `\n` markup for line breaks, but those were not affecting before the fix. Using `pre-line` for `white-space` should work for line breaks, but would still clean all the other formatting (that we most probably don't want).


<img width="809" height="1087" alt="image" src="https://github.com/user-attachments/assets/59e6c552-2f75-4da0-937f-4bc573d9dda9" />

