### PR TITLE
fix: hide neighborhood for internet events

### DIFF
--- a/packages/components/src/utils/__tests__/eventUtils.test.ts
+++ b/packages/components/src/utils/__tests__/eventUtils.test.ts
@@ -16,6 +16,7 @@ import {
   getEventFields,
   getEventIdFromUrl,
   getEventIdsFromUrls,
+  getEventNeighborhood,
   getEventSomeImageUrl,
   getKeywordList,
   getLocationId,
@@ -111,6 +112,24 @@ describe('getServiceMapUrl function', () => {
     expect(getServiceMapUrl(event, 'sv', true)).toBe(
       'https://palvelukartta.hel.fi/sv/embed/unit/123'
     );
+  });
+});
+
+describe('getEventNeighborhood function', () => {
+  it('does not return a neighborhood for Internet events', () => {
+    const event = fakeEvent({
+      location: fakePlace({
+        id: 'helsinki:internet',
+        divisions: [
+          {
+            name: { fi: 'Kluuvi' },
+            type: 'neighborhood',
+          },
+        ],
+      }),
+    }) as EventFieldsFragment;
+
+    expect(getEventNeighborhood(event, 'fi')).toBeNull();
   });
 });
 

--- a/packages/components/src/utils/eventUtils.ts
+++ b/packages/components/src/utils/eventUtils.ts
@@ -200,6 +200,10 @@ export const getEventNeighborhood = (
   event: EventFields,
   locale: AppLanguage
 ): string | null => {
+  if (event.location?.id === EVENT_LOCATIONS.INTERNET) {
+    return null;
+  }
+
   const neighborhood = event.location?.divisions?.find(
     (division) => division.type === 'neighborhood'
   );


### PR DESCRIPTION
## Summary

Hide administrative neighborhood data for the special `helsinki:internet` location in the shared event location helper. This prevents Kluuvi from being displayed for online events while preserving existing physical-location behavior.



Refs: TH-1462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event location handling so online events no longer display a neighborhood.
  * Physical events continue to show the appropriate neighborhood when available.
  * Added coverage to verify the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->