### PR TITLE
fix: venue content description text font size should be larger

### DIFF
--- a/apps/sports-helsinki/src/domain/venue/venueContent/venueContent.module.scss
+++ b/apps/sports-helsinki/src/domain/venue/venueContent/venueContent.module.scss
@@ -1,7 +1,6 @@
 @use '../../../styles/breakpoints' as breakpoints;
 
 .venueContent {
-  --description-font-size: var(--fontsize-body-l);
   background-color: var(--color-white);
 
   .contentWrapper {
@@ -72,11 +71,12 @@
 }
 
 .description {
+  --description-font-size: var(--fontsize-body-l);
   line-height: 1.5;
   white-space: pre-line;
+  font-size: var(--description-font-size) !important;
 
   p {
-    font-size: var(--description-font-size);
     margin: 1rem 0;
   }
 


### PR DESCRIPTION
HCRC-178.

<img width="1004" height="1194" alt="image" src="https://github.com/user-attachments/assets/01d0a8a6-2c40-468e-9b9b-a97191cc2b4d" />
