### PR TITLE
fix(sports): search select menu should always open downwards

### DIFF
--- a/apps/sports-helsinki/src/domain/search/combinedSearch/search.module.scss
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/search.module.scss
@@ -173,4 +173,10 @@ $buttonWidth: 180px;
   svg {
     width: var(--icon-size);
   }
+  [id='sportsCategory-sl-container'],
+  [id='targetGroup-sl-container'],
+  [id='accessibilityProfile-sl-container'] {
+    /* Fix the menu should always open downwards. */
+    bottom: unset !important;
+  }
 }


### PR DESCRIPTION
HCRC-178.

<img width="1022" height="723" alt="image" src="https://github.com/user-attachments/assets/3aa54881-5199-4db4-9a57-e4edb06f7264" />
