### PR TITLE
feat: filter courses HH-460

### DIFF
--- a/apps/hobbies-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/hobbies-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -34,6 +34,7 @@ import {
 } from '../../../../config/vitest/test-utils';
 
 import AppConfig from '../../app/AppConfig';
+import { HOBBIES_EXCLUDED_KEYWORDS } from '../../search/eventSearch/constants';
 import type { EventPageContainerProps } from '../EventPageContainer';
 import EventPageContainer from '../EventPageContainer';
 
@@ -244,6 +245,7 @@ it('shows similar events when SIMILAR_EVENTS flag is on', async () => {
           audienceMinAgeLt: '5',
           audienceMaxAgeGt: '15',
           keywordOrSet2: ['yso:p916'],
+          keywordNot: HOBBIES_EXCLUDED_KEYWORDS,
           language: undefined,
           pageSize: 100,
           publisherAncestor: null,

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -150,7 +150,9 @@ describe('getEventSearchVariables function', () => {
       ...defaultParams,
       params: new URLSearchParams(),
     });
-    expect(keywordNot).toEqual(expect.arrayContaining(HOBBIES_EXCLUDED_KEYWORDS));
+    expect(keywordNot).toStrictEqual(
+      expect.arrayContaining(HOBBIES_EXCLUDED_KEYWORDS)
+    );
   });
 
   it('should merge user-provided keywordNot with HOBBIES_EXCLUDED_KEYWORDS', () => {
@@ -161,7 +163,7 @@ describe('getEventSearchVariables function', () => {
         `?${EVENT_SEARCH_FILTERS.KEYWORD_NOT}=${userKeyword}`
       ),
     });
-    expect(keywordNot).toEqual(
+    expect(keywordNot).toStrictEqual(
       expect.arrayContaining([userKeyword, ...HOBBIES_EXCLUDED_KEYWORDS])
     );
   });

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -5,7 +5,10 @@ import {
 } from '@events-helsinki/components';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { COURSE_DEFAULT_SEARCH_FILTERS } from '../constants';
+import {
+  COURSE_DEFAULT_SEARCH_FILTERS,
+  HOBBIES_EXCLUDED_KEYWORDS,
+} from '../constants';
 import {
   clampAgeInput,
   getEventSearchVariables,
@@ -140,6 +143,27 @@ describe('getEventSearchVariables function', () => {
     });
     expect(start7).toBe('now');
     expect(end7).toBe('2020-10-15');
+  });
+
+  it('should always include HOBBIES_EXCLUDED_KEYWORDS in keywordNot', () => {
+    const { keywordNot } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(),
+    });
+    expect(keywordNot).toEqual(expect.arrayContaining(HOBBIES_EXCLUDED_KEYWORDS));
+  });
+
+  it('should merge user-provided keywordNot with HOBBIES_EXCLUDED_KEYWORDS', () => {
+    const userKeyword = 'yso:p1234';
+    const { keywordNot } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(
+        `?${EVENT_SEARCH_FILTERS.KEYWORD_NOT}=${userKeyword}`
+      ),
+    });
+    expect(keywordNot).toEqual(
+      expect.arrayContaining([userKeyword, ...HOBBIES_EXCLUDED_KEYWORDS])
+    );
   });
 });
 

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/constants.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/constants.tsx
@@ -94,6 +94,15 @@ export const CATEGORY_CATALOG = {
   },
 };
 
+/**
+ * Keywords that are always excluded from hobbies search results,
+ * regardless of user-provided filters.
+ */
+export const HOBBIES_EXCLUDED_KEYWORDS = [
+  // Secondary school cross-institutional studies are not hobbies
+  'helsinki:secondary_schools_cross_institutional_studies',
+];
+
 export const MOVIES_AND_MEDIA_COURSES_KEYWORDS = [
   'yso:p1235', // elokuva
   'kulke:29', // elokuvat

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -36,6 +36,7 @@ import type { COURSE_CATEGORIES } from './constants';
 import {
   COURSE_DEFAULT_SEARCH_FILTERS,
   courseCategories,
+  HOBBIES_EXCLUDED_KEYWORDS,
   MAPPED_PLACES,
   CATEGORY_CATALOG,
   MAPPED_COURSE_CATEGORIES,
@@ -275,7 +276,7 @@ export const getEventSearchVariables = ({
     // internetBased: onlyRemoteEvents || undefined,
     keywordOrSet2: [...(keyword ?? []), ...mappedCategories],
     keywordAnd,
-    keywordNot,
+    keywordNot: [...(keywordNot ?? []), ...HOBBIES_EXCLUDED_KEYWORDS],
     language,
     location: places.sort((a, b) => a.localeCompare(b)),
     pageSize,


### PR DESCRIPTION
## Description

Secondary school cross-institutional studies are filtered out by adding keywordNot  `helsinki:secondary_schools_cross_institutional_studies`

So far there is no solution for caroucels. 


## Issues

### Closes

**[HH-460](https://helsinkisolutionoffice.atlassian.net/browse/HH-460):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-460]: https://helsinkisolutionoffice.atlassian.net/browse/HH-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ