### PR TITLE
fix(consent): consent cookie name cannot contain spaces

### DIFF
--- a/apps/events-helsinki/src/pages/_app.tsx
+++ b/apps/events-helsinki/src/pages/_app.tsx
@@ -39,7 +39,7 @@ export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 const ErrorBoundaryFallbackComponent = ({ error }: { error: Error }) => {
   const { resilientT } = useResilientTranslation();
-  const appName = resilientT('appHobbies:appName');
+  const appName = resilientT('appEvents:appName');
   return <FallbackComponent error={error} appName={appName} />;
 };
 

--- a/apps/sports-helsinki/src/pages/_app.tsx
+++ b/apps/sports-helsinki/src/pages/_app.tsx
@@ -39,7 +39,7 @@ export type CustomPageProps = NavigationProviderProps & SSRConfig;
 
 const ErrorBoundaryFallbackComponent = ({ error }: { error: Error }) => {
   const { resilientT } = useResilientTranslation();
-  const appName = resilientT('appHobbies:appName');
+  const appName = resilientT('appSports:appName');
   return <FallbackComponent error={error} appName={appName} />;
 };
 
@@ -48,6 +48,7 @@ function MyApp({ Component, pageProps }: AppProps<CustomPageProps>) {
   const locale = useLocale();
   const { asPath, pathname } = useRouter();
   const appName = resilientT('appSports:appName');
+
   return (
     <ErrorBoundary FallbackComponent={ErrorBoundaryFallbackComponent}>
       <SportsApolloProvider>

--- a/packages/components/src/components/eventsCookieConsent/useConsentSiteSettings.tsx
+++ b/packages/components/src/components/eventsCookieConsent/useConsentSiteSettings.tsx
@@ -16,7 +16,11 @@ function useLanguages(): SiteSettingsLanguage[] {
 
 function useAppCookieName() {
   const { appName } = useCookieConfigurationContext();
-  return `${appName.toLowerCase()}-cookie-consents`;
+  const prefix = appName
+    .replaceAll('.', '-')
+    .replaceAll(' ', '-')
+    .toLowerCase();
+  return `${prefix}-cookie-consents`;
 }
 
 function useConsentContentSource() {


### PR DESCRIPTION
TH-1461.

The Sports app has "Helsinki Liikkuu" set as an app name. The cookie consent cookie name cannot include spaces. Fix the useAppCookieName hook so that it generates a valid name.

Also, the Sports app and Events app had a wrong translation picked for app name.
