### PR TITLE
Fix CMS page styles without upgrading HCRC-lib

### DIFF
--- a/apps/events-helsinki/src/styles/globals.scss
+++ b/apps/events-helsinki/src/styles/globals.scss
@@ -72,3 +72,8 @@ button {
     font-size: var(--fontsize-heading-xl-mobile) !important;
   }
 }
+
+article figure {
+  /* TODO: remove when fixed in HCRC */
+  display: grid !important;
+}

--- a/apps/events-helsinki/src/styles/globals.scss
+++ b/apps/events-helsinki/src/styles/globals.scss
@@ -77,3 +77,11 @@ article figure {
   /* TODO: remove when fixed in HCRC */
   display: grid !important;
 }
+
+aside {
+  div > button > div {
+    /* TODO: remove when fixed in HCRC */
+    width: 40px !important;
+    height: 40px !important;
+  }
+}

--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -73,3 +73,8 @@ button {
     font-size: var(--fontsize-heading-xl-mobile) !important;
   }
 }
+
+article figure {
+  /* TODO: remove when fixed in HCRC */
+  display: grid !important;
+}

--- a/apps/hobbies-helsinki/src/styles/globals.scss
+++ b/apps/hobbies-helsinki/src/styles/globals.scss
@@ -78,3 +78,11 @@ article figure {
   /* TODO: remove when fixed in HCRC */
   display: grid !important;
 }
+
+aside {
+  div > button > div {
+    /* TODO: remove when fixed in HCRC */
+    width: 40px !important;
+    height: 40px !important;
+  }
+}

--- a/apps/sports-helsinki/src/styles/globals.scss
+++ b/apps/sports-helsinki/src/styles/globals.scss
@@ -72,3 +72,8 @@ button {
     font-size: var(--fontsize-heading-xl-mobile) !important;
   }
 }
+
+article figure {
+  /* TODO: remove when fixed in HCRC */
+  display: grid !important;
+}

--- a/apps/sports-helsinki/src/styles/globals.scss
+++ b/apps/sports-helsinki/src/styles/globals.scss
@@ -77,3 +77,11 @@ article figure {
   /* TODO: remove when fixed in HCRC */
   display: grid !important;
 }
+
+aside {
+  div > button > div {
+    /* TODO: remove when fixed in HCRC */
+    width: 40px !important;
+    height: 40px !important;
+  }
+}

--- a/packages/components/src/styles/globals.scss
+++ b/packages/components/src/styles/globals.scss
@@ -23,3 +23,8 @@ button {
   background-color: transparent;
   cursor: pointer;
 }
+
+article figure {
+  /* TODO: remove when fixed in HCRC */
+  display: grid !important;
+}

--- a/packages/components/src/styles/globals.scss
+++ b/packages/components/src/styles/globals.scss
@@ -28,3 +28,11 @@ article figure {
   /* TODO: remove when fixed in HCRC */
   display: grid !important;
 }
+
+aside {
+  div > button > div {
+    /* TODO: remove when fixed in HCRC */
+    width: 40px !important;
+    height: 40px !important;
+  }
+}


### PR DESCRIPTION
LIIKUNTA-771.

To fix CMS page table figure style issues without upgrading HCRC-lib (NOTE: HCRC -lib needs to be upgraded to a organisation scoped version).

Alternative to https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/966. This is a secondary option and it would be good to upgrade to organisation scoped package.

