### PR TITLE
fix: place selector should have single line text

### DIFF
--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/AdvancedSearchForm.tsx
@@ -263,7 +263,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = ({
         </div>
         <div className={styles.rowWrapper}>
           <div className={styles.row}>
-            <div>
+            <div className={styles.checkboxWrapper}>
               <Checkbox
                 className={styles.checkbox}
                 checked={isFree}
@@ -272,7 +272,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = ({
                 onChange={(e) => setIsFree(e.target.checked)}
               />
             </div>
-            <div>
+            <div className={styles.checkboxWrapper}>
               <Checkbox
                 className={styles.checkbox}
                 checked={isOnlyEveningEvents}
@@ -281,7 +281,7 @@ export const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = ({
                 onChange={(e) => setIsOnlyEveningEvents(e.target.checked)}
               />
             </div>
-            <div>
+            <div className={styles.checkboxWrapper}>
               <Checkbox
                 className={styles.checkbox}
                 checked={isOnlyRemoteEvents}

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
@@ -53,6 +53,14 @@ $buttonWidth: 180px;
     }
     @include breakpoints.respond-below(m) {
       grid-column: 1 / 3;
+      margin: var(--spacing-xs) 0;
+    }
+  }
+
+  .checkboxWrapper {
+    margin: var(--spacing-3-xs) 0;
+    @include breakpoints.respond-below(s) {
+      grid-column: 1 / 3;
     }
   }
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
+++ b/apps/events-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
@@ -61,7 +61,11 @@ $buttonWidth: 180px;
     grid-gap: var(--spacing-xs);
 
     @include breakpoints.respond-above(s) {
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    @include breakpoints.respond-below(s) {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
     }
 
     @include breakpoints.respond-above(m) {

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/advancedSearch/search.module.scss
@@ -61,7 +61,11 @@ $buttonWidth: 180px;
     grid-gap: var(--spacing-xs);
 
     @include breakpoints.respond-above(s) {
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    @include breakpoints.respond-below(s) {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
     }
 
     @include breakpoints.respond-above(m) {

--- a/packages/components/src/components/multiSelectDropdown/multiSelectDropdown.module.scss
+++ b/packages/components/src/components/multiSelectDropdown/multiSelectDropdown.module.scss
@@ -72,14 +72,6 @@
       color: var(--color-primary-black);
       font-size: var(--fontsize-body-m);
       padding-left: var(--spacing-3-xs);
-
-      @include breakpoints.respond-below(s) {
-        /* 
-        `white-space: nowrap` would make text a neat single liner, 
-        but then the mobile layout breaks with long values 
-        */
-        white-space: normal;
-      }
     }
 
     .placeholder {


### PR DESCRIPTION
HH-459.

Remove the old temporary fix for mobile view that converted place selector's text value to multi line text, because otherwise it would have broke the app (search) layout. Fix this with proper container element's grid configuration.

<img width="1045" height="366" alt="image" src="https://github.com/user-attachments/assets/3a9272af-f6f6-4a5e-bfee-a40c816b97ac" />

<img width="650" height="371" alt="image" src="https://github.com/user-attachments/assets/7c4090de-d68e-4eb0-bd18-5b04963c2203" />

<img width="590" height="435" alt="image" src="https://github.com/user-attachments/assets/a3384bda-b83e-4d30-832d-5a13a5f17c50" />

<img width="433" height="610" alt="image" src="https://github.com/user-attachments/assets/5d29954c-a611-4228-92d4-876b426e9b37" />

<img width="241" height="776" alt="image" src="https://github.com/user-attachments/assets/a53dca9d-35ad-4fad-bade-dc10ed51da43" />

<img width="164" height="898" alt="image" src="https://github.com/user-attachments/assets/a98ea1ad-277a-42e2-ad47-1ca3dc956c8c" />


<img width="750" height="414" alt="image" src="https://github.com/user-attachments/assets/f431e20e-23ce-466a-be20-bbb9f2c9d430" />


<img width="455" height="479" alt="image" src="https://github.com/user-attachments/assets/c57723ad-17da-44cd-b34f-f92fdd8109fa" />

<img width="368" height="791" alt="image" src="https://github.com/user-attachments/assets/54a2ce9d-4ab7-4085-96ea-1be2e817b67c" />
