### PR TITLE
TH-1462 | Add fullTextLanguage parameter support for language-aware search

### DIFF
--- a/apps/events-helsinki/README.md
+++ b/apps/events-helsinki/README.md
@@ -282,6 +282,7 @@ The conversion map looks (something) like this:
   { key: "suitable_for", value: params.suitableFor },
   { key: "ids", value: params.ids },
   { key: "full_text", value: params.fullText },
+  { key: "full_text_language", value: params.fullTextLanguage },
   { key: "ongoing", value: params.ongoing },
 ];
 ```
@@ -298,6 +299,7 @@ The "main events search" component is used in the search page at `/search`.
 | division          | "ocd-division/country:fi/kunta:helsinki" | -            | x        | Only events in Helsinki                                                                       |
 | ongoing           | true                                     | -            | x        | include the ongoing events                                                                    |
 | fullText          | ""                                       | x            | x        | A text scoring mathcher (title, place, description, ...)                                      |
+| fullTextLanguage  | ["fi", "en", "sv"]                       | -            | -        | Languages for full text search                                                                |
 | sort              | "end_time"                               | x            | x        | Sorting order of the result set. Default is "event end time as ascending"                     |
 | start             | "now"                                    | x            | x        | Filter by event starting time                                                                 |
 | end               | null                                     | x            | -        | Filter by event ending time                                                                   |

--- a/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/events-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import {
   DATE_TYPES,
   DEFAULT_EVENT_SORT_OPTION,
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
   EVENT_SEARCH_FILTERS,
 } from '@events-helsinki/components';
 import { advanceTo, clear } from 'jest-date-mock';
@@ -153,6 +154,22 @@ describe('getEventSearchVariables function', () => {
     });
     expect(start7).toBe('now');
     expect(end7).toBe('2020-10-15');
+  });
+
+  it('should set fullTextLanguage when text search is provided', () => {
+    const { fullTextLanguage } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?${EVENT_SEARCH_FILTERS.TEXT}=yoga`),
+    });
+    expect(fullTextLanguage).toStrictEqual(EVENT_FULL_TEXT_SEARCH_LANGUAGES);
+  });
+
+  it('should set fullTextLanguage to undefined when no text search is provided', () => {
+    const { fullTextLanguage } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(''),
+    });
+    expect(fullTextLanguage).toBeUndefined();
   });
 });
 

--- a/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/events-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -16,6 +16,7 @@ import {
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID,
   EVENT_SEARCH_FILTERS,
   EVENT_SORT_OPTIONS,
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
 } from '@events-helsinki/components';
 import {
   addDays,
@@ -247,6 +248,9 @@ export const getEventSearchVariables = ({
 
   return {
     [EVENT_SEARCH_FILTERS.TEXT]: !isEmpty(text) ? text?.join(',') : undefined, // NOTE: only *OngoingAnd supports Array.
+    fullTextLanguage: isEmpty(text)
+      ? undefined
+      : EVENT_FULL_TEXT_SEARCH_LANGUAGES,
     [EVENT_SEARCH_FILTERS.ONGOING]: true,
     [EVENT_SEARCH_FILTERS.DIVISIONS]: division,
     end,

--- a/apps/hobbies-helsinki/README.md
+++ b/apps/hobbies-helsinki/README.md
@@ -282,6 +282,7 @@ The conversion map looks (something) like this:
   { key: "suitable_for", value: params.suitableFor },
   { key: "ids", value: params.ids },
   { key: "full_text", value: params.fullText },
+  { key: "full_text_language", value: params.fullTextLanguage },
   { key: "ongoing", value: params.ongoing },
 ];
 ```
@@ -298,6 +299,7 @@ The "main events search" component is used in the search page at `/search`.
 | division          | "ocd-division/country:fi/kunta:helsinki" | -            | x        | Only city of Helsinki events                                                                  |
 | ongoing           | true                                     | -            | x        | include the ongoing events                                                                    |
 | fullText          | ""                                       | x            | x        | A text scoring mathcher (title, place, description, ...)                                      |
+| fullTextLanguage  | ["fi", "en", "sv"]                       | -            | -        | Languages for full text search                                                                |
 | sort              | "end_time"                               | x            | x        | Sorting order of the result set. Default is "event end time as ascending"                     |
 | start             | "now"                                    | x            | x        | Filter by event starting time                                                                 |
 | end               | null                                     | x            | -        | Filter by event ending time                                                                   |

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   DATE_TYPES,
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
   EVENT_SEARCH_FILTERS,
   EVENT_SORT_OPTIONS,
 } from '@events-helsinki/components';
@@ -166,6 +167,22 @@ describe('getEventSearchVariables function', () => {
     expect(keywordNot).toStrictEqual(
       expect.arrayContaining([userKeyword, ...HOBBIES_EXCLUDED_KEYWORDS])
     );
+  });
+
+  it('should set fullTextLanguage when text search is provided', () => {
+    const { fullTextLanguage } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?${EVENT_SEARCH_FILTERS.TEXT}=yoga`),
+    });
+    expect(fullTextLanguage).toStrictEqual(EVENT_FULL_TEXT_SEARCH_LANGUAGES);
+  });
+
+  it('should set fullTextLanguage to undefined when no text search is provided', () => {
+    const { fullTextLanguage } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(''),
+    });
+    expect(fullTextLanguage).toBeUndefined();
   });
 });
 

--- a/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/hobbies-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -8,6 +8,7 @@ import {
   EVENT_SEARCH_FILTERS,
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID,
   EVENT_SORT_OPTIONS,
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
 } from '@events-helsinki/components';
 import type {
   AppLanguage,
@@ -267,6 +268,9 @@ export const getEventSearchVariables = ({
 
   return {
     [EVENT_SEARCH_FILTERS.TEXT]: !isEmpty(text) ? text?.join(',') : undefined, // NOTE: only *OngoingAnd supports Array.
+    fullTextLanguage: isEmpty(text)
+      ? undefined
+      : EVENT_FULL_TEXT_SEARCH_LANGUAGES,
     [EVENT_SEARCH_FILTERS.ONGOING]: true,
     [EVENT_SEARCH_FILTERS.DIVISIONS]: division,
     end,

--- a/apps/sports-helsinki/README.md
+++ b/apps/sports-helsinki/README.md
@@ -369,6 +369,7 @@ The conversion map looks (something) like this:
   { key: "suitable_for", value: params.suitableFor },
   { key: "ids", value: params.ids },
   { key: "full_text", value: params.fullText },
+  { key: "full_text_language", value: params.fullTextLanguage },
   { key: "ongoing", value: params.ongoing },
 ];
 ```
@@ -389,6 +390,7 @@ The "main events search" component is used in the search page at `/search`.
 | division          | "ocd-division/country:fi/kunta:helsinki" | -            | x        | Only city of Helsinki events                                                                  |
 | ongoing           | true                                     | -            | x        | include the ongoing events                                                                    |
 | fullText          | ""                                       | x            | x        | A text scoring mathcher (title, place, description, ...)                                      |
+| fullTextLanguage  | ["fi", "en", "sv"]                       | -            | -        | Languages for full text search                                                                |
 | sort              | "end_time"                               | x            | x        | Sorting order of the result set. Default is "event end time as ascending"                     |
 | start             | "now"                                    | x            | x        | Filter by event starting time                                                                 |
 | end               | null                                     | x            | -        | Filter by event ending time                                                                   |

--- a/apps/sports-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/apps/sports-helsinki/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -25,10 +25,9 @@ import {
   createEventListRequestAndResultMocks,
   createOtherEventTimesRequestAndResultMocks,
 } from '@/test-utils/mocks/eventListMocks';
-
 import AppConfig from '../../app/AppConfig';
-import type { EventPageContainerProps } from '../EventPageContainer';
 import EventPageContainer from '../EventPageContainer';
+import type { EventPageContainerProps } from '../EventPageContainer';
 
 const id = 'hel:123';
 const name = 'Event title';
@@ -70,7 +69,10 @@ const eventRequest = {
   query: EventDetailsDocument,
   variables: {
     id: superEventId,
-    include: AppConfig.eventSecondaryQueryIncludeParamValue,
+    include: [
+      ...AppConfig.eventSecondaryQueryIncludeParamValue,
+      'registration',
+    ],
   },
 };
 const otherEventsRequest = {
@@ -87,7 +89,10 @@ const request = {
   query: EventDetailsDocument,
   variables: {
     id,
-    include: AppConfig.eventDetailsQueryIncludeParamValue,
+    include: [
+      ...AppConfig.eventSecondaryQueryIncludeParamValue,
+      'registration',
+    ],
   },
 };
 

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/__tests__/SearchUtilities.test.tsx
@@ -56,6 +56,7 @@ const mocks = [
   createEventListRequestAndResultMocks({
     variables: {
       fullText: '',
+      fullTextLanguage: undefined,
       ongoing: true,
       keywordOrSet1: SPORT_COURSES_KEYWORDS,
       language: undefined,
@@ -66,6 +67,7 @@ const mocks = [
   createEventListRequestAndResultMocks({
     variables: {
       fullText: '',
+      fullTextLanguage: undefined,
       ongoing: true,
       keywordOrSet1: SPORT_COURSES_KEYWORDS,
       language: undefined,
@@ -76,6 +78,7 @@ const mocks = [
   createEventListRequestAndResultMocks({
     variables: {
       fullText: '',
+      fullTextLanguage: undefined,
       ongoing: true,
       keywordOrSet1: SPORT_COURSES_KEYWORDS,
       language: undefined,

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/EventSearchAdapter.ts
@@ -1,5 +1,6 @@
 import {
   CITY_OF_HELSINKI_LINKED_EVENTS_ORGANIZATION_ID,
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
   EVENT_SORT_OPTIONS,
 } from '@events-helsinki/components';
 import { EventTypeId } from '@events-helsinki/components/types';
@@ -21,6 +22,7 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
    * that are wanted to be mapped with the combined search.
    */
   fullText?: EventSearchParams['fullText'];
+  fullTextLanguage?: EventSearchParams['fullTextLanguage'];
   ongoing: EventSearchParams['ongoing'];
   start: EventSearchParams['start'];
   end: EventSearchParams['end'];
@@ -54,7 +56,12 @@ class EventSearchAdapter implements CombinedSearchAdapter<EventSearchParams> {
     // Initialize the object with default values
     Object.assign(this, initialEventSearchAdapterValues, { eventType });
 
-    this.fullText = input.text || initialEventSearchAdapterValues.fullText;
+    const fullTextValue =
+      input.text || initialEventSearchAdapterValues.fullText;
+    this.fullText = fullTextValue;
+    this.fullTextLanguage = fullTextValue
+      ? EVENT_FULL_TEXT_SEARCH_LANGUAGES
+      : undefined;
     this.keywordAnd = [];
     this.keywordOrSet1 = SPORT_COURSES_KEYWORDS;
     this.keywordOrSet2 = this.getSportsKeywords(input);

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/CombinedSearchFormAdapter.test.ts
@@ -3,6 +3,7 @@ import {
   UnifiedSearchLanguage,
   EVENT_SEARCH_FILTERS,
   HELSINKI_OCD_DIVISION_ID,
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
 } from '@events-helsinki/components';
 import mockRouter from 'next-router-mock';
 import qs from 'query-string';
@@ -141,6 +142,9 @@ describe('CombinedSearchFormAdapter', () => {
           sort: outputQuery.eventOrderBy ?? null,
           eventType: EventTypeId.General,
           fullText: outputQuery.text,
+          fullTextLanguage: outputQuery.text
+            ? EVENT_FULL_TEXT_SEARCH_LANGUAGES
+            : undefined,
           ongoing: true,
           start: 'now',
           end: '',

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/EventSearchAdapter.test.ts
@@ -1,4 +1,5 @@
 import {
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
   EVENT_SEARCH_FILTERS,
   EventTypeId,
   HELSINKI_OCD_DIVISION_ID,
@@ -28,6 +29,9 @@ describe('EventSearchAdapter', () => {
         const result = {
           eventType,
           fullText: input.text,
+          fullTextLanguage: input.text
+            ? EVENT_FULL_TEXT_SEARCH_LANGUAGES
+            : undefined,
           ongoing: true,
           start: 'now',
           end: '',

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/adapters/__tests__/__snapshots__/CombinedSearchProvider.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`CombinedSearchProvider > reads the context properly 1`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"fullText":"test text","ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
+    {"fullText":"test text","fullTextLanguage":["fi","sv","en"],"ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"fullText":"test text","ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
+    {"fullText":"test text","fullTextLanguage":["fi","sv","en"],"ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"fullText":"test text","ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
+    {"fullText":"test text","fullTextLanguage":["fi","sv","en"],"ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":[],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
 </div>
 `;
@@ -35,17 +35,17 @@ exports[`CombinedSearchProvider > reads the context properly 2`] = `
   <p
     data-test-id="event-searchVariables"
   >
-    {"fullText":"test text","ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
+    {"fullText":"test text","fullTextLanguage":["fi","sv","en"],"ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"General","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="course-searchVariables"
   >
-    {"fullText":"test text","ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
+    {"fullText":"test text","fullTextLanguage":["fi","sv","en"],"ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
   <p
     data-test-id="venue-searchVariables"
   >
-    {"fullText":"test text","ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
+    {"fullText":"test text","fullTextLanguage":["fi","sv","en"],"ongoing":true,"start":"now","end":"","include":["keywords","location"],"keywordAnd":[],"keywordNot":[],"keywordOrSet1":["yso:p916","kulke:710","yso:p17018","yso:p1963","yso:p9824","yso:p965","yso:p6409","yso:p8781","yso:p26619","yso:p13035","yso:p2041"],"keywordOrSet2":["yso:p8504","yso:p8105"],"keywordOrSet3":[],"location":[],"sort":"end_time","eventType":"Course","superEvent":"none","publisher":null,"publisherAncestor":null,"pageSize":25,"division":["ocd-division/country:fi/kunta:helsinki"]}
   </p>
 </div>
 `;

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/constants.ts
@@ -48,6 +48,7 @@ export const initialVenueSearchAdapterValues = {
 
 export const initialEventSearchAdapterValues = {
   fullText: '',
+  fullTextLanguage: undefined,
   ongoing: true,
   start: 'now',
   end: '',

--- a/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
+++ b/apps/sports-helsinki/src/domain/search/combinedSearch/types.ts
@@ -95,6 +95,7 @@ export type CombinedSearchAdapterInputFallback =
 export type EventSearchParams = Pick<
   EventListQueryVariables,
   | 'fullText'
+  | 'fullTextLanguage'
   | 'ongoing'
   | 'start'
   | 'end'

--- a/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
+++ b/apps/sports-helsinki/src/domain/search/eventSearch/utils.tsx
@@ -21,6 +21,7 @@ import {
   isVenue,
   scrollToTop,
   EVENT_SORT_OPTIONS,
+  EVENT_FULL_TEXT_SEARCH_LANGUAGES,
 } from '@events-helsinki/components';
 import {
   addDays,
@@ -232,8 +233,12 @@ export const getEventSearchVariables = ({
     ),
   ];
 
+  const fullTextValue = text?.join(', ');
   return {
-    fullText: text?.join(', '),
+    fullText: fullTextValue,
+    fullTextLanguage: fullTextValue
+      ? EVENT_FULL_TEXT_SEARCH_LANGUAGES
+      : undefined,
     ongoing: true,
     [EVENT_SEARCH_FILTERS.DIVISIONS]: division,
     isFree: isFree || undefined,

--- a/packages/components/src/components/domain/eventSearch/query.ts
+++ b/packages/components/src/components/domain/eventSearch/query.ts
@@ -38,6 +38,7 @@ export const QUERY_EVENT_LIST = gql`
     $text: String
     $translation: String
     $fullText: String
+    $fullTextLanguage: [String]
     $ongoing: Boolean
   ) {
     eventList(
@@ -77,6 +78,7 @@ export const QUERY_EVENT_LIST = gql`
       text: $text
       translation: $translation
       fullText: $fullText
+      fullTextLanguage: $fullTextLanguage
       ongoing: $ongoing
     ) {
       meta {

--- a/packages/components/src/constants/event-constants.ts
+++ b/packages/components/src/constants/event-constants.ts
@@ -94,6 +94,8 @@ export enum EVENT_SEARCH_FILTERS {
   SUITABLE = 'suitableFor',
 }
 
+export const EVENT_FULL_TEXT_SEARCH_LANGUAGES = ['fi', 'sv', 'en'];
+
 /**
  * City of Helsinki's organization ID in Linked Events
  * @see https://api.hel.fi/linkedevents/v1/organization/ahjo:00001/

--- a/packages/components/src/types/generated/graphql.tsx
+++ b/packages/components/src/types/generated/graphql.tsx
@@ -8430,6 +8430,7 @@ export type QueryEventListArgs = {
   text?: InputMaybe<Scalars['String']['input']>;
   translation?: InputMaybe<Scalars['String']['input']>;
   fullText?: InputMaybe<Scalars['String']['input']>;
+  fullTextLanguage?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   ongoing?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
@@ -14474,6 +14475,7 @@ export type EventListQueryVariables = Exact<{
   text?: InputMaybe<Scalars['String']['input']>;
   translation?: InputMaybe<Scalars['String']['input']>;
   fullText?: InputMaybe<Scalars['String']['input']>;
+  fullTextLanguage?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   ongoing?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
@@ -16248,6 +16250,7 @@ export const EventListDocument = gql`
     $text: String
     $translation: String
     $fullText: String
+    $fullTextLanguage: [String]
     $ongoing: Boolean
   ) {
     eventList(
@@ -16287,6 +16290,7 @@ export const EventListDocument = gql`
       text: $text
       translation: $translation
       fullText: $fullText
+      fullTextLanguage: $fullTextLanguage
       ongoing: $ongoing
     ) {
       meta {
@@ -16350,6 +16354,7 @@ export const EventListDocument = gql`
  *      text: // value for 'text'
  *      translation: // value for 'translation'
  *      fullText: // value for 'fullText'
+ *      fullTextLanguage: // value for 'fullTextLanguage'
  *      ongoing: // value for 'ongoing'
  *   },
  * });


### PR DESCRIPTION
### Overview
This PR adds support for the fullTextLanguage parameter to enable language-aware full-text search. This improves search relevance by allowing searches to be performed in the user's current language.