### PR TITLE
fix(hobbies-helsinki): remove hardcoded campaign short URL redirects

### DIFF
--- a/apps/hobbies-helsinki/redirectCampaignRoutes.config.mjs
+++ b/apps/hobbies-helsinki/redirectCampaignRoutes.config.mjs
@@ -1,12 +1,3 @@
-// Ignore prettier in order to preserve readability of the routes:
-// prettier-ignore
-const redirectRoutes = {
-  // Finnish locale versions
-  '/suomenmalli': '/fi/haku?text=harrastamisen+suomen+malli',
-  // Swedish locale versions
-  '/finlandsmodellen': '/sv/sok?text=harrastamisen+suomen+malli',
-  // English locale versions
-  '/thefinnishmodel': '/en/search?text=harrastamisen+suomen+malli',
-};
+const redirectRoutes = {};
 
 export default redirectRoutes;

--- a/apps/hobbies-helsinki/src/middleware.ts
+++ b/apps/hobbies-helsinki/src/middleware.ts
@@ -9,7 +9,7 @@ import type { NextRequest } from 'next/server';
 import redirectCampaignRoutes from '../redirectCampaignRoutes.config.mjs';
 
 const redirectHandler = new RedirectHandler({
-  redirectCampaignRoutes,
+  redirectCampaignRoutes: redirectCampaignRoutes as Record<string, string>,
 });
 
 export async function middleware(req: NextRequest) {


### PR DESCRIPTION
## Description

Removed hardcoded campaign short URL redirects from [apps/hobbies-helsinki/redirectCampaignRoutes.config.mjs](apps/hobbies-helsinki/redirectCampaignRoutes.config.mjs) so dynamic CMS-configured short URLs work correctly after the fulltext search based URL behavior change.

## Issues

### Closes

**[HH-462](https://helsinkisolutionoffice.atlassian.net/browse/HH-462):** Remove hardcoded hobby campaign short URL redirects to allow new admin-generated short URL to work.

Refs: HH-462

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-462]: https://helsinkisolutionoffice.atlassian.net/browse/HH-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ