### PR TITLE
Fixes to cookie consent implementation

### DIFF
--- a/next.base.config.mjs
+++ b/next.base.config.mjs
@@ -159,7 +159,8 @@ const nextBaseConfig = ({
       // Base CSP directives
       const cspDirectives = [
         "default-src 'self'",
-        `script-src 'self' ${isDevelopment ? "'unsafe-eval'" : ''} ${isDevelopment ? "'unsafe-inline'" : ''} https://webanalytics.digiaiiris.com *.reactandshare.com *.youtube.com *.googlesyndication.com *.google-analytics.com *.googletagmanager.com *.gstatic.com`,
+        // FIXME: "'unsafe-inline'" in script-src is not good practise. It's currently required by HDS cookie consent.
+        `script-src 'self' ${isDevelopment ? "'unsafe-eval'" : ''} 'unsafe-inline' https://webanalytics.digiaiiris.com *.reactandshare.com *.youtube.com *.googlesyndication.com *.google-analytics.com *.googletagmanager.com *.gstatic.com`,
         "style-src 'self' 'unsafe-inline' https://cdn.reactandshare.com",
         "img-src * 'self' data: https:",
         "font-src 'self' *.hel.fi *.hel.ninja fonts.gstatic.com https://cdn.reactandshare.com",

--- a/packages/common-i18n/src/locales/en/consent.json
+++ b/packages/common-i18n/src/locales/en/consent.json
@@ -32,7 +32,10 @@
     "servicemap_analytics": "A cookie of the Matomo statistics system for the Service Map.",
     "servicemap_session": "Service Map session.",
     "servicemap_ga": "A Google analytics cookie for the Service Map.",
-    "wordpress": "A cookie for operation of the WordPress-content management system."
+    "wordpress": "A cookie for operation of the WordPress-content management system.",
+    "nextjs_scroll": "Used by websites to remember a user's scroll position on a page, especially after they navigate back or forward. This provides a more seamless user experience by automatically scrolling to the correct location when the user returns to a previous page.",
+    "city_of_helsinki_consent_version": "TODO: city-of-helsinki-consent-version. Can be removed if this is only for HDS v3 version of cookie consent.",
+    "city_of_helsinki_cookie_consents": "TODO: city-of-helsinki-cookie-consents. Can be removed if this is only for HDS v3 version of cookie consent."
   },
   "expiration": {
     "session": "The session cookie is deleted once the user exits the page",

--- a/packages/common-i18n/src/locales/en/consent.json
+++ b/packages/common-i18n/src/locales/en/consent.json
@@ -27,15 +27,10 @@
     "app": "Used by {{ appName }} to store information about whether visitors have given or declined the use of cookie categories used on the site.",
     "matomo": "A cookie of the Matomo statistics system.",
     "askem": "A record related to the operation of the Askem react buttons.",
-    "linkedevents": "A cookie to authorise the retrieval of events.",
-    "i18next": "A cookie to remember the website language selection.",
     "servicemap_analytics": "A cookie of the Matomo statistics system for the Service Map.",
     "servicemap_session": "Service Map session.",
     "servicemap_ga": "A Google analytics cookie for the Service Map.",
-    "wordpress": "A cookie for operation of the WordPress-content management system.",
-    "nextjs_scroll": "Used by websites to remember a user's scroll position on a page, especially after they navigate back or forward. This provides a more seamless user experience by automatically scrolling to the correct location when the user returns to a previous page.",
-    "city_of_helsinki_consent_version": "TODO: city-of-helsinki-consent-version. Can be removed if this is only for HDS v3 version of cookie consent.",
-    "city_of_helsinki_cookie_consents": "TODO: city-of-helsinki-cookie-consents. Can be removed if this is only for HDS v3 version of cookie consent."
+    "nextjs_scroll": "Used by websites to remember a user's scroll position on a page, especially after they navigate back or forward. This provides a more seamless user experience by automatically scrolling to the correct location when the user returns to a previous page."
   },
   "expiration": {
     "session": "The session cookie is deleted once the user exits the page",

--- a/packages/common-i18n/src/locales/fi/consent.json
+++ b/packages/common-i18n/src/locales/fi/consent.json
@@ -32,7 +32,10 @@
     "servicemap_analytics": "Matomo-tilastointijärjestelmän eväste palvelukartalle.",
     "servicemap_session": "Palvelukartan istunto.",
     "servicemap_ga": "Google-analytiikan eväste palvelukartalle.",
-    "wordpress": "Wordpress-sisällönhallintajärjestelmän toimintaan liittyvä eväste."
+    "wordpress": "Wordpress-sisällönhallintajärjestelmän toimintaan liittyvä eväste.",
+    "nextjs_scroll": "Verkkosivustot käyttävät tätä käyttäjän vierityskohdan muistamiseen sivulla, erityisesti sen jälkeen, kun he ovat siirtyneet taaksepäin tai eteenpäin. Tämä tarjoaa saumattomamman käyttökokemuksen vierittämällä automaattisesti oikeaan sijaintiin, kun käyttäjä palaa edelliselle sivulle.",
+    "city_of_helsinki_consent_version": "TODO: city-of-helsinki-consent-version. Can be removed if this is only for HDS v3 version of cookie consent.",
+    "city_of_helsinki_cookie_consents": "TODO: city-of-helsinki-cookie-consents. Can be removed if this is only for HDS v3 version of cookie consent."
   },
   "expiration": {
     "session": "Istunto-eväste tuhotaan, kun käyttäjä poistuu sivulta",

--- a/packages/common-i18n/src/locales/fi/consent.json
+++ b/packages/common-i18n/src/locales/fi/consent.json
@@ -27,15 +27,10 @@
     "app": "{{ appName }} -sivusto käyttää tätä evästettä tietojen tallentamiseen siitä, ovatko kävijät antaneet hyväksyntänsä tai kieltäytyneet evästeiden käytöstä.",
     "matomo": "Matomo-tilastointijärjestelmän eväste.",
     "askem": "Askem-reaktionappien toimintaan liittyvä tietue.",
-    "linkedevents": "Eväste tapahtumien hakemisen valtuuttamiseen.",
-    "i18next": "Eväste sivuston kielivalinnan muistamiseen.",
     "servicemap_analytics": "Matomo-tilastointijärjestelmän eväste palvelukartalle.",
     "servicemap_session": "Palvelukartan istunto.",
     "servicemap_ga": "Google-analytiikan eväste palvelukartalle.",
-    "wordpress": "Wordpress-sisällönhallintajärjestelmän toimintaan liittyvä eväste.",
-    "nextjs_scroll": "Verkkosivustot käyttävät tätä käyttäjän vierityskohdan muistamiseen sivulla, erityisesti sen jälkeen, kun he ovat siirtyneet taaksepäin tai eteenpäin. Tämä tarjoaa saumattomamman käyttökokemuksen vierittämällä automaattisesti oikeaan sijaintiin, kun käyttäjä palaa edelliselle sivulle.",
-    "city_of_helsinki_consent_version": "TODO: city-of-helsinki-consent-version. Can be removed if this is only for HDS v3 version of cookie consent.",
-    "city_of_helsinki_cookie_consents": "TODO: city-of-helsinki-cookie-consents. Can be removed if this is only for HDS v3 version of cookie consent."
+    "nextjs_scroll": "Verkkosivustot käyttävät tätä käyttäjän vierityskohdan muistamiseen sivulla, erityisesti sen jälkeen, kun he ovat siirtyneet taaksepäin tai eteenpäin. Tämä tarjoaa saumattomamman käyttökokemuksen vierittämällä automaattisesti oikeaan sijaintiin, kun käyttäjä palaa edelliselle sivulle."
   },
   "expiration": {
     "session": "Istunto-eväste tuhotaan, kun käyttäjä poistuu sivulta",

--- a/packages/common-i18n/src/locales/sv/consent.json
+++ b/packages/common-i18n/src/locales/sv/consent.json
@@ -32,7 +32,10 @@
     "servicemap_analytics": "Kaka för statistiksystemet Matomo på servicekartan.",
     "servicemap_session": "Session på servicekartan.",
     "servicemap_ga": "Kaka för analysverktyget Google Analytics på servicekartan.",
-    "wordpress": "Kaka för användning av WordPress-innehållshanteringssystemet."
+    "wordpress": "Kaka för användning av WordPress-innehållshanteringssystemet.",
+    "nextjs_scroll": "Används av webbplatser för att komma ihåg en användares scrollposition på en sida, särskilt efter att de navigerat bakåt eller framåt. Detta ger en mer sömlös användarupplevelse genom att automatiskt scrolla till rätt plats när användaren återgår till en föregående sida.",
+    "city_of_helsinki_consent_version": "TODO: city-of-helsinki-consent-version. Can be removed if this is only for HDS v3 version of cookie consent.",
+    "city_of_helsinki_cookie_consents": "TODO: city-of-helsinki-cookie-consents. Can be removed if this is only for HDS v3 version of cookie consent."
   },
   "expiration": {
     "session": "Sessionskakan raderas när användaren lämnar webbsidan",

--- a/packages/common-i18n/src/locales/sv/consent.json
+++ b/packages/common-i18n/src/locales/sv/consent.json
@@ -27,15 +27,10 @@
     "app": "{{ appName }} - Cookie möjliggör hantering av cookies på webbplatsen.",
     "matomo": "Kaka för statistiksystemet Matomo.",
     "askem": "En post relaterad till driften av reaktionsknappen Askem.",
-    "linkedevents": "Kaka för att söka evenemang.",
-    "i18next": "Kaka som sparar användarens språkval på webbplatsen.",
     "servicemap_analytics": "Kaka för statistiksystemet Matomo på servicekartan.",
     "servicemap_session": "Session på servicekartan.",
     "servicemap_ga": "Kaka för analysverktyget Google Analytics på servicekartan.",
-    "wordpress": "Kaka för användning av WordPress-innehållshanteringssystemet.",
-    "nextjs_scroll": "Används av webbplatser för att komma ihåg en användares scrollposition på en sida, särskilt efter att de navigerat bakåt eller framåt. Detta ger en mer sömlös användarupplevelse genom att automatiskt scrolla till rätt plats när användaren återgår till en föregående sida.",
-    "city_of_helsinki_consent_version": "TODO: city-of-helsinki-consent-version. Can be removed if this is only for HDS v3 version of cookie consent.",
-    "city_of_helsinki_cookie_consents": "TODO: city-of-helsinki-cookie-consents. Can be removed if this is only for HDS v3 version of cookie consent."
+    "nextjs_scroll": "Används av webbplatser för att komma ihåg en användares scrollposition på en sida, särskilt efter att de navigerat bakåt eller framåt. Detta ger en mer sömlös användarupplevelse genom att automatiskt scrolla till rätt plats när användaren återgår till en föregående sida."
   },
   "expiration": {
     "session": "Sessionskakan raderas när användaren lämnar webbsidan",

--- a/packages/components/src/components/eventsCookieConsent/useConsentSiteSettings.tsx
+++ b/packages/components/src/components/eventsCookieConsent/useConsentSiteSettings.tsx
@@ -67,20 +67,22 @@ function useConsentContentSource() {
         //   ),
         //   expiration: buildDict('consent:expiration.session'),
         // },
-        {
-          name: 'wordpress_*, wp-settings-*',
-          host: '.hel.fi',
-          storageType: 1,
-          description: buildDict('consent:cookies.wordpress'),
-          expiration: buildDict('consent:expiration.session'),
-        },
-        {
-          name: 'linkedevents-api-prod-csrftoken',
-          host: 'api.hel.fi',
-          storageType: 1,
-          description: buildDict('consent:cookies.linkedevents'),
-          expiration: buildDict('consent:expiration.year'),
-        },
+        // TODO: Is wordpress cookie needed at all?
+        // {
+        //   name: 'wordpress_*, wp-settings-*',
+        //   host: '.hel.fi',
+        //   storageType: 1,
+        //   description: buildDict('consent:cookies.wordpress'),
+        //   expiration: buildDict('consent:expiration.session'),
+        // },
+        // TODO: Why would linkedevents-api-prod-csrftoken be needed?
+        // {
+        //   name: 'linkedevents-api-prod-csrftoken',
+        //   host: 'api.hel.fi',
+        //   storageType: 1,
+        //   description: buildDict('consent:cookies.linkedevents'),
+        //   expiration: buildDict('consent:expiration.year'),
+        // },
       ],
     },
   ] as const;

--- a/packages/components/src/components/eventsCookieConsent/useConsentSiteSettings.tsx
+++ b/packages/components/src/components/eventsCookieConsent/useConsentSiteSettings.tsx
@@ -14,10 +14,9 @@ function useLanguages(): SiteSettingsLanguage[] {
   ];
 }
 
-function useCookieName() {
-  const { cookieDomain } = useCookieConfigurationContext();
-  const prefix = cookieDomain.replaceAll('.', '-');
-  return `${prefix}-cookie-consents`;
+function useAppCookieName() {
+  const { appName } = useCookieConfigurationContext();
+  return `${appName.toLowerCase()}-cookie-consents`;
 }
 
 function useConsentContentSource() {
@@ -26,7 +25,7 @@ function useConsentContentSource() {
   const languageCodes = languages.map((lang) => lang.code);
 
   const buildDict = createLocaleDictBuilder(languageCodes, t);
-  const cookieName = useCookieName();
+  const cookieName = useAppCookieName();
   const { cookieDomain, appName } = useCookieConfigurationContext();
 
   const requiredGroups = [
@@ -40,11 +39,37 @@ function useConsentContentSource() {
           host: cookieDomain,
           storageType: 1,
           description: buildDict('consent:cookies.app', { appName }),
-          expiration: buildDict('consent:expiration.session'),
+          expiration: buildDict('consent:expiration.days', { days: 100 }),
         },
         {
+          name: '__next_scroll_*',
+          host: cookieDomain,
+          storageType: 3,
+          description: buildDict('consent:cookies.nextjs_scroll'),
+          expiration: buildDict('consent:expiration.session'),
+        },
+        // TODO: Can be reoved, if these are for old cookie consent.
+        // {
+        //   name: 'city-of-helsinki-consent-version',
+        //   host: cookieDomain,
+        //   storageType: 1,
+        //   description: buildDict(
+        //     'consent:cookies.city_of_helsinki_consent_version'
+        //   ),
+        //   expiration: buildDict('consent:expiration.session'),
+        // },
+        // {
+        //   name: 'city-of-helsinki-cookie-consents',
+        //   host: cookieDomain,
+        //   storageType: 1,
+        //   description: buildDict(
+        //     'consent:cookies.city_of_helsinki_cookie_consents'
+        //   ),
+        //   expiration: buildDict('consent:expiration.session'),
+        // },
+        {
           name: 'wordpress_*, wp-settings-*',
-          host: 'api.hel.fi',
+          host: '.hel.fi',
           storageType: 1,
           description: buildDict('consent:cookies.wordpress'),
           expiration: buildDict('consent:expiration.session'),
@@ -55,13 +80,6 @@ function useConsentContentSource() {
           storageType: 1,
           description: buildDict('consent:cookies.linkedevents'),
           expiration: buildDict('consent:expiration.year'),
-        },
-        {
-          name: 'i18next',
-          host: 'api.hel.fi',
-          storageType: 1,
-          description: buildDict('consent:cookies.i18next'),
-          expiration: buildDict('consent:expiration.session'),
         },
       ],
     },
@@ -212,7 +230,7 @@ function useConsentTranslations() {
 
 function useConsentSiteSettings() {
   const languages = useLanguages();
-  const cookieName = useCookieName();
+  const cookieName = useAppCookieName();
   const { requiredGroups, optionalGroups } = useConsentContentSource();
   const { translations } = useConsentTranslations();
   const { appName: siteName } = useCookieConfigurationContext();


### PR DESCRIPTION
TH-1461.

First set of fixes to new cookie consent implementation.

1. Remove needless cookies from cookie consent
2. Add missing cookies to consent modal
3. Add _dangerous_ "unsafe-inline" CSP-rule for "script-src". We should try to find another solution for this.