### PR TITLE
fix: update headless cms HCRC-194

### DIFF
--- a/apps/events-helsinki/package.json
+++ b/apps/events-helsinki/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@apollo/client": "^3.11.10",
-    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.1",
+    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.3",
     "@events-helsinki/common-i18n": "workspace:^",
     "@events-helsinki/components": "workspace:^",
     "@sentry/browser": "^10.52.0",

--- a/apps/hobbies-helsinki/package.json
+++ b/apps/hobbies-helsinki/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@apollo/client": "^3.11.10",
-    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.1",
+    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.3",
     "@events-helsinki/common-i18n": "workspace:^",
     "@events-helsinki/components": "workspace:^",
     "@sentry/browser": "^10.52.0",

--- a/apps/sports-helsinki/package.json
+++ b/apps/sports-helsinki/package.json
@@ -50,7 +50,7 @@
     "@apollo/client": "^3.11.10",
     "@apollo/datasource-rest": "6.4.1",
     "@apollo/subgraph": "2.13.3",
-    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.1",
+    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.3",
     "@events-helsinki/common-i18n": "workspace:^",
     "@events-helsinki/components": "workspace:^",
     "@sentry/browser": "^10.52.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@apollo/client": "^3.11.10",
     "@changey/react-leaflet-markercluster": "4.0.0-rc1",
-    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.1",
+    "@city-of-helsinki/react-helsinki-headless-cms": "3.0.3",
     "@jonkoops/matomo-tracker-react": "0.7.0",
     "@next/env": "15.5.11",
     "@react-leaflet/core": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 7
   cacheKey: 9
 
-"@acemir/cssom@npm:^0.9.28":
-  version: 0.9.30
-  resolution: "@acemir/cssom@npm:0.9.30"
-  checksum: 6618b310f7bb7e6b686a117eff6bff3346ea9547a254b0ada7964f7ff2bc3b4d3a1dae283d33e81e799b4195152856596385ac5b5154dec5e00e0d418464439f
+"@acemir/cssom@npm:^0.9.31":
+  version: 0.9.31
+  resolution: "@acemir/cssom@npm:0.9.31"
+  checksum: b597d4b66c2322b74f3be4b06c6dadc9b913a22ede0c6cbf0a1c3a49e2c47597eea8effe450efc2d1a191d28195f7b6e42036aadb08202e6dc8698aa85decfae
   languageName: node
   linkType: hard
 
@@ -368,29 +368,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asamuzakjp/css-color@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "@asamuzakjp/css-color@npm:4.1.1"
+"@asamuzakjp/css-color@npm:^5.0.1":
+  version: 5.1.11
+  resolution: "@asamuzakjp/css-color@npm:5.1.11"
   dependencies:
-    "@csstools/css-calc": "npm:^2.1.4"
-    "@csstools/css-color-parser": "npm:^3.1.0"
-    "@csstools/css-parser-algorithms": "npm:^3.0.5"
-    "@csstools/css-tokenizer": "npm:^3.0.4"
-    lru-cache: "npm:^11.2.4"
-  checksum: 1a8f8c3f84c9a7dd733cc1df67dcaf2e65b9a1340884b9f062dab46f893036eb7316075045b8dfb49920d09eebe8a2dd43fe787c036c7c44fbd4cbde3570f7c7
+    "@asamuzakjp/generational-cache": "npm:^1.0.1"
+    "@csstools/css-calc": "npm:^3.2.0"
+    "@csstools/css-color-parser": "npm:^4.1.0"
+    "@csstools/css-parser-algorithms": "npm:^4.0.0"
+    "@csstools/css-tokenizer": "npm:^4.0.0"
+  checksum: 6d4c0db351bba27bb9cdf5ebbe2dca77e7ab3515811453913f1749999c58cdc968f4f3838f2a439b13099e5739bedbc074d912b23f806633527c60ec15a71fe5
   languageName: node
   linkType: hard
 
-"@asamuzakjp/dom-selector@npm:^6.7.6":
-  version: 6.7.6
-  resolution: "@asamuzakjp/dom-selector@npm:6.7.6"
+"@asamuzakjp/dom-selector@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@asamuzakjp/dom-selector@npm:6.8.1"
   dependencies:
     "@asamuzakjp/nwsapi": "npm:^2.3.9"
     bidi-js: "npm:^1.0.3"
     css-tree: "npm:^3.1.0"
     is-potential-custom-element-name: "npm:^1.0.1"
-    lru-cache: "npm:^11.2.4"
-  checksum: d101a855ea118f4a3d5f0f0310a8d416915a34b8586380dc576eec435161ba11f654617074cdd4832b5157f72c5d8580783c8f153955cfae239e391d7d09351f
+    lru-cache: "npm:^11.2.6"
+  checksum: 92e14a278762f79c9ce63e842e15087ec79a1b4f3efb7003b41d3ccdd07995a13a972288c1eb4b6c923030dd0dc584e3440f1cef04b6cd2a5bef810675d40e02
+  languageName: node
+  linkType: hard
+
+"@asamuzakjp/generational-cache@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@asamuzakjp/generational-cache@npm:1.0.1"
+  checksum: e2bd5d6fe0f5d7475e8dd886fe0c4c6d2beb708b62744b188ef54d9cbd63f11c6f4ec1a8673b6ed6805b1ab924d63c923ac1b1b9ce6aca2868dfbac41e8870b6
   languageName: node
   linkType: hard
 
@@ -401,7 +408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.29.7":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/code-frame@npm:7.29.7"
   dependencies:
@@ -1845,6 +1852,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bramus/specificity@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "@bramus/specificity@npm:2.4.2"
+  dependencies:
+    css-tree: "npm:^3.0.0"
+  bin:
+    specificity: bin/cli.js
+  checksum: 04fd9ad0bed1d3de4437fa2bd14ea4ef4d2c920818a0a64698aabeb2a2c8b1759f4042f11aa25f0995aad6b7aee443d26ccde55d10c92968fc789bc9196926c7
+  languageName: node
+  linkType: hard
+
 "@bufbuild/protobuf@npm:^2.5.0":
   version: 2.11.0
   resolution: "@bufbuild/protobuf@npm:2.11.0"
@@ -1868,20 +1886,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@city-of-helsinki/react-helsinki-headless-cms@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@city-of-helsinki/react-helsinki-headless-cms@npm:3.0.1"
+"@city-of-helsinki/react-helsinki-headless-cms@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@city-of-helsinki/react-helsinki-headless-cms@npm:3.0.3"
   dependencies:
     classnames: "npm:^2.5.1"
     date-fns: "npm:^4.1.0"
-    doctoc: "npm:^2.2.1"
+    doctoc: "npm:^2.3.0"
     hds-design-tokens: "npm:^4.8.1"
     html-entities: "npm:^2.6.0"
     html-react-parser: "npm:^5.2.5"
-    isomorphic-dompurify: "npm:^2.34.0"
-    jest-environment-jsdom: "npm:^30.2.0"
-    jest-fixed-jsdom: "npm:^0.0.11"
-    lodash-es: "npm:^4.17.21"
+    isomorphic-dompurify: "npm:^2.36.0"
+    lodash-es: "npm:^4.17.23"
     msw: "npm:^2.12.4"
   peerDependencies:
     "@apollo/client": ^3.14.0
@@ -1891,7 +1907,7 @@ __metadata:
   peerDependenciesMeta:
     "@apollo/client":
       optional: true
-  checksum: b4ff811c158acb7e8243eeab410164aec229d6a2fb18ea816ee6fdf777ff0490d7f590d524f79e31b34a463270642531e390a750bd4547bb55969a182c5bb727
+  checksum: 5fd81766a5f8587314a2f11e8e9683dc690d5888c6670850ebfdf756d724a81a7b5f34eea75fc18ff459ac4282a0cb096d869e80c9a0b806cfe297d64d1e7e9a
   languageName: node
   linkType: hard
 
@@ -2119,6 +2135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@csstools/color-helpers@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@csstools/color-helpers@npm:6.1.0"
+  checksum: 139bd65e81e64319a14817c7096dcd699b1883d33a023f5d3659bc703261ededb62325103f8f8e3701ee04c7eaec5fe133b92b9941a73d518d82eaebce9da4f7
+  languageName: node
+  linkType: hard
+
 "@csstools/css-calc@npm:^2.1.3, @csstools/css-calc@npm:^2.1.4":
   version: 2.1.4
   resolution: "@csstools/css-calc@npm:2.1.4"
@@ -2129,7 +2152,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/css-color-parser@npm:^3.0.10, @csstools/css-color-parser@npm:^3.0.9, @csstools/css-color-parser@npm:^3.1.0":
+"@csstools/css-calc@npm:^3.2.0, @csstools/css-calc@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@csstools/css-calc@npm:3.2.1"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^4.0.0
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: 3da030ed97b7eae683aedf04bdd0ddd5dfa20bb3d829dc0946e86f9578c5f56fce6169f57d5f2f3c86beff30a4c2a715726ce8826c4bdf12a085de9de2041033
+  languageName: node
+  linkType: hard
+
+"@csstools/css-color-parser@npm:^3.0.10, @csstools/css-color-parser@npm:^3.0.9":
   version: 3.1.0
   resolution: "@csstools/css-color-parser@npm:3.1.0"
   dependencies:
@@ -2142,6 +2175,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@csstools/css-color-parser@npm:^4.1.0":
+  version: 4.1.9
+  resolution: "@csstools/css-color-parser@npm:4.1.9"
+  dependencies:
+    "@csstools/color-helpers": "npm:^6.1.0"
+    "@csstools/css-calc": "npm:^3.2.1"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^4.0.0
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: db68bb1f44c62eb1fdd6c29e7d132e8fc3fa8151ea809619acb126e8874524a9e3b6e916817dc52e62f3182d33b5afb7ff26226809edc3764633dcbf00d727af
+  languageName: node
+  linkType: hard
+
 "@csstools/css-parser-algorithms@npm:^3.0.4, @csstools/css-parser-algorithms@npm:^3.0.5":
   version: 3.0.5
   resolution: "@csstools/css-parser-algorithms@npm:3.0.5"
@@ -2151,10 +2197,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/css-syntax-patches-for-csstree@npm:^1.0.21":
-  version: 1.0.22
-  resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.0.22"
-  checksum: 214c67f05569a89521f5d0d026f5b443b7d58766491026aa0dd06e9e230ababed6fc5bc2b79574c4f5d13cb8914d9c88d28ec6d6ae3ec54ff172183f787d315b
+"@csstools/css-parser-algorithms@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/css-parser-algorithms@npm:4.0.0"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: b457993a66627a82853d8e305ec5163e13b179cf0ee2946246d104fd7a356b17d128dc18c3be21aa17788ca4e1e9ac12f3e64ddd5e07c75b92bd35bfe7cb9c2f
+  languageName: node
+  linkType: hard
+
+"@csstools/css-syntax-patches-for-csstree@npm:^1.0.28":
+  version: 1.1.6
+  resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.1.6"
+  peerDependencies:
+    css-tree: ^3.2.1
+  peerDependenciesMeta:
+    css-tree:
+      optional: true
+  checksum: 299cfbd9470aa534e330bcb179b4509e28c560f155a5df04b27afbb4bb1a65219343978fc8ecd72a73162feb610edb0743d504b6b08b30aab90df0fd326ca2a3
   languageName: node
   linkType: hard
 
@@ -2162,6 +2222,13 @@ __metadata:
   version: 3.0.4
   resolution: "@csstools/css-tokenizer@npm:3.0.4"
   checksum: 05ed8aeddd85038f94809803e789a6fc235d9edc9d722750a05211acd76c7d9219cb4207fab75e4fa01ef6660782b9e0a67ad67b11510f321885d3b5a9ac95ac
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/css-tokenizer@npm:4.0.0"
+  checksum: 0cd6356447e496cd832270a729624694c61299dd49897b712b706b8ae03965cc32e94af26d9cc22617959367f31f10554a37478932681dd738b0e5d04ba8d0ee
   languageName: node
   linkType: hard
 
@@ -3419,7 +3486,7 @@ __metadata:
     "@babel/preset-react": "npm:7.27.1"
     "@babel/preset-typescript": "npm:7.27.1"
     "@changey/react-leaflet-markercluster": "npm:4.0.0-rc1"
-    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.1"
+    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.3"
     "@events-helsinki/common-i18n": "workspace:^"
     "@events-helsinki/common-tests": "workspace:^"
     "@events-helsinki/eslint-config-bases": "workspace:^"
@@ -3659,15 +3726,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@exodus/bytes@npm:^1.6.0":
-  version: 1.7.0
-  resolution: "@exodus/bytes@npm:1.7.0"
+"@exodus/bytes@npm:^1.11.0, @exodus/bytes@npm:^1.6.0":
+  version: 1.15.1
+  resolution: "@exodus/bytes@npm:1.15.1"
   peerDependencies:
-    "@exodus/crypto": ^1.0.0-rc.4
+    "@noble/hashes": ^1.8.0 || ^2.0.0
   peerDependenciesMeta:
-    "@exodus/crypto":
+    "@noble/hashes":
       optional: true
-  checksum: 6f512bb89c401d691037c6a1fd185526494544250c803f1c77a6a8610d49342515d428cffb589b9da8326b8ca24182408f920d7f44eccb95d3c11aa83c4c7be1
+  checksum: 3080944680dac94a8b6534d65dcfd4461277df08a3abcf33209ffe910772e949a198d3344950001b1fb56299bde8257e629996f97e423004088eded31bc86414
   languageName: node
   linkType: hard
 
@@ -4960,87 +5027,6 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.4"
   checksum: 4ec07f53d8c8caf6543536c9b49473e18c603ea29a7cd91f8d8407bb140ce8676c5b8c931fe33fd591b10ccb8f289415e65af8596df80a3a0a1a302e1184fbe3
-  languageName: node
-  linkType: hard
-
-"@jest/environment-jsdom-abstract@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/environment-jsdom-abstract@npm:30.2.0"
-  dependencies:
-    "@jest/environment": "npm:30.2.0"
-    "@jest/fake-timers": "npm:30.2.0"
-    "@jest/types": "npm:30.2.0"
-    "@types/jsdom": "npm:^21.1.7"
-    "@types/node": "npm:*"
-    jest-mock: "npm:30.2.0"
-    jest-util: "npm:30.2.0"
-  peerDependencies:
-    canvas: ^3.0.0
-    jsdom: "*"
-  peerDependenciesMeta:
-    canvas:
-      optional: true
-  checksum: 2b653e32ff397675038a48e2ff69d40b88439c58f8cb3b0d6603c25761ae3db41b3dc879b6a2deb1a1c769ee42ec479c3628caee915c0068e95917b5765d88e1
-  languageName: node
-  linkType: hard
-
-"@jest/environment@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/environment@npm:30.2.0"
-  dependencies:
-    "@jest/fake-timers": "npm:30.2.0"
-    "@jest/types": "npm:30.2.0"
-    "@types/node": "npm:*"
-    jest-mock: "npm:30.2.0"
-  checksum: a0940da29abba1d47be3d53c303b7dddafc8a51df16220c45371a528934199e5e97acf0d0e254e7a023697bc6c415586cd7536c3c2c015d52e2bc74de200beae
-  languageName: node
-  linkType: hard
-
-"@jest/fake-timers@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/fake-timers@npm:30.2.0"
-  dependencies:
-    "@jest/types": "npm:30.2.0"
-    "@sinonjs/fake-timers": "npm:^13.0.0"
-    "@types/node": "npm:*"
-    jest-message-util: "npm:30.2.0"
-    jest-mock: "npm:30.2.0"
-    jest-util: "npm:30.2.0"
-  checksum: d827549ec3564d43486fad2f325076582e82ade76af5cd529c1f2a0fbd40e7433addfb2b1a5102098a7703fe0d3754b6100dc1535ef70bea7cdbc68302e7ec6f
-  languageName: node
-  linkType: hard
-
-"@jest/pattern@npm:30.0.1":
-  version: 30.0.1
-  resolution: "@jest/pattern@npm:30.0.1"
-  dependencies:
-    "@types/node": "npm:*"
-    jest-regex-util: "npm:30.0.1"
-  checksum: ca59e38489a72364a5c01dcb4d91b47f86c9672560b559baf0d27083aac8b1f2470d01836e8236e93f0ad52c182ddc745b9656860cbebbf5abd8ec4f23876e8b
-  languageName: node
-  linkType: hard
-
-"@jest/schemas@npm:30.0.5":
-  version: 30.0.5
-  resolution: "@jest/schemas@npm:30.0.5"
-  dependencies:
-    "@sinclair/typebox": "npm:^0.34.0"
-  checksum: 21ed00392c6c693bbd181174f5b6cd72cbcc1e1cfb780567a92f45cd3ffb97eeed61fb18e93f57afb0264474bf7161215dd66784c8bad6196651a1f5cea24a8e
-  languageName: node
-  linkType: hard
-
-"@jest/types@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/types@npm:30.2.0"
-  dependencies:
-    "@jest/pattern": "npm:30.0.1"
-    "@jest/schemas": "npm:30.0.5"
-    "@types/istanbul-lib-coverage": "npm:^2.0.6"
-    "@types/istanbul-reports": "npm:^3.0.4"
-    "@types/node": "npm:*"
-    "@types/yargs": "npm:^17.0.33"
-    chalk: "npm:^4.1.2"
-  checksum: 22b028c9af0427aa11c96e2f41c86bfdcace1c74adeb61a979e631f5522bb3eaea601d979413995fbbea369c418cb0848d6aeab516345a19d715ea9f23fc2b17
   languageName: node
   linkType: hard
 
@@ -6995,35 +6981,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:^0.34.0":
-  version: 0.34.41
-  resolution: "@sinclair/typebox@npm:0.34.41"
-  checksum: ecb924c2bb82cb780b6e13c0e73a77ac43928673a7e96151182c852ef12f4b8d62ea2464d5aa7c157bf9c29ff36a5a7cceff8a3337fd4865ca858e812e8948aa
-  languageName: node
-  linkType: hard
-
 "@sindresorhus/merge-streams@npm:^2.1.0":
   version: 2.3.0
   resolution: "@sindresorhus/merge-streams@npm:2.3.0"
   checksum: 28f1b1c14ad0045f792308a3eed6048fe918a868cb6b56f8bca786a6505e62d3a0631bcc0966ab811ae47fa9802d5167570343a0e30dfa96603d6cb18542915c
-  languageName: node
-  linkType: hard
-
-"@sinonjs/commons@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@sinonjs/commons@npm:3.0.1"
-  dependencies:
-    type-detect: "npm:4.0.8"
-  checksum: ed70918be73505b25bf4d6fb5b9dc93fddedfa2adc43f02b27e9fbe9beadcb6b4338ba1710beddcb147394eff46d69154427155afc0e4705abd1dca09a41a7f3
-  languageName: node
-  linkType: hard
-
-"@sinonjs/fake-timers@npm:^13.0.0":
-  version: 13.0.5
-  resolution: "@sinonjs/fake-timers@npm:13.0.5"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.1"
-  checksum: fe2b0459677da93301f6bda3bca40d72e0da932a830740b7277b1abc408fec99d0641576c1cc062a55c34fec29060316143e552a22eebf5b10821644a70fe845
   languageName: node
   linkType: hard
 
@@ -7534,6 +7495,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@textlint/ast-node-types@npm:15.7.1":
+  version: 15.7.1
+  resolution: "@textlint/ast-node-types@npm:15.7.1"
+  checksum: 62f48a5c216030cc30bb9783a357c26c8ad09a7f608ea30694e6906a5b3892998cfcc785c5a4d8f9eeb80e3575163ca88bcb083a3462be911da2ce0fca4b543a
+  languageName: node
+  linkType: hard
+
 "@textlint/ast-node-types@npm:^12.6.1":
   version: 12.6.1
   resolution: "@textlint/ast-node-types@npm:12.6.1"
@@ -7555,6 +7523,24 @@ __metadata:
     traverse: "npm:^0.6.7"
     unified: "npm:^9.2.2"
   checksum: 5ceaf4bf8cd9bbce27073c05d6687fe7ab05e25235a4efeb7c6670f40fad02a4331a3a2a1de30340cda69308102b1f9263cf59443f048ef28e87f16be9c5d807
+  languageName: node
+  linkType: hard
+
+"@textlint/markdown-to-ast@npm:^15.6.0":
+  version: 15.7.1
+  resolution: "@textlint/markdown-to-ast@npm:15.7.1"
+  dependencies:
+    "@textlint/ast-node-types": "npm:15.7.1"
+    debug: "npm:^4.4.3"
+    mdast-util-gfm-autolink-literal: "npm:^0.1.3"
+    neotraverse: "npm:^0.6.18"
+    remark-footnotes: "npm:^3.0.0"
+    remark-frontmatter: "npm:^3.0.0"
+    remark-gfm: "npm:^1.0.0"
+    remark-parse: "npm:^9.0.0"
+    structured-source: "npm:^4.0.0"
+    unified: "npm:^9.2.2"
+  checksum: d7f0c8ec6ab2cef37b0c048a00e189143606a0fe4a5ff5dedbfa36943f3d91fa39f0a845a0b3083023535d513e8f14e3db060316c3f05ef71d2f88b6eb0daba6
   languageName: node
   linkType: hard
 
@@ -7859,31 +7845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
-  checksum: 4c0fceacf1747575397d16768636f18b76e383b403ab38cc69c8c8d7bed22a7b27014e944d1200a956928bee3c36f526129c621b3d4e4656afe6a06c83abf772
-  languageName: node
-  linkType: hard
-
-"@types/istanbul-lib-report@npm:*":
-  version: 3.0.0
-  resolution: "@types/istanbul-lib-report@npm:3.0.0"
-  dependencies:
-    "@types/istanbul-lib-coverage": "npm:*"
-  checksum: ed2b2a214e247bb24aede74cde6edf00989e575dc8827e160f63ced1816d227f6fb370c2d9b5fa56f9b5bd7202804f272a4fe05ac51461982760730966e39efb
-  languageName: node
-  linkType: hard
-
-"@types/istanbul-reports@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "@types/istanbul-reports@npm:3.0.4"
-  dependencies:
-    "@types/istanbul-lib-report": "npm:*"
-  checksum: 307dee2b5a41fedc9ca0f11aa036d49ef6abf24b81865f9e9a237f010d78bfffbac0a9ba46ced765751262cddd0fada6a89b7a149ce00136b110514ead09719a
-  languageName: node
-  linkType: hard
-
 "@types/js-yaml@npm:^4.0.0, @types/js-yaml@npm:^4.0.5":
   version: 4.0.5
   resolution: "@types/js-yaml@npm:4.0.5"
@@ -7891,7 +7852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsdom@npm:21.1.7, @types/jsdom@npm:^21.1.7":
+"@types/jsdom@npm:21.1.7":
   version: 21.1.7
   resolution: "@types/jsdom@npm:21.1.7"
   dependencies:
@@ -8154,13 +8115,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/stack-utils@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@types/stack-utils@npm:2.0.3"
-  checksum: ca418197f076c4c1decc551f3d814aee1ca88c2d72285f41e0dff4864b9269b3b813581630a09292070432de02c1a2754480ad62868a6017ed2965af0b4b8d4d
-  languageName: node
-  linkType: hard
-
 "@types/statuses@npm:^2.0.6":
   version: 2.0.6
   resolution: "@types/statuses@npm:2.0.6"
@@ -8225,22 +8179,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 9e70def71c922767d70689c2300eeb2b78bbd18a1dd9f75ea81494f365f36cc7374a6504692ec134064d7bce438ee4fb2fe7420521f79d839fa8f35fc788d819
-  languageName: node
-  linkType: hard
-
-"@types/yargs-parser@npm:*":
-  version: 21.0.0
-  resolution: "@types/yargs-parser@npm:21.0.0"
-  checksum: 81725f71214a1b174d970177759871e9c87f186cd37fe4638b0ae39ad1ee630fa488525048a9a582cd2e27585c4c253198f2d5756e1a5a161988783e23630f3d
-  languageName: node
-  linkType: hard
-
-"@types/yargs@npm:^17.0.33":
-  version: 17.0.34
-  resolution: "@types/yargs@npm:17.0.34"
-  dependencies:
-    "@types/yargs-parser": "npm:*"
-  checksum: ab1a8aa0e14415d38b5b6e5554dca506017ef37cd1cfc34c4bf3307926bc11f60e69086d163d4163d46e18d8718ba116d6f036cec5f690f5cd5fa3ed84884c8b
   languageName: node
   linkType: hard
 
@@ -9420,13 +9358,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anchor-markdown-header@npm:^0.8.2":
-  version: 0.8.3
-  resolution: "anchor-markdown-header@npm:0.8.3"
+"anchor-markdown-header@npm:^0.8.2, anchor-markdown-header@npm:^0.8.4":
+  version: 0.8.4
+  resolution: "anchor-markdown-header@npm:0.8.4"
   dependencies:
     emoji-regex: "npm:~10.6.0"
     remove-markdown: "npm:^0.6.2"
-  checksum: cba6c0c5ac6249843ec829d1939fbd499439c74df034a83648964fb93b1ccaa393b38f48d93772c2d159580cb0e395fcc8235e73858bae78bf873b236b7eefdc
+  checksum: 8a2c1259a83f965268f9b6340b41b7810e101aa97cc68463ddc42b9f16ba60e7410f44cdb8c0c829d1a0809b31da96b9d558f8f985e65fce90f9c9070d457139
   languageName: node
   linkType: hard
 
@@ -9498,7 +9436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
+"ansi-styles@npm:^5.0.0":
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: be68c7c5f374e8d72174b43ff3ab5bdd0e2e024bcaace9c0d2bbcd0edef71281424a1d23e5b29c8c7911143e4c34090088287a15f36ed710167c5bcccc867c7e
@@ -10231,6 +10169,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"boundary@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "boundary@npm:2.0.0"
+  checksum: 5553d5721e9e9ce2f588b1e9ac874c8df4a57833d18273c0cc43ea2eca596f91f2a51beb5af040c0bf237587d19506685705a9eefa4df03e12b6faa017d77f84
+  languageName: node
+  linkType: hard
+
 "bowser@npm:1.6.0":
   version: 1.6.0
   resolution: "bowser@npm:1.6.0"
@@ -10905,7 +10850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.1.0, ci-info@npm:^4.2.0":
+"ci-info@npm:^4.1.0":
   version: 4.3.1
   resolution: "ci-info@npm:4.3.1"
   checksum: f5b7c57c5da59879adba27171f5b1e4053e2822120b174844fc1758ea12f1659dabc5643a4a163dfb27349beec63de9a845a242f23e444b35c8b2a140fd2031c
@@ -11792,7 +11737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-tree@npm:^3.0.1, css-tree@npm:^3.1.0":
+"css-tree@npm:^3.0.0, css-tree@npm:^3.0.1, css-tree@npm:^3.1.0":
   version: 3.2.1
   resolution: "css-tree@npm:3.2.1"
   dependencies:
@@ -11861,14 +11806,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssstyle@npm:^5.3.4":
-  version: 5.3.5
-  resolution: "cssstyle@npm:5.3.5"
+"cssstyle@npm:^6.0.1":
+  version: 6.2.0
+  resolution: "cssstyle@npm:6.2.0"
   dependencies:
-    "@asamuzakjp/css-color": "npm:^4.1.1"
-    "@csstools/css-syntax-patches-for-csstree": "npm:^1.0.21"
+    "@asamuzakjp/css-color": "npm:^5.0.1"
+    "@csstools/css-syntax-patches-for-csstree": "npm:^1.0.28"
     css-tree: "npm:^3.1.0"
-  checksum: fad7b22f734f95f75e4096f6dd5c4d2db69131e9a47c46067255106aa01881db3fd7ceaf1d5e04384393cf7f1ea8815dd967dfabe7a5c744452b65dfc7cd5993
+    lru-cache: "npm:^11.2.6"
+  checksum: 78c156ca34072fe826326b27050d6735b816b3b998790b8461cb08e5920fbe4371e6bf9ed4cec51099c30e0869b026ae923403bc341e6530f4bde5d2ddb0d14f
   languageName: node
   linkType: hard
 
@@ -11910,13 +11856,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-urls@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "data-urls@npm:6.0.0"
+"data-urls@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "data-urls@npm:7.0.0"
   dependencies:
-    whatwg-mimetype: "npm:^4.0.0"
-    whatwg-url: "npm:^15.0.0"
-  checksum: f0f52c55e567b9e2425fa229689be85c0854a8b36ea7573e3d5ea0c5e6e847afb3ac5cd3f16ee697d6bd7affb47e450febe2f1aac3ce43f8ff6562ae0eb80374
+    whatwg-mimetype: "npm:^5.0.0"
+    whatwg-url: "npm:^16.0.0"
+  checksum: 253ed7479ab3218885ea57b338d001ad10bb300196873cfaecb3e208061250257ae5d0e711bdf520a0dd5dee8335507624558bc3046b30e22c47ae7943d2dfd3
   languageName: node
   linkType: hard
 
@@ -12272,7 +12218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"doctoc@npm:2.3.0, doctoc@npm:^2.2.1":
+"doctoc@npm:2.3.0":
   version: 2.3.0
   resolution: "doctoc@npm:2.3.0"
   dependencies:
@@ -12285,6 +12231,21 @@ __metadata:
   bin:
     doctoc: doctoc.js
   checksum: 94f531ff337a992a1e33246fecc99169806352cdc1395ac2533a6788fd4fd17f8590e84ff7f4843268685f8da58d900c1069fd8f43585f659b494e5951b35185
+  languageName: node
+  linkType: hard
+
+"doctoc@npm:^2.3.0":
+  version: 2.5.0
+  resolution: "doctoc@npm:2.5.0"
+  dependencies:
+    "@textlint/markdown-to-ast": "npm:^15.6.0"
+    anchor-markdown-header: "npm:^0.8.4"
+    htmlparser2: "npm:^7.2.0"
+    loglevel: "npm:^1.9.2"
+    minimist: "npm:^1.2.6"
+  bin:
+    doctoc: doctoc.js
+  checksum: c1596c6b7fb1a21de6f83f4487397405a5944089e6e0398f105e39f3c0b9af8f9c66918375ddda238a5aedc8bb0cf95b25ef00fdb3c7d3762be63060be4abbae
   languageName: node
   linkType: hard
 
@@ -13239,13 +13200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "escape-string-regexp@npm:2.0.0"
-  checksum: eba6c3fb9b6d1fbad353258ce4aaf3875ee39506cbf525f95a4cd78435668b73c56b5a60b960225ab95ecb7274248ad0e05705468b850ba98e289bfa7021a68e
-  languageName: node
-  linkType: hard
-
 "escape-string-regexp@npm:^4.0.0":
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
@@ -13870,7 +13824,7 @@ __metadata:
   resolution: "events-helsinki@workspace:apps/events-helsinki"
   dependencies:
     "@apollo/client": "npm:^3.11.10"
-    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.1"
+    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.3"
     "@commitlint/cli": "npm:^19.8.1"
     "@commitlint/config-conventional": "npm:^19.8.1"
     "@events-helsinki/common-i18n": "workspace:^"
@@ -15466,7 +15420,7 @@ __metadata:
   resolution: "hobbies-helsinki@workspace:apps/hobbies-helsinki"
   dependencies:
     "@apollo/client": "npm:^3.11.10"
-    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.1"
+    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.3"
     "@commitlint/cli": "npm:^19.8.1"
     "@commitlint/config-conventional": "npm:^19.8.1"
     "@events-helsinki/common-i18n": "workspace:^"
@@ -16969,13 +16923,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isomorphic-dompurify@npm:^2.34.0":
-  version: 2.35.0
-  resolution: "isomorphic-dompurify@npm:2.35.0"
+"isomorphic-dompurify@npm:^2.36.0":
+  version: 2.36.0
+  resolution: "isomorphic-dompurify@npm:2.36.0"
   dependencies:
     dompurify: "npm:^3.3.1"
-    jsdom: "npm:^27.4.0"
-  checksum: 0d9200f5e63dcf35c702258763a2c53f6955ad209130889815f61c4798bed433e9dec5160310211a0d0462df563cd586d0612da14b0388c031269dfc8fbebbb8
+    jsdom: "npm:^28.0.0"
+  checksum: bff50825b47cf47b919696ce4766849cbdfd5b8fe987030a96f7ff1805732e7612294ebc217ba4db68f0a907dbc716201a0c19a0ddc1dc5cae5a95408661926a
   languageName: node
   linkType: hard
 
@@ -17057,82 +17011,6 @@ __metadata:
   version: 1.0.10
   resolution: "jest-date-mock@npm:1.0.10"
   checksum: 76532d80688921d2d691df2b3b0543fa437083453703e03dad0658c4fb4dc14205e3f7436b88aa77c244178f77fb22ff88cfe3421a21ba7bd9062d42f1129b58
-  languageName: node
-  linkType: hard
-
-"jest-environment-jsdom@npm:^30.2.0":
-  version: 30.2.0
-  resolution: "jest-environment-jsdom@npm:30.2.0"
-  dependencies:
-    "@jest/environment": "npm:30.2.0"
-    "@jest/environment-jsdom-abstract": "npm:30.2.0"
-    "@types/jsdom": "npm:^21.1.7"
-    "@types/node": "npm:*"
-    jsdom: "npm:^26.1.0"
-  peerDependencies:
-    canvas: ^3.0.0
-  peerDependenciesMeta:
-    canvas:
-      optional: true
-  checksum: 685e29f4b8969b0b59e65718efed422baff5fd2c52c6a7e17df1061cdaf695e025e0a5607f90fdd88a68e14c03e215ca5c764ca80ea93d05d085d48f96fda91c
-  languageName: node
-  linkType: hard
-
-"jest-fixed-jsdom@npm:^0.0.11":
-  version: 0.0.11
-  resolution: "jest-fixed-jsdom@npm:0.0.11"
-  peerDependencies:
-    jest-environment-jsdom: ">=28.0.0"
-  checksum: b6bb753df5ea246aa753172e63a94f1d3ffdf5916103f62155bb7b02bfbeaaa1bb5da58ac3336d977c5dd4debbb4c9553aec137ed41627e38d6bb40ff52464f8
-  languageName: node
-  linkType: hard
-
-"jest-message-util@npm:30.2.0":
-  version: 30.2.0
-  resolution: "jest-message-util@npm:30.2.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@jest/types": "npm:30.2.0"
-    "@types/stack-utils": "npm:^2.0.3"
-    chalk: "npm:^4.1.2"
-    graceful-fs: "npm:^4.2.11"
-    micromatch: "npm:^4.0.8"
-    pretty-format: "npm:30.2.0"
-    slash: "npm:^3.0.0"
-    stack-utils: "npm:^2.0.6"
-  checksum: 46abf52b7384cb838665aeb3ab543c8cae2abdd6eedfa90b7763287c84ed930d18499669dfabf782ad9edca454a3ea94eeded8e7ba8b0b8916c75470181b9884
-  languageName: node
-  linkType: hard
-
-"jest-mock@npm:30.2.0":
-  version: 30.2.0
-  resolution: "jest-mock@npm:30.2.0"
-  dependencies:
-    "@jest/types": "npm:30.2.0"
-    "@types/node": "npm:*"
-    jest-util: "npm:30.2.0"
-  checksum: b989aadf5d9af413a7db88c640ec7c74c0e3ce5bacc131b047f77e96838c1bcc77761f6033edb73aa501b47df8a3af3830c4e470909f65b6b9f8e933619fb65d
-  languageName: node
-  linkType: hard
-
-"jest-regex-util@npm:30.0.1":
-  version: 30.0.1
-  resolution: "jest-regex-util@npm:30.0.1"
-  checksum: 5d1582dbb2475f3c69d86e9e322af52fed17bcf5a4b5835536492f3ee018f6a3e764838b0910fe03413c5f5b6e796d3d6b479058bef46c27572d427fde1033d8
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:30.2.0":
-  version: 30.2.0
-  resolution: "jest-util@npm:30.2.0"
-  dependencies:
-    "@jest/types": "npm:30.2.0"
-    "@types/node": "npm:*"
-    chalk: "npm:^4.1.2"
-    ci-info: "npm:^4.2.0"
-    graceful-fs: "npm:^4.2.11"
-    picomatch: "npm:^4.0.2"
-  checksum: 9134cae8960e4d63f291c24d5f158890e68eaaad3a33bf01346ccbfec9db8205470ab574704c46ccf4b63febb4f0d9c60c15f91a2ee2a2c84f6c5d3fd0732d2a
   languageName: node
   linkType: hard
 
@@ -17232,7 +17110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdom@npm:26.1.0, jsdom@npm:^26.1.0":
+"jsdom@npm:26.1.0":
   version: 26.1.0
   resolution: "jsdom@npm:26.1.0"
   dependencies:
@@ -17265,15 +17143,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdom@npm:^27.4.0":
-  version: 27.4.0
-  resolution: "jsdom@npm:27.4.0"
+"jsdom@npm:^28.0.0":
+  version: 28.1.0
+  resolution: "jsdom@npm:28.1.0"
   dependencies:
-    "@acemir/cssom": "npm:^0.9.28"
-    "@asamuzakjp/dom-selector": "npm:^6.7.6"
-    "@exodus/bytes": "npm:^1.6.0"
-    cssstyle: "npm:^5.3.4"
-    data-urls: "npm:^6.0.0"
+    "@acemir/cssom": "npm:^0.9.31"
+    "@asamuzakjp/dom-selector": "npm:^6.8.1"
+    "@bramus/specificity": "npm:^2.4.2"
+    "@exodus/bytes": "npm:^1.11.0"
+    cssstyle: "npm:^6.0.1"
+    data-urls: "npm:^7.0.0"
     decimal.js: "npm:^10.6.0"
     html-encoding-sniffer: "npm:^6.0.0"
     http-proxy-agent: "npm:^7.0.2"
@@ -17283,18 +17162,18 @@ __metadata:
     saxes: "npm:^6.0.0"
     symbol-tree: "npm:^3.2.4"
     tough-cookie: "npm:^6.0.0"
+    undici: "npm:^7.21.0"
     w3c-xmlserializer: "npm:^5.0.0"
-    webidl-conversions: "npm:^8.0.0"
-    whatwg-mimetype: "npm:^4.0.0"
-    whatwg-url: "npm:^15.1.0"
-    ws: "npm:^8.18.3"
+    webidl-conversions: "npm:^8.0.1"
+    whatwg-mimetype: "npm:^5.0.0"
+    whatwg-url: "npm:^16.0.0"
     xml-name-validator: "npm:^5.0.0"
   peerDependencies:
     canvas: ^3.0.0
   peerDependenciesMeta:
     canvas:
       optional: true
-  checksum: 01bac2fc4434a187322d504ef7c1dee76623b20a614a4cbf421505570b71f362fb8be30b7b76ad2e53b98cc0110fc9a26df17e0120853630f1f37df0b39910cf
+  checksum: fb9c62ba520b3676e168608213f78cec8932b5bfecca7000acd5f6a9207c8a1b76e7c42305739f39334f0553c0f4d32110cc98b7ad57ce0eaf6f292d30727137
   languageName: node
   linkType: hard
 
@@ -17878,7 +17757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
+"lodash-es@npm:^4.17.21, lodash-es@npm:^4.17.23":
   version: 4.18.1
   resolution: "lodash-es@npm:4.18.1"
   checksum: 64ff03a29b248f660405299e2814db17b207513c07e0787194ebfe7f62680530085130f3b4051a83cae8683e58c78a030c88f41cdd106c69118dbdfe546346f8
@@ -18058,10 +17937,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loglevel@npm:^1.6.8":
-  version: 1.8.1
-  resolution: "loglevel@npm:1.8.1"
-  checksum: ccd8f46eee43ad65010b44228c2e38506c290b6f2c1a023c86b3dcda72804c4b34ae357f16b9bf645dee935975ec2e0ec0bb0a9ddc331d64de44e5d2abc8da5b
+"loglevel@npm:^1.6.8, loglevel@npm:^1.9.2":
+  version: 1.9.2
+  resolution: "loglevel@npm:1.9.2"
+  checksum: d288ccc1da1147fa42306c515cf66c3f0f368ab8c1c648a12b5573b454643df477d7a1c395389d233ec66ab414c0793395118b2f3154a06a7bd31bdd33b3fb01
   languageName: node
   linkType: hard
 
@@ -18129,10 +18008,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.4":
-  version: 11.2.6
-  resolution: "lru-cache@npm:11.2.6"
-  checksum: 157b8d4e3d5734be02f363f2f6f1f5f27bc3dbd0ad60dc6b50b0189938a4db2d022b9cbb5df7ccada4a76fd8b45fef148e0372f58ee603f466f784cc85cf1a64
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.6":
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: 94296e695aa068b4388101419d5f5dc0b86b7a654ee3b3f11970e47b84cdbe7e6aa648430f00aa03139cfab3540b589076cfe4db9f79be5bb9d96e1d5b5cba65
   languageName: node
   linkType: hard
 
@@ -19045,6 +18924,13 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 968ceb7350efb069a413eaa590b9ec2532023d6f4075c06ada75a57f86ff7ffbfc5b0b72760fadc1ccdc546b9c0bc346b69e9f5b03cdaa42f21e8063b880d305
+  languageName: node
+  linkType: hard
+
+"neotraverse@npm:^0.6.18":
+  version: 0.6.18
+  resolution: "neotraverse@npm:0.6.18"
+  checksum: f6ef7a19181bd743a81636348d9d5134f64c97c2e29f9bdb0f03a0b4b412891679c627c90e9719c5e7b1ca49f6c4d13f6abe0435d53918d39f797dd403c9b0e8
   languageName: node
   linkType: hard
 
@@ -20841,17 +20727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:30.2.0":
-  version: 30.2.0
-  resolution: "pretty-format@npm:30.2.0"
-  dependencies:
-    "@jest/schemas": "npm:30.0.5"
-    ansi-styles: "npm:^5.2.0"
-    react-is: "npm:^18.3.1"
-  checksum: 480ea5e3bd43cc1c4f9ff97b151bbc45fa0855042d18ae69e1be37e4c643532b2f74ceab1103bbd7fb31dcf832b8a5e5d41895cfbe1fdb4733012572ed1aa8e6
-  languageName: node
-  linkType: hard
-
 "pretty-format@npm:^27.0.2":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
@@ -21275,13 +21150,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 24af7af3abd0bf94d4eb018a70db25fd4e23648eec7bb8b203bf59e24a715ac4eec8279939e15a4d90cbad19ed6be243a0f2c9aa0b1faec0a1c102d9c89ca3f9
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: e0a752975e25e2965259576e78785857c6b3f97249b686ea8434f4502578c5430a5dd27bd2f57250d567ebf44f0d8ebc5944964cca8d321b964dc21c3ba2dc94
   languageName: node
   linkType: hard
 
@@ -23365,7 +23233,7 @@ __metadata:
     "@apollo/client": "npm:^3.11.10"
     "@apollo/datasource-rest": "npm:6.4.1"
     "@apollo/subgraph": "npm:2.13.3"
-    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.1"
+    "@city-of-helsinki/react-helsinki-headless-cms": "npm:3.0.3"
     "@commitlint/cli": "npm:^19.8.1"
     "@commitlint/config-conventional": "npm:^19.8.1"
     "@events-helsinki/common-i18n": "workspace:^"
@@ -23513,15 +23381,6 @@ __metadata:
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
   checksum: f9a4244c4ba2523b79c8eee52c6dd6505289c7d13ae06664baa36b7482f5e6556564ac2d8442a604fc43a519c3217499572100a51956c0d5b521e05bbc9c4433
-  languageName: node
-  linkType: hard
-
-"stack-utils@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "stack-utils@npm:2.0.6"
-  dependencies:
-    escape-string-regexp: "npm:^2.0.0"
-  checksum: 79e5c96b05bd8b12ab441d95a5c960e819c4783dfdbdef7f663b01fc97a9c51698fd0e8d76d4a91913f33c3fea6e35cf44df1710a6a85d572f20e85fb0846df3
   languageName: node
   linkType: hard
 
@@ -23854,6 +23713,15 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 20cff3f15267a8b603c4dcec9c3cc5217bcf3f1a66481a4f9ecf262eacc1733a0457756288472328d24efef7705f7755e9511f9c383742389add93d4a9207ae5
+  languageName: node
+  linkType: hard
+
+"structured-source@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "structured-source@npm:4.0.0"
+  dependencies:
+    boundary: "npm:^2.0.0"
+  checksum: 4255658689bd4941aef9cae5cec7c1b053ccbd3dc16862c705d5e0c66e32a329b7299c0d91fc49761c3f93f9f8883346aa1831ccaaaa7271460ac33e0252f8d5
   languageName: node
   linkType: hard
 
@@ -25104,7 +24972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8, type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
+"type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 2d2111a44529a381e9be7090066cc89b60ac2c822194e3d213a0d5f630e81abfd07d2b91a324ef4a173973c5b0c68b0bdf29ac6896459cf819914a6f56199e0f
@@ -25332,6 +25200,13 @@ __metadata:
   version: 6.21.0
   resolution: "undici-types@npm:6.21.0"
   checksum: c30efd07d09b3e6ea31aae5acc3c708202ae3efc3360379050cfb72f3c95a8b934bd1e5c905d85605a3d1f3bdc33aa66461a4448da3321ae848554f0b500735b
+  languageName: node
+  linkType: hard
+
+"undici@npm:^7.21.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 1d3dd33e370ef3b03c1c4523defbcb3a5585879ae0585af75950eb5da3dfda4e16dca2f79272a1e75778d7ee02513b80d2c527f62b769d86ffdac1839ed0a4da
   languageName: node
   linkType: hard
 
@@ -26093,10 +25968,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "webidl-conversions@npm:8.0.0"
-  checksum: 08399cb03a3a4efe1f03354d365ca76925c628a86a5cf82002e31cf2cc6a0f52f219b5118baa40b394fde0557d131c2726c72137545fe4902b8fe898105481d6
+"webidl-conversions@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "webidl-conversions@npm:8.0.1"
+  checksum: 82e70e670756bc5a4f163d58b42f4f662ba29b83e2adb2ac56b1530adf675b90ff7fccd22bf4bd32bc94af839d269c285cb2c34e3ec1d38d6dcf85e02de88d2e
   languageName: node
   linkType: hard
 
@@ -26268,6 +26143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-mimetype@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-mimetype@npm:5.0.0"
+  checksum: aad344b0d95e712936f8564e9b32ddeedd6afdd374ff7e7e3018da9fbd47a43d3be1ab33ecbc9f82df4366b219a600c053f8550749f8be4c9330eef2bad0f050
+  languageName: node
+  linkType: hard
+
 "whatwg-url@npm:^14.0.0, whatwg-url@npm:^14.1.1":
   version: 14.2.0
   resolution: "whatwg-url@npm:14.2.0"
@@ -26278,13 +26160,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^15.0.0, whatwg-url@npm:^15.1.0":
-  version: 15.1.0
-  resolution: "whatwg-url@npm:15.1.0"
+"whatwg-url@npm:^16.0.0":
+  version: 16.0.1
+  resolution: "whatwg-url@npm:16.0.1"
   dependencies:
+    "@exodus/bytes": "npm:^1.11.0"
     tr46: "npm:^6.0.0"
-    webidl-conversions: "npm:^8.0.0"
-  checksum: 939f169c7ef99a8c3ff8ee896813d10f46e2b0af3a5f003e009741370827de7d1f7cc925364289839178b3bb2822b831a509e3820f1bcd3e70e6e26393a86f7a
+    webidl-conversions: "npm:^8.0.1"
+  checksum: 6dd0d13a532d563d99d1f9a8e5f4e8e35791c72156f50a44c3995d7ae4c71d5de5ccde94d93d17e06222228f24bedcdb929cf05dac4d1603b9a4e3a668e88c6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Refs: HCRC-194

## Description :sparkles:

Update react-helsinki-headless-cms from 3.0.1 to 3.0.3.
That contains dependency updates and bug fixes.

**[HCRC-194](https://helsinkisolutionoffice.atlassian.net/browse/HCRC-194):**

[HCRC-194]: https://helsinkisolutionoffice.atlassian.net/browse/HCRC-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `@city-of-helsinki/react-helsinki-headless-cms` dependency to **3.0.3** across all affected apps and shared components to keep enhancements current and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->