### PR TITLE
HH-430 | Fix `.next` folder permission issues on Linux in Docker development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,6 +180,11 @@ ENV WATCHPACK_POLLING=${WATCHPACK_POLLING}
 
 WORKDIR /app
 
+# Make sure the app's next.js build output, cache etc are writable by the application
+RUN mkdir -p /app/apps/${PROJECT}/.next \
+    && chown -R default:root /app/apps/${PROJECT}/.next \
+    && chmod -R g+w /app/apps/${PROJECT}/.next
+
 COPY --from=deps --chown=default:root /workspace-install ./
 
 RUN yarn install --immutable --inline-builds


### PR DESCRIPTION
## Description

Fix `.next` folder permission issues on Linux in Docker development

Make sure the app's .next folder is writable from inside the container when running hobbies/events/sports in Docker.

## Related

[HH-430](https://helsinkisolutionoffice.atlassian.net/browse/HH-430)

## Testing

### Automated tests

### Manual testing

Tested locally on Windows 11 with hobbies.
`yarn docker:hobbies:develop --build` and opened http://localhost:3000/ and it worked ok with a little browsing.

## Screenshots

## Additional notes


[HH-430]: https://helsinkisolutionoffice.atlassian.net/browse/HH-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ