### PR TITLE
LIIKUNTA-770 | Fix browser tests by using `--disable-features=LocalNetworkAccessChecks` with chrome

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -35,9 +35,8 @@
     "test:debug": "yarn test --inspect-brk ----no-file-parallelism",
     "test:staged": "cross-env TZ=Europe/Helsinki vitest related --run",
     "test:watch": "cross-env TZ=Europe/Helsinki vitest watch",
-    "test:browser": "testcafe \"chrome --window-size='1249,720'\" browser-tests/ --live --dev",
-    "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1249,720'\" --screenshots path=report takeOnFails=true --video report browser-tests/",
-    "test:browser:wsl2win": "testcafe 'path:`/mnt/c/Program Files/Google/Chrome/Application/chrome.exe`' browser-tests/ --live --dev",
+    "test:browser": "testcafe \"chrome --disable-features=LocalNetworkAccessChecks --window-size='1249,720'\" browser-tests/ --live --dev",
+    "test:browser:ci": "testcafe \"chrome:headless --disable-features=LocalNetworkAccessChecks --disable-gpu --window-size='1249,720'\" --screenshots path=report takeOnFails=true --video report browser-tests/",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",
     "vercel-build": "yarn share-static-hardlink && next build"
   },

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -35,9 +35,8 @@
     "test:debug": "yarn test --inspect-brk ----no-file-parallelism",
     "test:staged": "cross-env TZ=Europe/Helsinki vitest related --run",
     "test:watch": "cross-env TZ=Europe/Helsinki vitest watch",
-    "test:browser": "testcafe \"chrome --window-size='1249,720'\" browser-tests/ --live --dev",
-    "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1249,720'\" --screenshots path=report takeOnFails=true --video report browser-tests/",
-    "test:browser:wsl2win": "testcafe 'path:`/mnt/c/Program Files/Google/Chrome/Application/chrome.exe`' browser-tests/ --live --dev",
+    "test:browser": "testcafe \"chrome --disable-features=LocalNetworkAccessChecks --window-size='1249,720'\" browser-tests/ --live --dev",
+    "test:browser:ci": "testcafe \"chrome:headless --disable-features=LocalNetworkAccessChecks --disable-gpu --window-size='1249,720'\" --screenshots path=report takeOnFails=true --video report browser-tests/",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",
     "vercel-build": "yarn share-static-hardlink && next build"
   },

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -36,9 +36,8 @@
     "test:debug": "yarn test --inspect-brk ----no-file-parallelism",
     "test:staged": "cross-env TZ=Europe/Helsinki vitest related --run",
     "test:watch": "cross-env TZ=Europe/Helsinki vitest watch",
-    "test:browser": "testcafe \"chrome --window-size='1249,720'\" browser-tests/ --live --dev",
-    "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1249,720'\" --screenshots path=report takeOnFails=true --video report browser-tests/",
-    "test:browser:wsl2win": "testcafe 'path:`/mnt/c/Program Files/Google/Chrome/Application/chrome.exe`' browser-tests/ --live --dev",
+    "test:browser": "testcafe \"chrome --disable-features=LocalNetworkAccessChecks --window-size='1249,720'\" browser-tests/ --live --dev",
+    "test:browser:ci": "testcafe \"chrome:headless --disable-features=LocalNetworkAccessChecks --disable-gpu --window-size='1249,720'\" --screenshots path=report takeOnFails=true --video report browser-tests/",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",
     "vercel-build": "yarn share-static-hardlink && next build"
   },


### PR DESCRIPTION
## Description

Fix browser tests by using `--disable-features=LocalNetworkAccessChecks` with chrome.

Chrome 140→142 broke testcafe browser tests, see
https://github.com/DevExpress/testcafe/issues/8446

Testcafe has not released a bugfix for this issue as of 2025-12-02, but the comments in the above issue pointed to using
`--disable-features=LocalNetworkAccessChecks` with chrome as a working workaround.

This PR only adds `--disable-features=LocalNetworkAccessChecks` to all testcafe invocations, and removes wsl2win testcafe running as unnecessary.

### Related

[LIIKUNTA-770](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-770)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-770]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ