### PR TITLE
ci: remove test patterns Refs: KEH-189

### DIFF
--- a/apps/events-helsinki/sonar-project.properties
+++ b/apps/events-helsinki/sonar-project.properties
@@ -5,7 +5,6 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sourceEncoding=UTF-8
 sonar.sources=src
 sonar.exclusions= \
-  **/__tests__/**/*, \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \

--- a/apps/events-helsinki/sonar-project.properties
+++ b/apps/events-helsinki/sonar-project.properties
@@ -9,8 +9,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  src/setupTests.js, \
-  src/setupTests.ts, \
   src/i18n.ts, \
   src/logger.ts
 
@@ -23,8 +21,6 @@ sonar.coverage.exclusions= \
   src/index.jsx, \
   src/index.ts, \
   src/index.tsx, \
-  src/serviceWorker.js, \
-  src/serviceWorker.ts, \
   src/pages/**/*.tsx, \
   src/pages/api/healthz.ts, \
   src/pages/api/readiness.ts, \

--- a/apps/events-helsinki/sonar-project.properties
+++ b/apps/events-helsinki/sonar-project.properties
@@ -9,10 +9,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  **/*.test.js, \
-  **/*.test.ts, \
-  **/*.test.jsx, \
-  **/*.test.tsx, \
   src/setupTests.js, \
   src/setupTests.ts, \
   src/i18n.ts, \

--- a/apps/events-helsinki/sonar-project.properties
+++ b/apps/events-helsinki/sonar-project.properties
@@ -11,24 +11,15 @@ sonar.exclusions= \
   src/i18n.ts, \
   src/logger.ts
 
-sonar.coverage.exclusions= \
-  **/*.stories.js, \
-  **/*.stories.ts, \
-  **/*.stories.jsx, \
-  **/*.stories.tsx, \
-  src/index.js, \
-  src/index.jsx, \
-  src/index.ts, \
-  src/index.tsx, \
-  src/pages/**/*.tsx, \
-  src/pages/api/healthz.ts, \
-  src/pages/api/readiness.ts, \
-  src/lib/**
-
-
 sonar.test.inclusions= \
   **/__tests__/**/*, \
   **/*.test.js, \
   **/*.test.ts, \
   **/*.test.jsx, \
   **/*.test.tsx
+
+sonar.coverage.exclusions= \
+  src/pages/**/*.tsx, \
+  src/pages/api/healthz.ts, \
+  src/pages/api/readiness.ts, \
+  src/lib/**

--- a/apps/hobbies-helsinki/sonar-project.properties
+++ b/apps/hobbies-helsinki/sonar-project.properties
@@ -5,7 +5,6 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sourceEncoding=UTF-8
 sonar.sources=src
 sonar.exclusions= \
-  **/__tests__/**/*, \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \

--- a/apps/hobbies-helsinki/sonar-project.properties
+++ b/apps/hobbies-helsinki/sonar-project.properties
@@ -9,8 +9,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  src/setupTests.js, \
-  src/setupTests.ts, \
   src/i18n.ts, \
   src/logger.ts
 
@@ -23,8 +21,6 @@ sonar.coverage.exclusions= \
   src/index.jsx, \
   src/index.ts, \
   src/index.tsx, \
-  src/serviceWorker.js, \
-  src/serviceWorker.ts, \
   src/pages/**/*.tsx, \
   src/pages/api/healthz.ts, \
   src/pages/api/readiness.ts, \

--- a/apps/hobbies-helsinki/sonar-project.properties
+++ b/apps/hobbies-helsinki/sonar-project.properties
@@ -9,10 +9,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  **/*.test.js, \
-  **/*.test.ts, \
-  **/*.test.jsx, \
-  **/*.test.tsx, \
   src/setupTests.js, \
   src/setupTests.ts, \
   src/i18n.ts, \

--- a/apps/hobbies-helsinki/sonar-project.properties
+++ b/apps/hobbies-helsinki/sonar-project.properties
@@ -11,24 +11,15 @@ sonar.exclusions= \
   src/i18n.ts, \
   src/logger.ts
 
-sonar.coverage.exclusions= \
-  **/*.stories.js, \
-  **/*.stories.ts, \
-  **/*.stories.jsx, \
-  **/*.stories.tsx, \
-  src/index.js, \
-  src/index.jsx, \
-  src/index.ts, \
-  src/index.tsx, \
-  src/pages/**/*.tsx, \
-  src/pages/api/healthz.ts, \
-  src/pages/api/readiness.ts, \
-  src/lib/**
-
-
 sonar.test.inclusions= \
   **/__tests__/**/*, \
   **/*.test.js, \
   **/*.test.ts, \
   **/*.test.jsx, \
   **/*.test.tsx
+
+sonar.coverage.exclusions= \
+  src/pages/**/*.tsx, \
+  src/pages/api/healthz.ts, \
+  src/pages/api/readiness.ts, \
+  src/lib/**

--- a/apps/sports-helsinki/sonar-project.properties
+++ b/apps/sports-helsinki/sonar-project.properties
@@ -5,7 +5,6 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sourceEncoding=UTF-8
 sonar.sources=src
 sonar.exclusions= \
-  **/__tests__/**/*, \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \

--- a/apps/sports-helsinki/sonar-project.properties
+++ b/apps/sports-helsinki/sonar-project.properties
@@ -9,8 +9,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  src/setupTests.js, \
-  src/setupTests.ts, \
   src/i18n.ts, \
   src/logger.ts
 
@@ -23,8 +21,6 @@ sonar.coverage.exclusions= \
   src/index.jsx, \
   src/index.ts, \
   src/index.tsx, \
-  src/serviceWorker.js, \
-  src/serviceWorker.ts, \
   src/pages/**/*.tsx, \
   src/pages/api/healthz.ts, \
   src/pages/api/readiness.ts, \

--- a/apps/sports-helsinki/sonar-project.properties
+++ b/apps/sports-helsinki/sonar-project.properties
@@ -9,10 +9,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  **/*.test.js, \
-  **/*.test.ts, \
-  **/*.test.jsx, \
-  **/*.test.tsx, \
   src/setupTests.js, \
   src/setupTests.ts, \
   src/i18n.ts, \

--- a/apps/sports-helsinki/sonar-project.properties
+++ b/apps/sports-helsinki/sonar-project.properties
@@ -11,24 +11,15 @@ sonar.exclusions= \
   src/i18n.ts, \
   src/logger.ts
 
-sonar.coverage.exclusions= \
-  **/*.stories.js, \
-  **/*.stories.ts, \
-  **/*.stories.jsx, \
-  **/*.stories.tsx, \
-  src/index.js, \
-  src/index.jsx, \
-  src/index.ts, \
-  src/index.tsx, \
-  src/pages/**/*.tsx, \
-  src/pages/api/healthz.ts, \
-  src/pages/api/readiness.ts, \
-  src/lib/**
-
-
 sonar.test.inclusions= \
   **/__tests__/**/*, \
   **/*.test.js, \
   **/*.test.ts, \
   **/*.test.jsx, \
   **/*.test.tsx
+
+sonar.coverage.exclusions= \
+  src/pages/**/*.tsx, \
+  src/pages/api/healthz.ts, \
+  src/pages/api/readiness.ts, \
+  src/lib/**

--- a/packages/components/sonar-project.properties
+++ b/packages/components/sonar-project.properties
@@ -20,26 +20,20 @@ sonar.exclusions= \
   src/i18n.ts, \
   src/components/document/Document.tsx
 
-# Analyze for quality issues but exclude from coverage metrics:
-# storybook files, entry points, service workers, and icon components (no testable logic)
-sonar.coverage.exclusions= \
-  **/*.stories.js, \
-  **/*.stories.ts, \
-  **/*.stories.jsx, \
-  **/*.stories.tsx, \
-  src/index.js, \
-  src/index.jsx, \
-  src/index.ts, \
-  src/index.tsx, \
-  **/*Icon.tsx, \
-  **/*Icon.ts
-
 sonar.test.inclusions= \
-  **/__tests__/**/*, \
+  **/__tests__/**/*,  \
   **/*.test.js, \
   **/*.test.ts, \
   **/*.test.jsx, \
   **/*.test.tsx
+
+# Analyze for quality issues but exclude from coverage metrics:
+# storybook files, entry points, service workers, and icon components (no testable logic)
+sonar.coverage.exclusions= \
+  src/index.ts, \
+  **/*.stories.tsx, \
+  **/*Icon.tsx, \
+  **/*Icon.ts
 
 # Ignore "Refactor this code to not nest functions more than 4 levels deep." in test files,
 # because it's mostly raised when describe-functions are used.

--- a/packages/components/sonar-project.properties
+++ b/packages/components/sonar-project.properties
@@ -12,8 +12,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  src/setupTests.js, \
-  src/setupTests.ts, \
   src/assets/**, \
   src/styles/**, \
   src/types/**, \
@@ -34,8 +32,6 @@ sonar.coverage.exclusions= \
   src/index.jsx, \
   src/index.ts, \
   src/index.tsx, \
-  src/serviceWorker.js, \
-  src/serviceWorker.ts, \
   **/*Icon.tsx, \
   **/*Icon.ts
 

--- a/packages/components/sonar-project.properties
+++ b/packages/components/sonar-project.properties
@@ -8,7 +8,6 @@ sonar.sources=src
 # Exclude non-analyzable files: test infrastructure, type declarations,
 # library assets, generated GraphQL code, and infrastructure-only files
 sonar.exclusions= \
-  **/__tests__/**/*, \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \

--- a/packages/components/sonar-project.properties
+++ b/packages/components/sonar-project.properties
@@ -12,10 +12,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  **/*.test.js, \
-  **/*.test.ts, \
-  **/*.test.jsx, \
-  **/*.test.tsx, \
   src/setupTests.js, \
   src/setupTests.ts, \
   src/assets/**, \


### PR DESCRIPTION
## Description
- No need to exclude test file patterns, they are excluded automatically.
- Remove dead patterns
## Issues

### Closes

**[KEH-189](https://helsinkisolutionoffice.atlassian.net/browse/KEH-189):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[KEH-189]: https://helsinkisolutionoffice.atlassian.net/browse/KEH-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ