### PR TITLE
Fix place selector mobile view for long text values

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
@@ -241,6 +241,8 @@ $buttonWidth: 180px;
   font-weight: 500;
   margin-top: 2px;
   margin-bottom: var(--spacing-xl);
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &.withDescription {
     margin-bottom: var(--spacing-s) !important;

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
@@ -217,6 +217,8 @@ $buttonWidth: 180px;
   font-weight: 500;
   margin-top: 2px;
   margin-bottom: var(--spacing-xl);
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &.withDescription {
     margin-bottom: var(--spacing-s) !important;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/search.module.scss
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/search.module.scss
@@ -15,6 +15,8 @@ $buttonWidth: 180px;
   font-weight: 500;
   margin-top: 2px;
   margin-bottom: var(--spacing-xl);
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &.withDescription {
     margin-bottom: var(--spacing-s);

--- a/packages/components/src/components/multiSelectDropdown/multiSelectDropdown.module.scss
+++ b/packages/components/src/components/multiSelectDropdown/multiSelectDropdown.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/breakpoints' as breakpoints;
+
 .dropdown {
   --dropdown-height: var(--spacing-3-xl) !important;
 
@@ -70,6 +72,14 @@
       color: var(--color-primary-black);
       font-size: var(--fontsize-body-m);
       padding-left: var(--spacing-3-xs);
+
+      @include breakpoints.respond-below(s) {
+        /* 
+        `white-space: nowrap` would make text a neat single liner, 
+        but then the mobile layout breaks with long values 
+        */
+        white-space: normal;
+      }
     }
 
     .placeholder {


### PR DESCRIPTION
fix: allow place filter text to be multiline in mobile view

HH-459.

Mobile view's layout breaks if a long text value is selected in place selector, when it's forced as single liner with `white-space: nowrap`.

NOTE: This fix is not ideal, but helps as a quick aid and prevents greater damage. It's checked and approved from product owner.

<img width="529" height="656" alt="image" src="https://github.com/user-attachments/assets/9cded287-896f-4664-a559-b6b12b85802f" />

<img width="617" height="932" alt="image" src="https://github.com/user-attachments/assets/d39b918b-97aa-4f80-a5d1-78ac5bfe83a5" />

<img width="929" height="559" alt="image" src="https://github.com/user-attachments/assets/321ddea8-85e7-4056-999c-50bea75c0e87" />


If screen is really narrow, the layout breaks a bit, but the whole app layout, but only the place selector:

<img width="362" height="855" alt="image" src="https://github.com/user-attachments/assets/5f40f732-7513-4a57-9bdc-30656fcf2108" />
